### PR TITLE
Applying configured display mode at startup.

### DIFF
--- a/Assets/Scripts/Managers/UserSettingsManager.cs
+++ b/Assets/Scripts/Managers/UserSettingsManager.cs
@@ -58,6 +58,7 @@ public sealed class UserSettingsManager
 
         _audioManager?.ApplySettings(Settings.Audio);
         _inputManager?.LoadBindingOverrides(Settings.Input.BindingOverridesJson);
+        ApplyVideoSettings(Settings.Video);
     }
 
     /// <summary>
@@ -122,6 +123,22 @@ public sealed class UserSettingsManager
             Settings.Input.BindingOverridesJson = _inputManager.SaveBindingOverrides();
 
         Settings.Normalize();
+    }
+
+    /// <summary>
+    /// Applies the saved display mode once during startup. Zero dimensions select the
+    /// current display's native resolution.
+    /// </summary>
+    /// <param name="video">The normalized video settings.</param>
+    private static void ApplyVideoSettings(UserVideoSettings video)
+    {
+        if (Application.isEditor)
+            return;
+
+        int width = video.ResolutionWidth > 0 ? video.ResolutionWidth : Display.main.systemWidth;
+        int height =
+            video.ResolutionHeight > 0 ? video.ResolutionHeight : Display.main.systemHeight;
+        Screen.SetResolution(width, height, (FullScreenMode)video.FullScreenMode);
     }
 
     /// <summary>

--- a/Assets/Scripts/UserSettings/UserSettings.cs
+++ b/Assets/Scripts/UserSettings/UserSettings.cs
@@ -29,5 +29,6 @@ public sealed class UserSettings
         }
 
         Audio.Normalize();
+        Video.Normalize();
     }
 }

--- a/Assets/Scripts/UserSettings/UserVideoSettings.cs
+++ b/Assets/Scripts/UserSettings/UserVideoSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityFullScreenMode = UnityEngine.FullScreenMode;
 
 /// <summary>
 /// Identifies a persisted tactical presentation option.
@@ -30,12 +31,26 @@ public sealed class UserVideoSettings
 {
     public int ResolutionWidth;
     public int ResolutionHeight;
-    public int FullScreenMode;
+    public int FullScreenMode = (int)UnityFullScreenMode.ExclusiveFullScreen;
     public bool ShowStarfield = true;
     public bool ShowPlanet = true;
     public bool ShowPyro = true;
     public bool HighDetail = true;
     public bool ShowHolocube = true;
+
+    /// <summary>
+    /// Normalizes persisted display values without replacing the native-resolution sentinel.
+    /// </summary>
+    public void Normalize()
+    {
+        if (ResolutionWidth <= 0 || ResolutionHeight <= 0)
+        {
+            ResolutionWidth = 0;
+            ResolutionHeight = 0;
+        }
+        if (!Enum.IsDefined(typeof(UnityFullScreenMode), FullScreenMode))
+            FullScreenMode = (int)UnityFullScreenMode.ExclusiveFullScreen;
+    }
 
     /// <summary>
     /// Gets whether a tactical presentation option is enabled.

--- a/Assets/Tests/EditMode/UserSettings/UserVideoSettingsTests.cs
+++ b/Assets/Tests/EditMode/UserSettings/UserVideoSettingsTests.cs
@@ -47,6 +47,40 @@ namespace Rebellion.Tests.UserSettings
         }
 
         [Test]
+        public void Normalize_InvalidDisplayValues_RestoresNativeExclusiveDefaults()
+        {
+            UserVideoSettings settings = new UserVideoSettings
+            {
+                ResolutionWidth = -1,
+                ResolutionHeight = -1,
+                FullScreenMode = 99,
+            };
+
+            settings.Normalize();
+
+            Assert.AreEqual(0, settings.ResolutionWidth);
+            Assert.AreEqual(0, settings.ResolutionHeight);
+            Assert.AreEqual((int)FullScreenMode.ExclusiveFullScreen, settings.FullScreenMode);
+        }
+
+        [Test]
+        public void Normalize_ValidDisplayValues_PreservesSelection()
+        {
+            UserVideoSettings settings = new UserVideoSettings
+            {
+                ResolutionWidth = 1920,
+                ResolutionHeight = 1080,
+                FullScreenMode = (int)FullScreenMode.Windowed,
+            };
+
+            settings.Normalize();
+
+            Assert.AreEqual(1920, settings.ResolutionWidth);
+            Assert.AreEqual(1080, settings.ResolutionHeight);
+            Assert.AreEqual((int)FullScreenMode.Windowed, settings.FullScreenMode);
+        }
+
+        [Test]
         public void JsonUtility_ExplicitTacticalOptions_RoundTripsState()
         {
             global::UserSettings settings = new global::UserSettings();


### PR DESCRIPTION
## Summary
- Updating the code to enforce the user's display preference at startup.
- 
## Why
Unity can inherit stale player display state. The game now reapplies its own configuration rather than relying solely on Player Settings or Unity’s persisted registry values.

## Validation
- Unity editor compilation completed without C# errors
- focused normalization tests added
- `git diff --check` passed