### PR TITLE
Refresh project documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,6 @@
 
 ## Checklist
 
-- [ ] The change is focused and contains no unrelated files.
 - [ ] Relevant automated tests pass, or the reason they were not run is stated above.
 - [ ] UI builder changes were verified by rebuilding the affected UI.
 - [ ] Content path or structure changes were also made in `rebellion2-media`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 ## Checklist
 
 - [ ] Relevant automated tests pass, or the reason they were not run is stated above.
-- [ ] I reviewed and understand all AI-assisted code; this submission was not vibe coded.
+- [ ] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
 - [ ] UI builder changes were verified by rebuilding the affected UI.
 - [ ] Content path or structure changes were also made in `rebellion2-media`.
 - [ ] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Validation
+
+<!-- List the tests, builds, or manual checks performed. -->
+
+## Checklist
+
+- [ ] The change is focused and contains no unrelated files.
+- [ ] Relevant automated tests pass, or the reason they were not run is stated above.
+- [ ] UI builder changes were verified by rebuilding the affected UI.
+- [ ] Content path or structure changes were also made in `rebellion2-media`.
+- [ ] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
+- [ ] Documentation was updated when behavior or setup changed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 ## Checklist
 
 - [ ] Relevant automated tests pass, or the reason they were not run is stated above.
+- [ ] I reviewed and understand all AI-assisted code; this submission was not vibe coded.
 - [ ] UI builder changes were verified by rebuilding the affected UI.
 - [ ] Content path or structure changes were also made in `rebellion2-media`.
 - [ ] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   UNITY_VERSION: 6000.4.0f1
   UNITY_IMAGE_VERSION: 3
@@ -50,7 +54,19 @@ jobs:
         run: |
           HOST="${R2_ENDPOINT#https://}"
           git config lfs.url "https://${R2_ACCESS_KEY_ID}:${R2_SECRET_ACCESS_KEY}@rebellion2-lfs-proxy.pages.dev/${HOST}/${R2_BUCKET}"
-          git lfs pull --include="Content/**,Models/MainMenu/**" --exclude=""
+          git config lfs.concurrenttransfers 3
+          for attempt in 1 2 3 4; do
+            if git lfs pull --include="Content/**,Models/MainMenu/**" --exclude=""; then
+              break
+            fi
+            if [ "$attempt" = "4" ]; then
+              echo "Media LFS download failed after $attempt attempts."
+              exit 1
+            fi
+            delay=$((attempt * 20))
+            echo "Media LFS download attempt $attempt failed; retrying in ${delay}s..."
+            sleep "$delay"
+          done
           if grep -RIl '^version https://git-lfs.github.com/spec/v1$' Content Models/MainMenu; then
             echo "Media checkout still contains Git LFS pointers."
             exit 1
@@ -214,7 +230,19 @@ jobs:
         run: |
           HOST="${R2_ENDPOINT#https://}"
           git config lfs.url "https://${R2_ACCESS_KEY_ID}:${R2_SECRET_ACCESS_KEY}@rebellion2-lfs-proxy.pages.dev/${HOST}/${R2_BUCKET}"
-          git lfs pull --include="Content/**,Models/MainMenu/**" --exclude=""
+          git config lfs.concurrenttransfers 3
+          for attempt in 1 2 3 4; do
+            if git lfs pull --include="Content/**,Models/MainMenu/**" --exclude=""; then
+              break
+            fi
+            if [ "$attempt" = "4" ]; then
+              echo "Media LFS download failed after $attempt attempts."
+              exit 1
+            fi
+            delay=$((attempt * 20))
+            echo "Media LFS download attempt $attempt failed; retrying in ${delay}s..."
+            sleep "$delay"
+          done
           if grep -RIl '^version https://git-lfs.github.com/spec/v1$' Content Models/MainMenu; then
             echo "Media checkout still contains Git LFS pointers."
             exit 1

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -55,6 +55,7 @@ jobs:
           HOST="${R2_ENDPOINT#https://}"
           git config lfs.url "https://${R2_ACCESS_KEY_ID}:${R2_SECRET_ACCESS_KEY}@rebellion2-lfs-proxy.pages.dev/${HOST}/${R2_BUCKET}"
           git config lfs.concurrenttransfers 3
+          git config lfs.transfer.batchSize 20
           for attempt in 1 2 3 4; do
             if git lfs pull --include="Content/**,Models/MainMenu/**" --exclude=""; then
               break
@@ -231,6 +232,7 @@ jobs:
           HOST="${R2_ENDPOINT#https://}"
           git config lfs.url "https://${R2_ACCESS_KEY_ID}:${R2_SECRET_ACCESS_KEY}@rebellion2-lfs-proxy.pages.dev/${HOST}/${R2_BUCKET}"
           git config lfs.concurrenttransfers 3
+          git config lfs.transfer.batchSize 20
           for attempt in 1 2 3 4; do
             if git lfs pull --include="Content/**,Models/MainMenu/**" --exclude=""; then
               break

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ Assets/TextMesh Pro/
 # Misc
 *.md
 !README.md
+!/CONTRIBUTING.md
 !/Docs/
 !/Docs/*.md
 !/.github/pull_request_template.md

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ Assets/TextMesh Pro/
 !README.md
 !/Docs/
 !/Docs/*.md
+!/.github/pull_request_template.md
 *.tmp.driveupload*
 **/*.scratch
 **/dump

--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,8 @@ Assets/TextMesh Pro/
 # Misc
 *.md
 !README.md
-/[Dd]ocs/
+!/Docs/
+!/Docs/*.md
 *.tmp.driveupload*
 **/*.scratch
 **/dump

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Contributions are welcome. Preserve behavior from the original game when source parity is the goal,
+include tests where practical, and describe how the change was validated.
+
+## Development
+
+Follow the [development guide](Docs/Development.md) for project setup, UI generation, tests, and
+other local checks.
+
+Do not commit generated UI prefabs, generated scenes, or copyrighted game assets. Keep content path
+and structure changes synchronized with `rebellion2-media`.
+
+## AI assistance
+
+Using AI as a development tool is fine. Vibe coding is not.
+
+Contributors must understand every submitted change, review generated code carefully, test it, and
+be able to explain and maintain it. Large, unreviewed, or unverified AI-generated changes will not
+be accepted.
+
+Never provide secrets, private repository content, or copyrighted game assets to an external AI
+service.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ include tests where practical, and describe how the change was validated.
 Follow the [development guide](Docs/Development.md) for project setup, UI generation, tests, and
 other local checks.
 
-Do not commit generated UI prefabs or generated scenes. Contributors must own a copy of the
-original game and **must never share, upload, commit, or redistribute copyrighted game assets**.
-Keep content path and structure changes synchronized with `rebellion2-media`.
+Do not commit generated UI prefabs, generated scenes, or copyrighted game assets. Contributors
+must own a copy of the original game and **must never share, upload, or redistribute copyrighted
+game assets**.
 
 ## AI assistance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ and structure changes synchronized with `rebellion2-media`.
 Using AI as a development tool is fine. Vibe coding is not.
 
 Contributors must understand every submitted change, review generated code carefully, test it, and
-be able to explain and maintain it. Large, unreviewed, or unverified AI-generated changes will not
-be accepted.
+be able to explain and maintain it. Unreviewed or unverified AI-generated changes will not be
+accepted.
 
 Never provide secrets, private repository content, or copyrighted game assets to an external AI
 service.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,9 @@ include tests where practical, and describe how the change was validated.
 Follow the [development guide](Docs/Development.md) for project setup, UI generation, tests, and
 other local checks.
 
-Do not commit generated UI prefabs, generated scenes, or copyrighted game assets. Keep content path
-and structure changes synchronized with `rebellion2-media`.
+Do not commit generated UI prefabs or generated scenes. Contributors must own a copy of the
+original game and **must never share, upload, commit, or redistribute copyrighted game assets**.
+Keep content path and structure changes synchronized with `rebellion2-media`.
 
 ## AI assistance
 

--- a/Docs/Development.md
+++ b/Docs/Development.md
@@ -1,0 +1,46 @@
+# Development
+
+## Requirements
+
+- Unity 6000.4.0f1
+- .NET SDK
+- A Bash-compatible shell
+- Access to the separate `rebellion2-media` repository
+
+## Setup
+
+1. Clone `rebellion2` and `rebellion2-media` beside one another.
+2. Copy `rebellion2-media/Content/` to `rebellion2/Assets/Content/`.
+3. Copy `rebellion2-media/Models/MainMenu/` to
+   `rebellion2/Assets/Art/Models/MainMenu/`.
+4. Open `rebellion2` in Unity and allow the assets to import.
+5. Run **Rebellion > UI > Build All**.
+
+The copied content, generated UI prefabs, and generated scenes are local development artifacts and
+are ignored by Git. Repeat the copies when `rebellion2-media` changes and rebuild the UI after
+changing builder code or content used by a builder.
+
+## Commands
+
+```bash
+./build.sh format     # Check C# formatting
+./build.sh xmlformat  # Format XML data
+./build.sh lint       # Run static analysis
+./build.sh test       # Run Unity EditMode tests
+./build.sh coverage   # Run tests with coverage thresholds
+./build.sh build      # Build the standalone player
+./build.sh clean      # Remove build artifacts
+./build.sh all        # Run the complete local verification suite
+```
+
+Running `./build.sh` without a command is equivalent to `./build.sh all`.
+
+Set `UNITY` if Unity is installed somewhere other than the detected platform default. Standalone
+builds use the host platform unless `BUILD_TARGET` and `BUILD_PLAYER_PATH` are set:
+
+```bash
+BUILD_TARGET=StandaloneWindows64 BUILD_PLAYER_PATH=build/rebellion2.exe ./build.sh build
+```
+
+Player builds generate the UI through `StandalonePlayerBuild.Build` and verify that development
+content under `Assets/Content/` was not embedded in the player.

--- a/Docs/Development.md
+++ b/Docs/Development.md
@@ -5,7 +5,11 @@
 - Unity 6000.4.0f1
 - .NET SDK
 - A Bash-compatible shell
+- A copy of *Star Wars: Rebellion* owned through GOG or Steam
 - Access to the separate `rebellion2-media` repository
+
+Access to development content does not grant redistribution rights. **NEVER share, upload, commit,
+or otherwise redistribute `rebellion2-media`, `Assets/Content`, or any copyrighted game asset.**
 
 ## Setup
 

--- a/Docs/Modding.md
+++ b/Docs/Modding.md
@@ -3,6 +3,16 @@
 Rebellion 2 loads its art, audio, video, configuration, and game data from an external `Content`
 directory. Most content can therefore be changed without rebuilding the game.
 
+## Redistribution
+
+**NEVER redistribute the installed `Content` directory, the original content pack, or copyrighted
+assets taken from them.** Every player and mod developer must own a copy of the original game and
+obtain the base content through the ownership-verifying installer.
+
+A distributed mod may contain original work, patch files, or instructions that modify a user's own
+installed copy. It must not include the original pack or unchanged copyrighted assets. When in
+doubt, distribute the changes required to reproduce the mod rather than a copied content tree.
+
 ## Protect the installed pack
 
 Do not edit the installed pack in place. Copy the existing pack before making a mod because future

--- a/Docs/Modding.md
+++ b/Docs/Modding.md
@@ -1,0 +1,112 @@
+# Modding
+
+Rebellion 2 loads its art, audio, video, configuration, and game data from an external `Content`
+directory. Most content can therefore be changed without rebuilding the game.
+
+## Protect the installed pack
+
+Do not edit the installed pack in place. Copy the existing pack before making a mod because future
+installer updates may replace files in the original directory and overwrite those edits.
+
+Start by copying:
+
+```text
+Content/Packs/ClassicGalacticCivilWar/
+```
+
+to a new directory beneath `Content/Packs/`. In the copied `pack.xml`, give the pack a unique `ID`,
+`DisplayName`, and `Version`. The directory name is for organization; the `ID` declared by
+`pack.xml` is the identity used by the game and save files.
+
+## Select a pack and scenario
+
+`Content/catalog.xml` selects the active pack and scenario:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentCatalog>
+  <ActivePackID>my-content-pack</ActivePackID>
+  <ActiveScenarioID>standard</ActiveScenarioID>
+</ContentCatalog>
+```
+
+`ActivePackID` must match the copied pack's `pack.xml` ID. `ActiveScenarioID` must match a scenario
+declared by that pack. If `ActiveScenarioID` is empty, the pack's `DefaultScenarioID` is used.
+
+You can keep an entirely separate `Content` directory and launch the game with it:
+
+```bash
+"/path/to/Rebellion 2" -contentPath "/path/to/Content"
+```
+
+## Pack structure
+
+```text
+Content/
+  catalog.xml
+  Application/                 Shared application UI, audio, video, and preload manifests
+  Packs/
+    MyPack/
+      pack.xml                 Pack identity and definition paths
+      Rules/                   Campaign rules
+      Shared/                  Shared data and presentation
+      Factions/                Faction data, units, UI themes, and media
+      Scenarios/               Scenario definitions and generation settings
+      Preload/                 Assets loaded before each major screen
+```
+
+Paths in `pack.xml`, faction definitions, and scenario definitions are relative to the pack root.
+Content addresses beginning with `Application/` resolve from the shared application directory;
+addresses beginning with `Pack/` resolve from the active pack.
+
+## Common changes
+
+### Campaign setup
+
+Copy or edit a scenario under `Scenarios/`. Its `scenario.xml` controls the scenario ID, display
+name, playable factions, default player faction, and generation-config path. The referenced
+`generation.xml` controls starting planets, headquarters, garrisons, difficulty profiles, and
+initial officer counts.
+
+Add a new scenario's `scenario.xml` path to `ScenarioPaths` in `pack.xml`, then select its ID in
+`catalog.xml`.
+
+### Units, officers, planets, and buildings
+
+The XML files referenced by `pack.xml` and each faction's `faction.xml` define the game's entities.
+Faction files point to capital ships, starfighters, regiments, special forces, officers, faction
+data, themes, and encyclopedia entries. Shared definitions include planet systems, buildings,
+events, and messages.
+
+IDs must be present and unique within their definition type. References between files use those
+IDs, so renaming one requires updating every reference to it.
+
+### UI appearance
+
+Faction presentation is controlled by its `ThemePath`. Theme XML files contain addressed textures
+for Strategy UI windows, controls, advisors, messages, and faction-specific presentation. Replace
+an existing file while preserving its address, or copy the theme and update the faction's
+`ThemePath`.
+
+PNG, JPG, and JPEG images are loaded directly from the content directory. Unity `.meta` files are
+not part of the content format and should not be distributed with a mod.
+
+### Audio and video
+
+Audio and video are loose files referenced by extensionless content addresses. Preserve the address
+expected by the XML or update the corresponding definition. Application-level main-menu and
+cutscene media lives under `Application/`; faction- and scenario-specific media belongs in the
+pack.
+
+### Preloaded assets
+
+Preload manifests list textures, texture directories, and audio needed before a major screen is
+shown. When adding required UI art or audio, update the corresponding manifest under
+`Application/Preload/` or the pack's `Preload/` directory. Missing required preload content causes
+the game to fail loudly instead of silently displaying an incomplete interface.
+
+## Compatibility
+
+Save files record the pack ID, pack version, and scenario ID. Changing those values may make an
+existing save incompatible. Increment the pack version when publishing changes and test a new game
+after modifying definitions or generation rules.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ The installer verifies ownership automatically. A copy of *Star Wars: Rebellion*
 
 Game assets and generated UI artifacts are intentionally kept outside this source repository.
 
+## Reporting bugs
+
+Search [existing issues](https://github.com/davidadas/rebellion2/issues) before filing a new bug.
+Include your platform, game version, reproduction steps, expected and actual behavior, and relevant
+logs or screenshots. Do not attach copyrighted game assets or secrets.
+
 ## Contributing
 
 Focused fixes and improvements are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ files or issues.
 | --- | ---: |
 | Foundation and Data | 60% |
 | Strategy Simulation | 60% |
-| Tactical Simulation | 0% |
-| Multiplayer | 0% |
+| Strategic AI | 50% |
 | Missions | 80% |
 | Events | 0% |
+| Tactical Simulation | 0% |
+| Tactical AI | 0% |
 | Strategy Interface | 80% |
 | UI Upscaling | 40% |
-| Strategic AI | 50% |
-| Tactical AI | 0% |
 | Save Games* | 100% |
 | Settings | 10% |
 | Moddability | 65% |
 | Modding Tools | 0% |
+| Multiplayer | 0% |
 
 \* Save compatibility is not guaranteed between versions during development.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ files or issues.
 | Foundation and Data | 60% |
 | Strategy Simulation | 60% |
 | Tactical Simulation | 0% |
+| Multiplayer | 0% |
 | Missions | 80% |
 | Events | 0% |
 | Strategy Interface | 80% |
@@ -28,7 +29,7 @@ files or issues.
 
 Campaign generation, core strategy systems, missions, save games, and most of the Strategy
 interface are functional. Major remaining work includes story events, AI depth, settings, modding
-tools, tactical simulation, balance, and release polish.
+tools, tactical simulation, multiplayer, balance, and release polish.
 
 The project has more than **3,700 automated tests**, but it is still an early-access build rather
 than a finished replacement for the original game.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Rebellion 2
 
 An open-source remake of the 1998 strategy game *Star Wars: Rebellion*, built with Unity.
+Despite the name, Rebellion 2 is not a sequel. Think of it as a remaster of the original game,
+but with the updates we have always wanted.
 
 <img width="1421" height="794" alt="Rebellion 2 strategy view screenshot" src="https://github.com/user-attachments/assets/a440fc8c-6916-47a5-a7eb-5a8811700844" />
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,25 @@ An open-source remake of the 1998 strategy game *Star Wars: Rebellion*, built wi
 
 <img width="1421" height="794" alt="Rebellion 2 strategy view screenshot" src="https://github.com/user-attachments/assets/a440fc8c-6916-47a5-a7eb-5a8811700844" />
 
-## Status
+## Current Status
 
-Rebellion 2 is under active development. The campaign simulation, missions, construction, movement,
-save games, and core strategy interface are implemented and continue to evolve. It is not yet a
-finished release.
+Rebellion 2 is approximately **75% complete toward a feature-complete single-player campaign**.
+This is an engineering estimate based on implemented gameplay and remaining work, not a count of
+files or issues.
+
+| Area | Estimate | Current state |
+| --- | ---: | --- |
+| Game foundation and data | 90% | Typed game data, campaign generation, serialization, fog of war, events, messages, research, and encyclopedia data are operational. |
+| Strategy simulation | 85% | Movement, fleets, blockades, production, maintenance, personnel, uprisings, bombardment, planetary assault, victory conditions, and strategic combat resolution are implemented. |
+| Missions and campaign events | 80% | Diplomacy, espionage, sabotage, recruitment, rescue, research, Jedi training, abduction, assassination, reconnaissance, and uprising missions are implemented. Duel resolution and broader event coverage remain. |
+| Strategy interface | 80% | Galaxy map, HUD, advisors, messages, construction, facilities, fleets, missions, defense, encyclopedia, status, planet systems, targeting, and contextual commands are functional. Runtime-content integration and presentation polish remain in progress. |
+| Computer opponent | 70% | The AI plans and scores fleet actions, missions, production, manufacturing, and unit transfers. Strategy quality, balance, and edge cases still need iteration. |
+| Save games and settings | 90% | Save/load flows, metadata, compatibility checks, audio settings, input settings, and video settings are implemented. Release hardening remains. |
+| External content and modding | 80% | Structured content packs, scenarios, external media, preload manifests, validation, and alternate content roots are supported. Tooling and documentation will continue to expand. |
+| Presentation and release polish | 60% | Main Menu, Save Game, Strategy presentation, audio, music, video, and cutscenes are integrated. Tactical presentation, accessibility, performance, packaging, and final polish remain. |
+
+The project has more than **3,700 automated tests**, but it is still an early-access build rather
+than a finished replacement for the original game.
 
 ## Playing the game
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ files or issues.
 | Missions | 80% |
 | Events | 0% |
 | Strategy Interface | 80% |
+| UI Upscaling | 40% |
 | Computer Opponent | 50% |
 | Save Games* | 100% |
 | Settings | 10% |
@@ -28,8 +29,8 @@ files or issues.
 \* Save compatibility is not guaranteed between versions during development.
 
 Campaign generation, core strategy systems, missions, save games, and most of the Strategy
-interface are functional. Major remaining work includes story events, AI depth, settings, modding
-tools, tactical simulation, multiplayer, balance, and release polish.
+interface are functional. Major remaining work includes story events, AI depth, UI upscaling,
+settings, modding tools, tactical simulation, multiplayer, balance, and release polish.
 
 The project has more than **3,700 automated tests**, but it is still an early-access build rather
 than a finished replacement for the original game.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ files or issues.
 | Events | 0% |
 | Strategy Interface | 80% |
 | UI Upscaling | 40% |
-| Computer Opponent | 50% |
+| AI | 50% |
 | Save Games* | 100% |
 | Settings | 10% |
 | Moddability | 65% |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Game assets and generated UI artifacts are intentionally kept outside this sourc
 
 Search [existing issues](https://github.com/davidadas/rebellion2/issues) before filing a new bug.
 Include your platform, game version, reproduction steps, expected and actual behavior, and relevant
-logs or screenshots. Do not attach copyrighted game assets or secrets.
+logs or screenshots. **DO NOT** attach copyrighted game assets or secrets.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,20 +6,24 @@ An open-source remake of the 1998 strategy game *Star Wars: Rebellion*, built wi
 
 ## Current Status
 
-Rebellion 2 is approximately **75% complete toward a feature-complete single-player campaign**.
+Rebellion 2 is approximately **55% complete toward a feature-complete single-player campaign**.
 This is an engineering estimate based on implemented gameplay and remaining work, not a count of
 files or issues.
 
 | Area | Estimate | Current state |
 | --- | ---: | --- |
-| Game foundation and data | 90% | Typed game data, campaign generation, serialization, fog of war, events, messages, research, and encyclopedia data are operational. |
-| Strategy simulation | 85% | Movement, fleets, blockades, production, maintenance, personnel, uprisings, bombardment, planetary assault, victory conditions, and strategic combat resolution are implemented. |
-| Missions and campaign events | 80% | Diplomacy, espionage, sabotage, recruitment, rescue, research, Jedi training, abduction, assassination, reconnaissance, and uprising missions are implemented. Duel resolution and broader event coverage remain. |
+| Foundation and data | 60% | Typed game data, campaign generation, serialization, fog of war, messages, research, and encyclopedia data are operational. Significant integration, validation, and completeness work remains. |
+| Strategy simulation | 60% | Movement, fleets, blockades, production, maintenance, personnel, uprisings, bombardment, planetary assault, victory conditions, and strategic combat resolution exist but still need substantial depth, balance, and campaign validation. |
+| Missions | 80% | Diplomacy, espionage, sabotage, recruitment, rescue, research, Jedi training, abduction, assassination, reconnaissance, and uprising missions are implemented. Duel resolution and additional refinement remain. |
+| Events | 0% | Supporting code and data structures exist, but story-driven in-game events are not implemented yet. |
 | Strategy interface | 80% | Galaxy map, HUD, advisors, messages, construction, facilities, fleets, missions, defense, encyclopedia, status, planet systems, targeting, and contextual commands are functional. Runtime-content integration and presentation polish remain in progress. |
-| Computer opponent | 70% | The AI plans and scores fleet actions, missions, production, manufacturing, and unit transfers. Strategy quality, balance, and edge cases still need iteration. |
-| Save games and settings | 90% | Save/load flows, metadata, compatibility checks, audio settings, input settings, and video settings are implemented. Release hardening remains. |
-| External content and modding | 80% | Structured content packs, scenarios, external media, preload manifests, validation, and alternate content roots are supported. Tooling and documentation will continue to expand. |
-| Presentation and release polish | 60% | Main Menu, Save Game, Strategy presentation, audio, music, video, and cutscenes are integrated. Tactical presentation, accessibility, performance, packaging, and final polish remain. |
+| Computer opponent | 50% | The AI can plan fleet actions, missions, production, manufacturing, and unit transfers, but its strategy, balance, and handling of campaign situations need major work. |
+| Save games* | 100% | A current game can be saved and loaded. |
+| Settings | 10% | Basic audio settings exist. The settings interface and other player-facing options remain to be built. |
+| Moddability | 65% | External content packs, scenarios, loose media, preload manifests, validation, and alternate content roots are supported. More game behavior still needs to become data-driven. |
+| Modding tools | 0% | There are no player-facing tools for creating, validating, or packaging mods yet. |
+
+\* Save compatibility is not guaranteed between versions during development.
 
 The project has more than **3,700 automated tests**, but it is still an early-access build rather
 than a finished replacement for the original game.

--- a/README.md
+++ b/README.md
@@ -10,20 +10,24 @@ Rebellion 2 is approximately **55% complete toward a feature-complete single-pla
 This is an engineering estimate based on implemented gameplay and remaining work, not a count of
 files or issues.
 
-| Area | Estimate | Current state |
-| --- | ---: | --- |
-| Foundation and data | 60% | Typed game data, campaign generation, serialization, fog of war, messages, research, and encyclopedia data are operational. Significant integration, validation, and completeness work remains. |
-| Strategy simulation | 60% | Movement, fleets, blockades, production, maintenance, personnel, uprisings, bombardment, planetary assault, victory conditions, and strategic combat resolution exist but still need substantial depth, balance, and campaign validation. |
-| Missions | 80% | Diplomacy, espionage, sabotage, recruitment, rescue, research, Jedi training, abduction, assassination, reconnaissance, and uprising missions are implemented. Duel resolution and additional refinement remain. |
-| Events | 0% | Supporting code and data structures exist, but story-driven in-game events are not implemented yet. |
-| Strategy interface | 80% | Galaxy map, HUD, advisors, messages, construction, facilities, fleets, missions, defense, encyclopedia, status, planet systems, targeting, and contextual commands are functional. Runtime-content integration and presentation polish remain in progress. |
-| Computer opponent | 50% | The AI can plan fleet actions, missions, production, manufacturing, and unit transfers, but its strategy, balance, and handling of campaign situations need major work. |
-| Save games* | 100% | A current game can be saved and loaded. |
-| Settings | 10% | Basic audio settings exist. The settings interface and other player-facing options remain to be built. |
-| Moddability | 65% | External content packs, scenarios, loose media, preload manifests, validation, and alternate content roots are supported. More game behavior still needs to become data-driven. |
-| Modding tools | 0% | There are no player-facing tools for creating, validating, or packaging mods yet. |
+| Area | Estimate |
+| --- | ---: |
+| Foundation and data | 60% |
+| Strategy simulation | 60% |
+| Missions | 80% |
+| Events | 0% |
+| Strategy interface | 80% |
+| Computer opponent | 50% |
+| Save games* | 100% |
+| Settings | 10% |
+| Moddability | 65% |
+| Modding tools | 0% |
 
 \* Save compatibility is not guaranteed between versions during development.
+
+Campaign generation, core strategy systems, missions, save games, and most of the Strategy
+interface are functional. Major remaining work includes story events, AI depth, settings, modding
+tools, balance, and release polish.
 
 The project has more than **3,700 automated tests**, but it is still an early-access build rather
 than a finished replacement for the original game.

--- a/README.md
+++ b/README.md
@@ -12,22 +12,23 @@ files or issues.
 
 | Area | Estimate |
 | --- | ---: |
-| Foundation and data | 60% |
-| Strategy simulation | 60% |
+| Foundation and Data | 60% |
+| Strategy Simulation | 60% |
+| Tactical Simulation | 0% |
 | Missions | 80% |
 | Events | 0% |
-| Strategy interface | 80% |
-| Computer opponent | 50% |
-| Save games* | 100% |
+| Strategy Interface | 80% |
+| Computer Opponent | 50% |
+| Save Games* | 100% |
 | Settings | 10% |
 | Moddability | 65% |
-| Modding tools | 0% |
+| Modding Tools | 0% |
 
 \* Save compatibility is not guaranteed between versions during development.
 
 Campaign generation, core strategy systems, missions, save games, and most of the Strategy
 interface are functional. Major remaining work includes story events, AI depth, settings, modding
-tools, balance, and release polish.
+tools, tactical simulation, balance, and release polish.
 
 The project has more than **3,700 automated tests**, but it is still an early-access build rather
 than a finished replacement for the original game.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,8 @@ access.
 The installer verifies ownership automatically. A copy of *Star Wars: Rebellion* from either
 **GOG** or **Steam** is required.
 
-### Content Rules
-
-Players and developers must own a copy of the original game. Game content is provided only through
-the ownership-verifying installer or approved development access. **NEVER redistribute, upload, or
-share the installed `Content` directory or any copyrighted assets from it.**
+**NOTE: Installed game data and copyrighted assets must NEVER be redistributed, uploaded, or
+shared under any circumstances.**
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ An open-source remake of the 1998 strategy game *Star Wars: Rebellion*, built wi
 ## Current Status
 
 Rebellion 2 is approximately **55% complete toward a feature-complete single-player campaign**.
-This is an engineering estimate based on implemented gameplay and remaining work, not a count of
-files or issues.
 
 | Area | Estimate |
 | --- | ---: |
@@ -33,9 +31,6 @@ Campaign generation, core strategy systems, missions, save games, and most of th
 interface are functional. Major remaining work includes story events, strategic AI depth, tactical
 AI, UI upscaling, settings, modding tools, tactical simulation, multiplayer, balance, and release
 polish.
-
-The project has more than **3,700 automated tests**, but it is still an early-access build rather
-than a finished replacement for the original game.
 
 ## Playing the game
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Game assets and generated UI artifacts are intentionally kept outside this sourc
 
 ## Contributing
 
-Focused fixes and improvements are welcome. Include tests where practical and preserve behavior
-from the original game when source parity is the goal.
+Focused fixes and improvements are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a
+pull request.
 
 ## Legal
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ access.
 The installer verifies ownership automatically. A copy of *Star Wars: Rebellion* from either
 **GOG** or **Steam** is required.
 
+### Content Rules
+
+Players and developers must own a copy of the original game. Game content is provided only through
+the ownership-verifying installer or approved development access. **NEVER redistribute, upload, or
+share the installed `Content` directory or any copyrighted assets from it.**
+
 ## Documentation
 
 - [Development setup and commands](Docs/Development.md)
@@ -67,4 +73,5 @@ pull request.
 ## Legal
 
 This unofficial fan project is not affiliated with or endorsed by Disney, Lucasfilm, or the owners
-of *Star Wars*. Copyrighted game assets are not distributed in this repository.
+of *Star Wars*. Copyrighted game assets are not distributed in this repository and must not be
+redistributed by players, modders, or contributors.

--- a/README.md
+++ b/README.md
@@ -1,99 +1,37 @@
 # Rebellion 2
 
-A work-in-progress remake of the 1998 *Star Wars: Rebellion* PC strategy game.
+An open-source remake of the 1998 strategy game *Star Wars: Rebellion*, built with Unity.
 
 <img width="1421" height="794" alt="Rebellion 2 strategy view screenshot" src="https://github.com/user-attachments/assets/a440fc8c-6916-47a5-a7eb-5a8811700844" />
 
-## Project Status
+## Status
 
-Rebellion 2 is under active development. Core strategy systems, data loading, missions, manufacturing, movement, and the Unity strategy UI are being rebuilt and validated incrementally.
+Rebellion 2 is under active development. The campaign simulation, missions, construction, movement,
+save games, and core strategy interface are implemented and continue to evolve. It is not yet a
+finished release.
 
-This is a development build, not a public playable release. The project can be opened and exercised in Unity with the required assets, but it is not currently a complete campaign experience or a stable replacement for the original game.
+## Playing the game
 
-## Setup
+Rebellion 2 is currently available through an early-access installer. Join the
+[Star Wars Rebellion Discord](https://discord.com/invite/rWP4vzw8Gg) and ask **@DavidAdas** for
+access.
 
-### Prerequisites
-- [Unity 6000.4.0f1](https://unity.com/releases/editor/whats-new/6000.4.0) via Unity Hub
-- [.NET SDK](https://dotnet.microsoft.com/en-us/download) for local formatting and analyzer tools
-- Bash-compatible shell for `build.sh`
+The installer verifies ownership automatically. A copy of *Star Wars: Rebellion* from either
+**GOG** or **Steam** is required.
 
-### Steps
-1. Clone this repository to a local directory.
-2. Install Unity 6000.4.0f1 via Unity Hub.
-3. In Unity Hub, select **Projects** from the left-hand menu, click **Open**, and select the cloned `rebellion2` folder.
-4. Once the project opens, import TextMesh Pro assets if Unity prompts for them, or use **Window > TextMeshPro > Import TMP Essential Resources**.
-5. After installing the game assets below and allowing Unity to import them, select
-   **Rebellion > UI > Build All**. Generated UI prefab payloads and the Main Menu, Save Menu, and
-   Strategy scenes are intentionally absent from a fresh clone and ignored by Git; run this command
-   whenever you first set up the project or change UI builder code.
-6. Hit the play button.
+## Documentation
 
-### Game Assets
+- [Development setup and commands](Docs/Development.md)
+- [Modding and content packs](Docs/Modding.md)
 
-The game's art, audio, and video assets are not included in this repository. To run the project with the original assets, you must provide those assets separately from a legally owned copy of the original game.
-
-1. Join the [Star Wars Rebellion Discord](https://discord.com/invite/rWP4vzw8Gg).
-2. Follow the instructions in the server to verify ownership of the original game.
-3. Once verified, you will be granted access to the asset pack.
-4. Copy the media repository's `Content/` directory to `Assets/Content/`.
-5. Copy `Models/MainMenu/` to `Assets/Art/Models/MainMenu/`.
-
-Copy the complete directories and preserve their relative paths. Image `.meta` files are not
-part of the media contract. The Unity prefab builders generate ignored local prefabs with preview
-assets for editor use. Player builds regenerate clean prefabs and load the same raw files from the
-external `Content/` directory.
-
-> **Note:** The game will not run without these assets.
-
-### Packaged Content and Mods
-
-Standalone builds intentionally do not contain or copy the private game assets. An authorized installer must place a raw `Content` directory beside the game executable or `.app` bundle before the game can run. Art, audio, video, configuration, and game-data files are loaded from that directory at runtime rather than from a Unity asset bundle.
-
-To modify a packaged build, replace files under `Content/` while preserving their relative paths and file names, then restart the game. Numbered main-menu animation frames are loaded from their existing file-name sequence while retaining the timings authored by the game.
-
-An alternate content directory can be selected when launching the game:
-
-```bash
-"/path/to/Rebellion 2" -contentPath "/path/to/custom/Content"
-```
-
-On macOS, pass the same option to the executable inside the application bundle or use a launcher that forwards command-line arguments.
-
-## Building, Testing, and Linting
-
-All commands are available via `build.sh`:
-
-```bash
-./build.sh format     # Check C# formatting with CSharpier
-./build.sh xmlformat  # Format XML data files in-place with xmllint
-./build.sh lint       # Run Roslynator static analysis
-./build.sh test       # Run EditMode tests via Unity
-./build.sh coverage   # Run EditMode tests with coverage thresholds
-./build.sh build      # Build standalone player
-./build.sh clean      # Remove build artifacts
-./build.sh all        # Run format + lint + coverage
-```
-
-Running `./build.sh` with no command is equivalent to `./build.sh all`.
-
-The Unity editor path is detected per platform. Override it with the `UNITY` environment variable if your installation differs.
-
-Standalone builds default to the host platform. Override with `BUILD_TARGET` or `BUILD_PLAYER_PATH` when needed:
-
-```bash
-BUILD_TARGET=StandaloneWindows64 BUILD_PLAYER_PATH=build/rebellion2.exe ./build.sh build
-```
-
-> **Note:** `xmllint` is not available on Windows by default. Install it via Chocolatey with `choco install xsltproc` if you need XML formatting on Windows.
+Game assets and generated UI artifacts are intentionally kept outside this source repository.
 
 ## Contributing
 
-Contributions are welcome. The most useful contributions are focused fixes or improvements with clear reproduction steps, tests where appropriate, and behavior that matches the original game where source parity is the goal.
-
-Before opening a larger pull request, start a discussion or issue so the design can be aligned first.
+Focused fixes and improvements are welcome. Include tests where practical and preserve behavior
+from the original game when source parity is the goal.
 
 ## Legal
 
-This is an unofficial fan project. It is not affiliated with, endorsed by, or sponsored by Disney, Lucasfilm, or the owners of *Star Wars*.
-
-No original game assets are distributed in this repository. Users are responsible for supplying any required assets from their own legally obtained copy of the original game.
+This unofficial fan project is not affiliated with or endorsed by Disney, Lucasfilm, or the owners
+of *Star Wars*. Copyrighted game assets are not distributed in this repository.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ files or issues.
 | Events | 0% |
 | Strategy Interface | 80% |
 | UI Upscaling | 40% |
-| AI | 50% |
+| Strategic AI | 50% |
+| Tactical AI | 0% |
 | Save Games* | 100% |
 | Settings | 10% |
 | Moddability | 65% |
@@ -29,8 +30,9 @@ files or issues.
 \* Save compatibility is not guaranteed between versions during development.
 
 Campaign generation, core strategy systems, missions, save games, and most of the Strategy
-interface are functional. Major remaining work includes story events, AI depth, UI upscaling,
-settings, modding tools, tactical simulation, multiplayer, balance, and release polish.
+interface are functional. Major remaining work includes story events, strategic AI depth, tactical
+AI, UI upscaling, settings, modding tools, tactical simulation, multiplayer, balance, and release
+polish.
 
 The project has more than **3,700 automated tests**, but it is still an early-access build rather
 than a finished replacement for the original game.


### PR DESCRIPTION
## Summary

- replace the dated README with a concise project overview and early-access instructions
- document developer setup and local verification commands
- add a practical modding guide for copying, selecting, and modifying content packs
- allow Markdown documentation under `Docs/` to be tracked

## Why

The README described an obsolete manual asset-access flow and had grown into a long operational guide. Player access now uses an early-access installer with automatic GOG or Steam ownership verification, while detailed development and modding guidance belongs in dedicated documents.

## Impact

Players get the correct early-access path, developers get a focused setup guide, and modders get instructions that protect installed content from updater overwrites.

## Validation

- `git diff --check`
- verified README documentation links and tracked file scope