### PR TITLE
Adding new headquarters, espionage, and advisor automation behavior.

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -20,20 +20,30 @@ jobs:
   resolve-media:
     name: Resolve media revision
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: read
     outputs:
       revision: ${{ steps.resolve.outputs.revision }}
 
     steps:
+      - name: Checkout media metadata
+        uses: actions/checkout@v4
+        with:
+          repository: davidadas/rebellion2-media
+          ref: main
+          ssh-key: ${{ secrets.REBELLION2_MEDIA_SSH_KEY }}
+          lfs: false
+          path: .ci/rebellion2-media
+
       - name: Resolve matching media branch
         id: resolve
         env:
           PULL_REQUEST_BRANCH: ${{ github.head_ref }}
         run: |
           revision="main"
-          if [ -n "$PULL_REQUEST_BRANCH" ] && git ls-remote --exit-code --heads \
-            https://github.com/davidadas/rebellion2-media.git \
+          if [ -n "$PULL_REQUEST_BRANCH" ] && git -C .ci/rebellion2-media \
+            ls-remote --exit-code --heads origin \
             "refs/heads/$PULL_REQUEST_BRANCH" >/dev/null; then
             revision="$PULL_REQUEST_BRANCH"
           fi

--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -15,13 +15,35 @@ concurrency:
 env:
   UNITY_VERSION: 6000.4.0f1
   UNITY_IMAGE_VERSION: 3
-  REBELLION2_MEDIA_REVISION: main
 
 jobs:
+  resolve-media:
+    name: Resolve media revision
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      revision: ${{ steps.resolve.outputs.revision }}
+
+    steps:
+      - name: Resolve matching media branch
+        id: resolve
+        env:
+          PULL_REQUEST_BRANCH: ${{ github.head_ref }}
+        run: |
+          revision="main"
+          if [ -n "$PULL_REQUEST_BRANCH" ] && git ls-remote --exit-code --heads \
+            https://github.com/davidadas/rebellion2-media.git \
+            "refs/heads/$PULL_REQUEST_BRANCH" >/dev/null; then
+            revision="$PULL_REQUEST_BRANCH"
+          fi
+          echo "Using rebellion2-media revision: $revision"
+          echo "revision=$revision" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build (${{ matrix.targetPlatform }})
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, resolve-media]
     environment: production
     permissions:
       contents: read
@@ -39,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: davidadas/rebellion2-media
-          ref: ${{ env.REBELLION2_MEDIA_REVISION }}
+          ref: ${{ needs.resolve-media.outputs.revision }}
           ssh-key: ${{ secrets.REBELLION2_MEDIA_SSH_KEY }}
           lfs: false
           path: .ci/rebellion2-media
@@ -201,7 +223,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, resolve-media]
     environment: production
     permissions:
       checks: write
@@ -216,7 +238,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: davidadas/rebellion2-media
-          ref: ${{ env.REBELLION2_MEDIA_REVISION }}
+          ref: ${{ needs.resolve-media.outputs.revision }}
           ssh-key: ${{ secrets.REBELLION2_MEDIA_SSH_KEY }}
           lfs: false
           path: .ci/rebellion2-media

--- a/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
@@ -1116,6 +1116,7 @@ public static class StrategyViewPrefabBuilder
         FacilityWindowView view = EnableRuntimeComponent(window.GetComponent<FacilityWindowView>());
         SetSourceRect(window.GetComponent<RectTransform>(), 0, 0, windowWidth, windowHeight);
 
+        CreateWindowSurfaceBacking(window.transform, windowWidth, windowHeight);
         RawImage background = CreateRawImage(
             "BackgroundImage",
             window.transform,
@@ -1124,6 +1125,10 @@ public static class StrategyViewPrefabBuilder
             0,
             windowWidth,
             windowHeight
+        );
+        background.rectTransform.SetSizeWithCurrentAnchors(
+            RectTransform.Axis.Horizontal,
+            windowHeight * background.texture.width / (float)background.texture.height
         );
         background.raycastTarget = true;
 
@@ -1185,7 +1190,6 @@ public static class StrategyViewPrefabBuilder
             windowWidth,
             windowHeight
         );
-        tabs.gameObject.AddComponent<RectMask2D>();
         List<RawImage> tabImages = new List<RawImage>();
         for (int i = 0; i < 6; i++)
         {
@@ -1194,7 +1198,11 @@ public static class StrategyViewPrefabBuilder
                 tabs,
                 null
             );
-            SetSourceRect(tabImage.rectTransform, i * 38, 20, 38, 33);
+            SetSourceRect(tabImage.rectTransform, i * 38, 20, 36, 33);
+            tabImage.rectTransform.SetSizeWithCurrentAnchors(
+                RectTransform.Axis.Vertical,
+                36f * 149f / 162f
+            );
             tabImages.Add(tabImage);
         }
         List<Button> tabButtons = CreateButtons(tabImages);
@@ -1819,6 +1827,7 @@ public static class StrategyViewPrefabBuilder
         DefenseWindowView view = EnableRuntimeComponent(window.AddComponent<DefenseWindowView>());
         SetSourceRect(window.GetComponent<RectTransform>(), 0, 0, windowWidth, windowHeight);
 
+        CreateWindowSurfaceBacking(window.transform, windowWidth, windowHeight);
         RawImage background = CreateRawImage(
             "BackgroundImage",
             window.transform,
@@ -1827,6 +1836,10 @@ public static class StrategyViewPrefabBuilder
             0,
             windowWidth,
             windowHeight
+        );
+        background.rectTransform.SetSizeWithCurrentAnchors(
+            RectTransform.Axis.Horizontal,
+            windowHeight * background.texture.width / (float)background.texture.height
         );
         background.raycastTarget = true;
 
@@ -1896,7 +1909,11 @@ public static class StrategyViewPrefabBuilder
                 tabs,
                 null
             );
-            SetSourceRect(tabImage.rectTransform, 27 + i * 36, 20, 36, 33);
+            SetSourceRect(tabImage.rectTransform, 28 + i * 36, 20, 36, 33);
+            tabImage.rectTransform.SetSizeWithCurrentAnchors(
+                RectTransform.Axis.Vertical,
+                36f * 149f / 162f
+            );
             tabImages.Add(tabImage);
         }
         List<Button> tabButtons = CreateButtons(tabImages);
@@ -4662,15 +4679,22 @@ public static class StrategyViewPrefabBuilder
         MessagesDetailPanelView detailPanel = EnableRuntimeComponent(
             detailPanelTransform.gameObject.AddComponent<MessagesDetailPanelView>()
         );
+        detailPanelTransform.gameObject.AddComponent<RectMask2D>();
+        RawImage detailBacking = CreatePanelImage(
+            "DetailSurfaceBackingImage",
+            detailPanelTransform,
+            Color.black
+        );
+        SetSourceRect(detailBacking.rectTransform, 12, 13, 400, 306);
         RawImage detailStrip = CreateRawButton("DetailStripImage", detailPanelTransform);
-        SetSourceRect(detailStrip.rectTransform, 12, 14, 400, 18);
+        SetSourceRect(detailStrip.rectTransform, 12, 13, 400, 18);
         RawImage detailCard = CreateRawButton("DetailCardImage", detailPanelTransform);
         SetSourceRect(detailCard.rectTransform, 12, 33, 400, 200);
         RawImage detailOverlay = CreateRawButton("DetailOverlayImage", detailPanelTransform);
         SetSourceRect(detailOverlay.rectTransform, 12, 33, 400, 200);
         detailOverlay.raycastTarget = false;
         RawImage detailBody = CreateRawButton("DetailBodyImage", detailPanelTransform);
-        SetSourceRect(detailBody.rectTransform, 12, 232, 400, 87);
+        SetSourceRect(detailBody.rectTransform, 12, 230, 400, 87);
         RawImage detailIcon = CreateRawButton("DetailIconImage", detailPanelTransform);
         SetSourceRect(detailIcon.rectTransform, 19, 15, 15, 16);
         TextMeshProUGUI detailHeader = CreateTextLabel(
@@ -4722,6 +4746,7 @@ public static class StrategyViewPrefabBuilder
 
         Transform[] detailLayerOrder =
         {
+            detailBacking.transform,
             detailCard.transform,
             detailOverlay.transform,
             detailStrip.transform,
@@ -7107,7 +7132,7 @@ public static class StrategyViewPrefabBuilder
         SetSourceRect(
             iconImage.rectTransform,
             4,
-            1,
+            7,
             _contextMenuIconPreviewSize,
             _contextMenuIconPreviewSize
         );
@@ -7440,6 +7465,18 @@ public static class StrategyViewPrefabBuilder
         AssignFloat(view, "galaxyProjectionHeight", _galaxyProjectionHeight);
         AssignInt(view, "planetPositionOffsetY", -1);
         return window;
+    }
+
+    /// <summary>
+    /// Authors the opaque surface used by the original window renderer beneath its bitmap.
+    /// </summary>
+    /// <param name="parent">The window transform.</param>
+    /// <param name="width">The window width.</param>
+    /// <param name="height">The window height.</param>
+    private static void CreateWindowSurfaceBacking(Transform parent, int width, int height)
+    {
+        RawImage backing = CreatePanelImage("WindowSurfaceBackingImage", parent, Color.black);
+        SetSourceRect(backing.rectTransform, 0, 0, width, height);
     }
 
     /// <summary>

--- a/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
@@ -1116,7 +1116,7 @@ public static class StrategyViewPrefabBuilder
         FacilityWindowView view = EnableRuntimeComponent(window.GetComponent<FacilityWindowView>());
         SetSourceRect(window.GetComponent<RectTransform>(), 0, 0, windowWidth, windowHeight);
 
-        CreateWindowSurfaceBacking(window.transform, windowWidth, windowHeight);
+        CreateBlackWindowUnderlay(window.transform, windowWidth, windowHeight);
         RawImage background = CreateRawImage(
             "BackgroundImage",
             window.transform,
@@ -1827,7 +1827,7 @@ public static class StrategyViewPrefabBuilder
         DefenseWindowView view = EnableRuntimeComponent(window.AddComponent<DefenseWindowView>());
         SetSourceRect(window.GetComponent<RectTransform>(), 0, 0, windowWidth, windowHeight);
 
-        CreateWindowSurfaceBacking(window.transform, windowWidth, windowHeight);
+        CreateBlackWindowUnderlay(window.transform, windowWidth, windowHeight);
         RawImage background = CreateRawImage(
             "BackgroundImage",
             window.transform,
@@ -7473,10 +7473,10 @@ public static class StrategyViewPrefabBuilder
     /// <param name="parent">The window transform.</param>
     /// <param name="width">The window width.</param>
     /// <param name="height">The window height.</param>
-    private static void CreateWindowSurfaceBacking(Transform parent, int width, int height)
+    private static void CreateBlackWindowUnderlay(Transform parent, int width, int height)
     {
-        RawImage backing = CreatePanelImage("WindowSurfaceBackingImage", parent, Color.black);
-        SetSourceRect(backing.rectTransform, 0, 0, width, height);
+        RawImage underlay = CreatePanelImage("BlackWindowUnderlayImage", parent, Color.black);
+        SetSourceRect(underlay.rectTransform, 0, 0, width, height);
     }
 
     /// <summary>

--- a/Assets/Scripts/App/AppBootstrap.cs
+++ b/Assets/Scripts/App/AppBootstrap.cs
@@ -11,6 +11,7 @@ using UnityEditor;
 /// </summary>
 public sealed class AppBootstrap : MonoBehaviour
 {
+    private const string _defaultCursorAddress = "Application/Common/UI/ui_common_cursor_default";
     private const string _mainMenuPreloadID = "main-menu";
     private const string _saveMenuPreloadID = "save-menu";
     private const string _strategyPreloadID = "strategy";
@@ -107,6 +108,12 @@ public sealed class AppBootstrap : MonoBehaviour
             _strategyPreloadID
         );
         _contentAssets = new ContentAssets(_contentPack.ContentRootPath, _contentPack.PackRootPath);
+        Texture2D cursorTexture =
+            _contentAssets.GetReadableTexture(_defaultCursorAddress)
+            ?? throw new System.InvalidOperationException(
+                $"Application cursor is missing: {_defaultCursorAddress}"
+            );
+        Cursor.SetCursor(cursorTexture, Vector2.zero, CursorMode.Auto);
         _contentModelCache = new ContentModelCache(_contentAssets);
         GameLaunchContext.Reset(_contentPack);
         _runtime = new GameRuntime(_sceneLoader.Load, _contentPack);
@@ -248,6 +255,7 @@ public sealed class AppBootstrap : MonoBehaviour
         if (Instance != this)
             return;
 
+        Cursor.SetCursor(null, Vector2.zero, CursorMode.Auto);
         _contentModelCache?.Dispose();
         _contentAssets?.Dispose();
         Instance = null;

--- a/Assets/Scripts/App/AppBootstrap.cs
+++ b/Assets/Scripts/App/AppBootstrap.cs
@@ -11,7 +11,8 @@ using UnityEditor;
 /// </summary>
 public sealed class AppBootstrap : MonoBehaviour
 {
-    private const string _defaultCursorAddress = "Application/Common/UI/ui_common_cursor_default";
+    private const string _defaultCursorAddress =
+        "Application/Common/UI/ui_common_cursor_default_outlined";
     private const string _mainMenuPreloadID = "main-menu";
     private const string _saveMenuPreloadID = "save-menu";
     private const string _strategyPreloadID = "strategy";

--- a/Assets/Scripts/Content/ContentAssets.cs
+++ b/Assets/Scripts/Content/ContentAssets.cs
@@ -25,6 +25,10 @@ public sealed class ContentAssets : IContentAssetSource, IDisposable
     private readonly Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>(
         StringComparer.Ordinal
     );
+    private readonly Dictionary<string, Texture2D> readableTextures = new Dictionary<
+        string,
+        Texture2D
+    >(StringComparer.Ordinal);
     private readonly Dictionary<string, Sprite> sprites = new Dictionary<string, Sprite>(
         StringComparer.Ordinal
     );
@@ -131,18 +135,40 @@ public sealed class ContentAssets : IContentAssetSource, IDisposable
     /// <returns>The loaded texture, or null when the address cannot be loaded.</returns>
     public Texture2D GetTexture(string path)
     {
+        return GetTexture(path, textures, true);
+    }
+
+    /// <summary>
+    /// Resolves and caches a CPU-readable texture for APIs such as the hardware cursor.
+    /// </summary>
+    /// <param name="path">The application or pack content address.</param>
+    /// <returns>The loaded readable texture, or null when the address cannot be loaded.</returns>
+    public Texture2D GetReadableTexture(string path)
+    {
+        return GetTexture(path, readableTextures, false);
+    }
+
+    /// <summary>
+    /// Resolves and caches a texture with the requested CPU-readability.
+    /// </summary>
+    private Texture2D GetTexture(
+        string path,
+        IDictionary<string, Texture2D> cache,
+        bool markNonReadable
+    )
+    {
         ThrowIfDisposed();
         string normalizedPath = NormalizeAddress(path);
         if (string.IsNullOrEmpty(normalizedPath))
             return null;
-        if (textures.TryGetValue(normalizedPath, out Texture2D texture))
+        if (cache.TryGetValue(normalizedPath, out Texture2D texture))
         {
             if (texture != null)
                 return texture;
 
             // Unity can destroy transient editor-preview objects when a prefab stage closes while
             // domain reload is disabled. Never retain a dead Unity object in the content cache.
-            textures.Remove(normalizedPath);
+            cache.Remove(normalizedPath);
         }
         if (unavailableTextures.Contains(normalizedPath))
             return null;
@@ -158,7 +184,7 @@ public sealed class ContentAssets : IContentAssetSource, IDisposable
         {
             byte[] bytes = File.ReadAllBytes(filePath);
             texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
-            if (!ImageConversion.LoadImage(texture, bytes, true))
+            if (!ImageConversion.LoadImage(texture, bytes, markNonReadable))
             {
                 DestroyAsset(texture);
                 unavailableTextures.Add(normalizedPath);
@@ -179,7 +205,7 @@ public sealed class ContentAssets : IContentAssetSource, IDisposable
         texture.name = Path.GetFileNameWithoutExtension(filePath);
         texture.filterMode = FilterMode.Point;
         texture.wrapMode = TextureWrapMode.Clamp;
-        textures.Add(normalizedPath, texture);
+        cache.Add(normalizedPath, texture);
         return texture;
     }
 
@@ -283,10 +309,13 @@ public sealed class ContentAssets : IContentAssetSource, IDisposable
             DestroyAsset(sprite);
         foreach (Texture2D texture in textures.Values)
             DestroyAsset(texture);
+        foreach (Texture2D texture in readableTextures.Values)
+            DestroyAsset(texture);
 
         audioClips.Clear();
         audioLoads.Clear();
         textures.Clear();
+        readableTextures.Clear();
         sprites.Clear();
         unavailableTextures.Clear();
         disposed = true;

--- a/Assets/Scripts/Game/Encyclopedia/EncyclopediaCatalogBuilder.cs
+++ b/Assets/Scripts/Game/Encyclopedia/EncyclopediaCatalogBuilder.cs
@@ -192,7 +192,7 @@ namespace Rebellion.Game.Encyclopedia
             EncyclopediaEntryCategory category
         )
         {
-            if (entity == null || !HasEncyclopediaData(entity))
+            if (entity == null || !entity.HasEncyclopediaData)
                 return null;
 
             return new EncyclopediaEntry
@@ -205,18 +205,6 @@ namespace Rebellion.Game.Encyclopedia
                 Stats = CloneStats(entity.EncyclopediaStats),
                 Description = GetEncyclopediaDescription(entity),
             };
-        }
-
-        /// <summary>
-        /// Returns whether an entity explicitly defines encyclopedia presentation data.
-        /// </summary>
-        /// <param name="entity">The entity to inspect.</param>
-        /// <returns>True when the entity should appear in the generated encyclopedia.</returns>
-        private static bool HasEncyclopediaData(BaseGameEntity entity)
-        {
-            return !string.IsNullOrEmpty(entity.EncyclopediaImagePath)
-                || !string.IsNullOrEmpty(entity.EncyclopediaDescription)
-                || entity.EncyclopediaStats?.Count > 0;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Encyclopedia/EncyclopediaCatalogBuilder.cs
+++ b/Assets/Scripts/Game/Encyclopedia/EncyclopediaCatalogBuilder.cs
@@ -192,7 +192,7 @@ namespace Rebellion.Game.Encyclopedia
             EncyclopediaEntryCategory category
         )
         {
-            if (entity == null || !entity.HasEncyclopediaData)
+            if (entity?.HasEncyclopediaData != true)
                 return null;
 
             return new EncyclopediaEntry

--- a/Assets/Scripts/Game/Encyclopedia/EncyclopediaCatalogBuilder.cs
+++ b/Assets/Scripts/Game/Encyclopedia/EncyclopediaCatalogBuilder.cs
@@ -192,7 +192,7 @@ namespace Rebellion.Game.Encyclopedia
             EncyclopediaEntryCategory category
         )
         {
-            if (entity == null)
+            if (entity == null || !HasEncyclopediaData(entity))
                 return null;
 
             return new EncyclopediaEntry
@@ -205,6 +205,18 @@ namespace Rebellion.Game.Encyclopedia
                 Stats = CloneStats(entity.EncyclopediaStats),
                 Description = GetEncyclopediaDescription(entity),
             };
+        }
+
+        /// <summary>
+        /// Returns whether an entity explicitly defines encyclopedia presentation data.
+        /// </summary>
+        /// <param name="entity">The entity to inspect.</param>
+        /// <returns>True when the entity should appear in the generated encyclopedia.</returns>
+        private static bool HasEncyclopediaData(BaseGameEntity entity)
+        {
+            return !string.IsNullOrEmpty(entity.EncyclopediaImagePath)
+                || !string.IsNullOrEmpty(entity.EncyclopediaDescription)
+                || entity.EncyclopediaStats?.Count > 0;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Factions/Faction.cs
+++ b/Assets/Scripts/Game/Factions/Faction.cs
@@ -67,6 +67,8 @@ namespace Rebellion.Game.Factions
             new Dictionary<MessageType, bool>();
         public bool TranslateCounterpart { get; set; } = true;
         public bool AgentAdvice { get; set; } = true;
+        public bool ManageGarrisons { get; set; }
+        public bool ManageProduction { get; set; }
 
         // Research Status.
         public FactionResearchState ResearchState { get; set; } = new FactionResearchState();
@@ -759,6 +761,9 @@ namespace Rebellion.Game.Factions
 
             foreach (IManufacturable template in templates)
             {
+                if (template is Building { CanBeManufactured: false })
+                    continue;
+
                 if (
                     template.AllowedOwnerInstanceIDs?.Count > 0
                     && !template.AllowedOwnerInstanceIDs.Contains(InstanceID)

--- a/Assets/Scripts/Game/Factions/FactionSettings.cs
+++ b/Assets/Scripts/Game/Factions/FactionSettings.cs
@@ -16,6 +16,7 @@ namespace Rebellion.Game.Factions
         private int _garrisonEfficiency = 1;
         private int _troopEffectiveness = 1;
         private int _uprisingResistance = 1;
+        private HeadquartersSettings _headquarters = new HeadquartersSettings();
 
         /// <summary>
         /// Multiplier applied when converting raw/refined production into material supply.
@@ -82,7 +83,22 @@ namespace Rebellion.Game.Factions
         public SupportShiftCondition WeakSupportPenaltyTrigger { get; set; } =
             SupportShiftCondition.Positive;
 
-        public bool HeadquartersCanBeBombarded { get; set; }
+        public HeadquartersSettings Headquarters
+        {
+            get => _headquarters ??= new HeadquartersSettings();
+            set => _headquarters = value ?? new HeadquartersSettings();
+        }
+    }
+
+    /// <summary>
+    /// Defines permanent headquarters behavior for a faction.
+    /// </summary>
+    [PersistableObject]
+    public class HeadquartersSettings
+    {
+        public string FacilityTypeID { get; set; }
+        public bool IsMobile { get; set; }
+        public bool IsBombardable { get; set; }
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
+++ b/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
@@ -153,7 +153,7 @@ namespace Rebellion.Game.FogOfWar
             {
                 planetSnapshot.HasEspionageIntelligence =
                     previousSnapshot?.HasEspionageIntelligence == true;
-                PreserveMissionIntelligence(previousSnapshot, planetSnapshot);
+                CarryForwardRevealedMissions(previousSnapshot, planetSnapshot);
                 PreserveIncomingFleetIntelligence(previousSnapshot, planetSnapshot);
                 PreserveManufacturingIntelligence(previousSnapshot, planetSnapshot, planet);
             }
@@ -186,7 +186,7 @@ namespace Rebellion.Game.FogOfWar
         /// </summary>
         /// <param name="previousSnapshot">The prior intelligence snapshot.</param>
         /// <param name="snapshot">The replacement snapshot.</param>
-        private static void PreserveMissionIntelligence(
+        private static void CarryForwardRevealedMissions(
             PlanetSnapshot previousSnapshot,
             PlanetSnapshot snapshot
         )

--- a/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
+++ b/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
@@ -38,13 +38,13 @@ namespace Rebellion.Game.FogOfWar
         }
 
         /// <summary>
-        /// Records a planet snapshot that includes unfinished units and manufacturing queues.
+        /// Records the complete planet intelligence revealed by successful espionage.
         /// </summary>
-        /// <param name="faction">The faction receiving the manufacturing observation.</param>
+        /// <param name="faction">The faction receiving the intelligence.</param>
         /// <param name="planet">The observed planet.</param>
         /// <param name="system">The system containing the planet.</param>
         /// <param name="currentTick">The tick when the observation is recorded.</param>
-        public void RecordPlanetManufacturingSnapshot(
+        public void RecordEspionageSnapshot(
             Faction faction,
             Planet planet,
             PlanetSystem system,
@@ -94,13 +94,13 @@ namespace Rebellion.Game.FogOfWar
         /// <param name="planet">The observed planet.</param>
         /// <param name="system">The system containing the planet.</param>
         /// <param name="currentTick">The tick when the observation is recorded.</param>
-        /// <param name="includeManufacturing">Whether unfinished units and queue contents are observable.</param>
+        /// <param name="includeEspionageIntelligence">Whether complete espionage intelligence is observable.</param>
         private void RecordPlanetSnapshot(
             Faction faction,
             Planet planet,
             PlanetSystem system,
             int currentTick,
-            bool includeManufacturing
+            bool includeEspionageIntelligence
         )
         {
             if (faction == null || planet == null || system == null)
@@ -116,40 +116,111 @@ namespace Rebellion.Game.FogOfWar
             );
 
             PlanetSnapshot planetSnapshot = CreatePlanetSnapshot(planet, currentTick);
-            AddOfficersToSnapshot(faction, planet, planetSnapshot);
-            AddFleetsToSnapshot(faction, planet, planetSnapshot, includeManufacturing);
+            AddOfficersToSnapshot(faction, planet, planetSnapshot, includeEspionageIntelligence);
+            AddFleetsToSnapshot(faction, planet, planetSnapshot, includeEspionageIntelligence);
             AddEntityCopiesToSnapshot(
                 planet.Regiments,
                 planetSnapshot.Regiments,
                 faction,
-                includeManufacturing
+                includeEspionageIntelligence
             );
             AddEntityCopiesToSnapshot(
                 planet.SpecialForces,
                 planetSnapshot.SpecialForces,
                 faction,
-                includeManufacturing
+                includeEspionageIntelligence
             );
             AddEntityCopiesToSnapshot(
                 planet.Buildings,
                 planetSnapshot.Buildings,
                 faction,
-                includeManufacturing
+                includeEspionageIntelligence
             );
             AddEntityCopiesToSnapshot(
                 planet.Starfighters,
                 planetSnapshot.Starfighters,
                 faction,
-                includeManufacturing
+                includeEspionageIntelligence
             );
 
-            if (includeManufacturing)
+            if (includeEspionageIntelligence)
+            {
+                planetSnapshot.HasEspionageIntelligence = true;
+                AddEnemyMissionsToSnapshot(faction, planet, planetSnapshot);
                 AddManufacturingQueueToSnapshot(planet, planetSnapshot);
+            }
             else
+            {
+                planetSnapshot.HasEspionageIntelligence =
+                    previousSnapshot?.HasEspionageIntelligence == true;
+                PreserveMissionIntelligence(previousSnapshot, planetSnapshot);
+                PreserveIncomingFleetIntelligence(previousSnapshot, planetSnapshot);
                 PreserveManufacturingIntelligence(previousSnapshot, planetSnapshot, planet);
+            }
 
             ReconcileEntityLocations(faction, planet.InstanceID, planetSnapshot);
             systemSnapshot.Planets[planet.InstanceID] = planetSnapshot;
+        }
+
+        /// <summary>
+        /// Records enemy missions exposed by a successful espionage observation.
+        /// </summary>
+        /// <param name="faction">The faction receiving the intelligence.</param>
+        /// <param name="planet">The planet whose missions were observed.</param>
+        /// <param name="snapshot">The snapshot receiving mission copies.</param>
+        private static void AddEnemyMissionsToSnapshot(
+            Faction faction,
+            Planet planet,
+            PlanetSnapshot snapshot
+        )
+        {
+            snapshot.Missions.AddRange(
+                planet
+                    .Missions.Where(mission => mission.GetOwnerInstanceID() != faction.InstanceID)
+                    .Select(mission => CopyEntityForSnapshot(mission))
+            );
+        }
+
+        /// <summary>
+        /// Retains previously gathered mission intelligence during an ordinary observation.
+        /// </summary>
+        /// <param name="previousSnapshot">The prior intelligence snapshot.</param>
+        /// <param name="snapshot">The replacement snapshot.</param>
+        private static void PreserveMissionIntelligence(
+            PlanetSnapshot previousSnapshot,
+            PlanetSnapshot snapshot
+        )
+        {
+            if (previousSnapshot?.HasEspionageIntelligence != true)
+                return;
+
+            snapshot.Missions.AddRange(
+                previousSnapshot.Missions.Select(mission => CopyEntityForSnapshot(mission))
+            );
+        }
+
+        /// <summary>
+        /// Retains incoming fleets learned through espionage during an ordinary observation.
+        /// </summary>
+        /// <param name="previousSnapshot">The prior intelligence snapshot.</param>
+        /// <param name="snapshot">The replacement snapshot.</param>
+        private static void PreserveIncomingFleetIntelligence(
+            PlanetSnapshot previousSnapshot,
+            PlanetSnapshot snapshot
+        )
+        {
+            if (previousSnapshot?.HasEspionageIntelligence != true)
+                return;
+
+            foreach (
+                Fleet fleet in previousSnapshot.Fleets.Where(fleet =>
+                    fleet.Movement != null
+                    && snapshot.Fleets.All(current => current.InstanceID != fleet.InstanceID)
+                )
+            )
+            {
+                snapshot.Fleets.Add(CopyFleetForSnapshot(fleet));
+            }
         }
 
         /// <summary>
@@ -267,7 +338,13 @@ namespace Rebellion.Game.FogOfWar
         /// <param name="faction">The faction receiving the snapshot.</param>
         /// <param name="planet">The observed planet.</param>
         /// <param name="snapshot">The snapshot being populated.</param>
-        private void AddOfficersToSnapshot(Faction faction, Planet planet, PlanetSnapshot snapshot)
+        /// <param name="includeInTransit">Whether moving officers should be included.</param>
+        private void AddOfficersToSnapshot(
+            Faction faction,
+            Planet planet,
+            PlanetSnapshot snapshot,
+            bool includeInTransit
+        )
         {
             foreach (Officer officer in planet.Officers)
             {
@@ -277,7 +354,7 @@ namespace Rebellion.Game.FogOfWar
                     continue;
                 }
 
-                if (!IsObservableAtPlanet(officer, faction.InstanceID))
+                if (!includeInTransit && !IsObservableAtPlanet(officer, faction.InstanceID))
                     continue;
 
                 snapshot.Officers.Add(CopyOfficerForSnapshot(officer));
@@ -290,12 +367,12 @@ namespace Rebellion.Game.FogOfWar
         /// <param name="faction">The faction receiving the snapshot.</param>
         /// <param name="planet">The observed planet.</param>
         /// <param name="snapshot">The snapshot being populated.</param>
-        /// <param name="includeManufacturing">Whether unfinished units should be included.</param>
+        /// <param name="includeEspionageIntelligence">Whether hidden intelligence should be included.</param>
         private void AddFleetsToSnapshot(
             Faction faction,
             Planet planet,
             PlanetSnapshot snapshot,
-            bool includeManufacturing
+            bool includeEspionageIntelligence
         )
         {
             foreach (Fleet fleet in planet.Fleets)
@@ -308,13 +385,17 @@ namespace Rebellion.Game.FogOfWar
                     continue;
                 }
 
-                if (!IsObservableAtPlanet(fleet, faction.InstanceID))
+                if (
+                    !includeEspionageIntelligence
+                    && !IsObservableAtPlanet(fleet, faction.InstanceID)
+                )
                     continue;
 
                 Fleet fleetCopy = CopyObservedFleetForSnapshot(
                     fleet,
                     faction.InstanceID,
-                    includeManufacturing
+                    includeEspionageIntelligence,
+                    includeEspionageIntelligence
                 );
                 if (fleetCopy == null)
                     continue;
@@ -330,12 +411,12 @@ namespace Rebellion.Game.FogOfWar
         /// <param name="source">The live entities to copy.</param>
         /// <param name="destination">The snapshot list to populate.</param>
         /// <param name="faction">The faction receiving the snapshot.</param>
-        /// <param name="includeManufacturing">Whether unfinished units should be included.</param>
+        /// <param name="includeEspionageIntelligence">Whether hidden intelligence should be included.</param>
         private void AddEntityCopiesToSnapshot<T>(
             IEnumerable<T> source,
             List<T> destination,
             Faction faction,
-            bool includeManufacturing
+            bool includeEspionageIntelligence
         )
             where T : class, ISceneNode
         {
@@ -347,11 +428,14 @@ namespace Rebellion.Game.FogOfWar
                     continue;
                 }
 
-                if (!IsObservableAtPlanet(entity, faction.InstanceID))
+                if (
+                    !includeEspionageIntelligence
+                    && !IsObservableAtPlanet(entity, faction.InstanceID)
+                )
                     continue;
 
                 if (
-                    !includeManufacturing
+                    !includeEspionageIntelligence
                     && entity is IManufacturable manufacturable
                     && IsManufacturingInProgress(manufacturable)
                 )
@@ -670,14 +754,16 @@ namespace Rebellion.Game.FogOfWar
         /// <param name="fleet">The observed fleet to copy.</param>
         /// <param name="observerFactionInstanceID">The faction receiving the observation.</param>
         /// <param name="includeManufacturing">Whether unfinished units should be retained.</param>
+        /// <param name="includeInTransit">Whether moving fleets and their contents should be retained.</param>
         /// <returns>The detached fleet copy, or null when no completed ships remain.</returns>
         internal static Fleet CopyObservedFleetForSnapshot(
             Fleet fleet,
             string observerFactionInstanceID,
-            bool includeManufacturing = false
+            bool includeManufacturing = false,
+            bool includeInTransit = false
         )
         {
-            if (!IsObservableAtPlanet(fleet, observerFactionInstanceID))
+            if (!includeInTransit && !IsObservableAtPlanet(fleet, observerFactionInstanceID))
                 return null;
 
             Fleet copy = CopyFleetForSnapshot(fleet);
@@ -685,25 +771,31 @@ namespace Rebellion.Game.FogOfWar
                 return null;
 
             copy.CapitalShips.RemoveAll(ship =>
-                !IsObservableAtPlanet(ship, observerFactionInstanceID)
-                || !includeManufacturing && IsManufacturingInProgress(ship)
+                (!includeInTransit && !IsObservableAtPlanet(ship, observerFactionInstanceID))
+                || (!includeManufacturing && IsManufacturingInProgress(ship))
             );
             foreach (CapitalShip ship in copy.CapitalShips)
             {
                 ship.Officers.RemoveAll(officer =>
-                    !IsObservableAtPlanet(officer, observerFactionInstanceID)
+                    !includeInTransit && !IsObservableAtPlanet(officer, observerFactionInstanceID)
                 );
                 ship.Regiments.RemoveAll(regiment =>
-                    !IsObservableAtPlanet(regiment, observerFactionInstanceID)
-                    || !includeManufacturing && IsManufacturingInProgress(regiment)
+                    (
+                        !includeInTransit
+                        && !IsObservableAtPlanet(regiment, observerFactionInstanceID)
+                    ) || (!includeManufacturing && IsManufacturingInProgress(regiment))
                 );
                 ship.SpecialForces.RemoveAll(specialForces =>
-                    !IsObservableAtPlanet(specialForces, observerFactionInstanceID)
-                    || !includeManufacturing && IsManufacturingInProgress(specialForces)
+                    (
+                        !includeInTransit
+                        && !IsObservableAtPlanet(specialForces, observerFactionInstanceID)
+                    ) || (!includeManufacturing && IsManufacturingInProgress(specialForces))
                 );
                 ship.Starfighters.RemoveAll(starfighter =>
-                    !IsObservableAtPlanet(starfighter, observerFactionInstanceID)
-                    || !includeManufacturing && IsManufacturingInProgress(starfighter)
+                    (
+                        !includeInTransit
+                        && !IsObservableAtPlanet(starfighter, observerFactionInstanceID)
+                    ) || (!includeManufacturing && IsManufacturingInProgress(starfighter))
                 );
             }
 
@@ -929,6 +1021,7 @@ namespace Rebellion.Game.FogOfWar
             snapshot.SpecialForces.RemoveAll(s => s.InstanceID == entityId);
             snapshot.Buildings.RemoveAll(b => b.InstanceID == entityId);
             snapshot.Starfighters.RemoveAll(s => s.InstanceID == entityId);
+            snapshot.Missions.RemoveAll(m => m.InstanceID == entityId);
             snapshot.ManufacturingQueueItems.RemoveAll(item => item.InstanceID == entityId);
 
             foreach (Fleet fleet in snapshot.Fleets)

--- a/Assets/Scripts/Game/FogOfWar/PlanetSnapshot.cs
+++ b/Assets/Scripts/Game/FogOfWar/PlanetSnapshot.cs
@@ -34,6 +34,9 @@ namespace Rebellion.Game.FogOfWar
         public List<Starfighter> Starfighters;
         public List<Mission> Missions;
 
+        // Complete Espionage Intelligence.
+        public bool HasEspionageIntelligence;
+
         // Manufacturing Intelligence.
         public bool HasManufacturingIntelligence;
         public List<IManufacturable> ManufacturingQueueItems;

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -644,8 +644,6 @@ namespace Rebellion.Game
 
             public string CapitalObserverFactionInstanceID { get; set; }
 
-            public string MobileHeadquartersFactionInstanceID { get; set; }
-
             public RandomCountConfig CoreSystemBonus { get; set; } = new RandomCountConfig();
 
             public RandomCountConfig CapitalBonus { get; set; } = new RandomCountConfig();

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -41,6 +41,8 @@ namespace Rebellion.Game
 
         public MessageConfig Messages { get; set; } = new MessageConfig();
 
+        public EspionageConfig Espionage { get; set; } = new EspionageConfig();
+
         public ProbabilityTablesConfig ProbabilityTables { get; set; } =
             new ProbabilityTablesConfig();
 
@@ -630,6 +632,37 @@ namespace Rebellion.Game
         public class MessageConfig
         {
             public int RetentionTicks { get; set; }
+        }
+
+        /// <summary>
+        /// Controls the additional system intelligence granted by successful espionage.
+        /// </summary>
+        [PersistableObject]
+        public class EspionageConfig
+        {
+            public string CapitalPlanetInstanceID { get; set; }
+
+            public string CapitalObserverFactionInstanceID { get; set; }
+
+            public string MobileHeadquartersFactionInstanceID { get; set; }
+
+            public RandomCountConfig CoreSystemBonus { get; set; } = new RandomCountConfig();
+
+            public RandomCountConfig CapitalBonus { get; set; } = new RandomCountConfig();
+
+            public RandomCountConfig MobileHeadquartersBonus { get; set; } =
+                new RandomCountConfig();
+        }
+
+        /// <summary>
+        /// Defines a count as a fixed minimum plus a random value below the spread.
+        /// </summary>
+        [PersistableObject]
+        public class RandomCountConfig
+        {
+            public int Base { get; set; }
+
+            public int Spread { get; set; }
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Messages/MessageDefinition.cs
+++ b/Assets/Scripts/Game/Messages/MessageDefinition.cs
@@ -99,6 +99,7 @@ namespace Rebellion.Game.Messages
         public ResearchDiscipline ResearchDiscipline { get; set; }
         public string TitleTemplate { get; set; }
         public string BodyTemplate { get; set; }
+        public bool ShowOfficerOverlay { get; set; }
         public string ImageKey { get; set; }
         public string ImagePath { get; set; }
         public Dictionary<string, string> ImagePaths { get; set; } =

--- a/Assets/Scripts/Game/Messages/MessageFactory.cs
+++ b/Assets/Scripts/Game/Messages/MessageFactory.cs
@@ -486,9 +486,10 @@ namespace Rebellion.Game.Messages
             if (officer == null)
                 return null;
 
+            MessageDefinition definition = GetDefinition(resultType);
             Message message = WithEventLocation(
                 CreateMessage(
-                    GetDefinition(resultType),
+                    definition,
                     faction,
                     new Dictionary<string, string>
                     {
@@ -500,7 +501,7 @@ namespace Rebellion.Game.Messages
                         },
                         { "system", planet?.GetDisplayName() ?? string.Empty },
                     },
-                    overlayImagePath: UsesOfficerOverlay(resultType)
+                    overlayImagePath: definition?.ShowOfficerOverlay == true
                         ? GetMessageImagePath(officer)
                         : null,
                     officerVoicePath: GetOfficerMessageVoicePath(resultType, officer, game)
@@ -520,24 +521,6 @@ namespace Rebellion.Game.Messages
                 _ => AdvisorSubjectNotification.None,
             };
             return WithAdvisorSubject(message, notification, officer);
-        }
-
-        /// <summary>
-        /// Returns whether the original event record supplies an officer portrait overlay.
-        /// </summary>
-        /// <param name="resultType">The officer event type.</param>
-        /// <returns>True when the event composites the officer portrait over its card.</returns>
-        private static bool UsesOfficerOverlay(MessageResultType resultType)
-        {
-            return resultType switch
-            {
-                MessageResultType.OfficerCaptured
-                or MessageResultType.EnemyOfficerCaptured
-                or MessageResultType.OfficerReleased
-                or MessageResultType.OfficerInjured
-                or MessageResultType.OfficerKilled => false,
-                _ => true,
-            };
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Messages/MessageFactory.cs
+++ b/Assets/Scripts/Game/Messages/MessageFactory.cs
@@ -474,15 +474,13 @@ namespace Rebellion.Game.Messages
         /// <param name="officer">The officer described by the message.</param>
         /// <param name="planet">The planet associated with the officer state.</param>
         /// <param name="game">The game state used for voice selection randomness.</param>
-        /// <param name="includeOfficerOverlay">Whether to include the officer portrait overlay.</param>
         /// <returns>The officer status message, or null when no matching definition exists.</returns>
         private Message CreateOfficerMessage(
             MessageResultType resultType,
             Faction faction,
             Officer officer,
             Planet planet,
-            GameRoot game,
-            bool includeOfficerOverlay = true
+            GameRoot game
         )
         {
             if (officer == null)
@@ -502,7 +500,9 @@ namespace Rebellion.Game.Messages
                         },
                         { "system", planet?.GetDisplayName() ?? string.Empty },
                     },
-                    overlayImagePath: includeOfficerOverlay ? GetMessageImagePath(officer) : null,
+                    overlayImagePath: UsesOfficerOverlay(resultType)
+                        ? GetMessageImagePath(officer)
+                        : null,
                     officerVoicePath: GetOfficerMessageVoicePath(resultType, officer, game)
                 ),
                 planet,
@@ -520,6 +520,24 @@ namespace Rebellion.Game.Messages
                 _ => AdvisorSubjectNotification.None,
             };
             return WithAdvisorSubject(message, notification, officer);
+        }
+
+        /// <summary>
+        /// Returns whether the original event record supplies an officer portrait overlay.
+        /// </summary>
+        /// <param name="resultType">The officer event type.</param>
+        /// <returns>True when the event composites the officer portrait over its card.</returns>
+        private static bool UsesOfficerOverlay(MessageResultType resultType)
+        {
+            return resultType switch
+            {
+                MessageResultType.OfficerCaptured
+                or MessageResultType.EnemyOfficerCaptured
+                or MessageResultType.OfficerReleased
+                or MessageResultType.OfficerInjured
+                or MessageResultType.OfficerKilled => false,
+                _ => true,
+            };
         }
 
         /// <summary>
@@ -1571,8 +1589,7 @@ namespace Rebellion.Game.Messages
                         faction,
                         result.TargetOfficer,
                         planet,
-                        game,
-                        false
+                        game
                     )
                 );
             }

--- a/Assets/Scripts/Game/Missions/EspionageMission.cs
+++ b/Assets/Scripts/Game/Missions/EspionageMission.cs
@@ -214,7 +214,7 @@ namespace Rebellion.Game.Missions
                 countConfig = config.CapitalBonus;
                 includeOuterRim = true;
             }
-            else if (IsMobileHeadquartersTarget(game, config, targetPlanet))
+            else if (IsMobileHeadquartersTarget(game, targetPlanet))
             {
                 countConfig = config.MobileHeadquartersBonus;
                 includeOuterRim = true;
@@ -244,21 +244,15 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns whether the target currently hosts the configured opposing mobile headquarters.
+        /// Returns whether the target currently hosts its owner's opposing mobile headquarters.
         /// </summary>
-        private bool IsMobileHeadquartersTarget(
-            GameRoot game,
-            GameConfig.EspionageConfig config,
-            Planet targetPlanet
-        )
+        private bool IsMobileHeadquartersTarget(GameRoot game, Planet targetPlanet)
         {
-            Faction headquartersFaction = game.Factions.FirstOrDefault(candidate =>
-                candidate.InstanceID == config.MobileHeadquartersFactionInstanceID
-            );
-            return headquartersFaction != null
-                && headquartersFaction.InstanceID != OwnerInstanceID
-                && headquartersFaction.Settings.Headquarters.IsMobile
-                && headquartersFaction.HQInstanceID == targetPlanet.InstanceID;
+            Faction owner = game.GetFactionByOwnerInstanceID(targetPlanet.OwnerInstanceID);
+            return owner != null
+                && owner.InstanceID != OwnerInstanceID
+                && owner.Settings.Headquarters.IsMobile
+                && owner.HQInstanceID == targetPlanet.InstanceID;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Missions/EspionageMission.cs
+++ b/Assets/Scripts/Game/Missions/EspionageMission.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Rebellion.Game.Factions;
 using Rebellion.Game.FogOfWar;
 using Rebellion.Game.Galaxy;
@@ -156,10 +157,10 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Captures a fog-of-war snapshot of the target planet for the owning faction.
+        /// Captures full intelligence for the target planet and any bonus planets.
         /// </summary>
         /// <param name="game">The current game state.</param>
-        /// <param name="provider">RNG provider (unused for espionage).</param>
+        /// <param name="provider">RNG provider used to select bonus planets.</param>
         /// <returns>An empty list; the snapshot is applied directly to faction fog state.</returns>
         protected override List<GameResult> OnSuccess(GameRoot game, IRandomNumberProvider provider)
         {
@@ -167,15 +168,97 @@ namespace Rebellion.Game.Missions
             Faction faction = game?.GetFactionByOwnerInstanceID(OwnerInstanceID);
             PlanetSystem system = planet?.GetParentOfType<PlanetSystem>();
 
+            if (game == null || faction == null || planet == null || system == null)
+                return new List<GameResult>();
+
             FogOfWarRecorder recorder = new FogOfWarRecorder();
-            recorder.RecordPlanetManufacturingSnapshot(
-                faction,
-                planet,
-                system,
-                game?.CurrentTick ?? 0
-            );
+            recorder.RecordEspionageSnapshot(faction, planet, system, game.CurrentTick);
+
+            foreach (Planet bonusPlanet in SelectBonusPlanets(game, provider, planet, system))
+            {
+                PlanetSystem bonusSystem = bonusPlanet.GetParentOfType<PlanetSystem>();
+                recorder.RecordEspionageSnapshot(
+                    faction,
+                    bonusPlanet,
+                    bonusSystem,
+                    game.CurrentTick
+                );
+            }
 
             return new List<GameResult>();
+        }
+
+        /// <summary>
+        /// Selects distinct bonus planets using the original mission's target-specific pools.
+        /// </summary>
+        private IEnumerable<Planet> SelectBonusPlanets(
+            GameRoot game,
+            IRandomNumberProvider provider,
+            Planet targetPlanet,
+            PlanetSystem targetSystem
+        )
+        {
+            if (targetSystem.SystemType != PlanetSystemType.CoreSystem)
+                return Enumerable.Empty<Planet>();
+
+            GameConfig.EspionageConfig config =
+                game.Config?.Espionage ?? new GameConfig.EspionageConfig();
+            GameConfig.RandomCountConfig countConfig = config.CoreSystemBonus;
+            bool includeOuterRim = false;
+
+            if (
+                OwnerInstanceID == config.CapitalObserverFactionInstanceID
+                && targetPlanet.InstanceID == config.CapitalPlanetInstanceID
+            )
+            {
+                countConfig = config.CapitalBonus;
+                includeOuterRim = true;
+            }
+            else if (IsMobileHeadquartersTarget(game, config, targetPlanet))
+            {
+                countConfig = config.MobileHeadquartersBonus;
+                includeOuterRim = true;
+            }
+
+            List<Planet> candidates = game
+                .Galaxy.PlanetSystems.Where(system =>
+                    includeOuterRim || system.SystemType == PlanetSystemType.CoreSystem
+                )
+                .SelectMany(system => system.Planets)
+                .Where(candidate => candidate != targetPlanet)
+                .Where(candidate => candidate.OwnerInstanceID == targetPlanet.OwnerInstanceID)
+                .ToList();
+            int count = countConfig.Base;
+            if (countConfig.Spread > 0)
+                count += provider.NextInt(0, countConfig.Spread);
+
+            List<Planet> selected = new List<Planet>();
+            while (selected.Count < count && candidates.Count > 0)
+            {
+                int index = provider.NextInt(0, candidates.Count);
+                selected.Add(candidates[index]);
+                candidates.RemoveAt(index);
+            }
+
+            return selected;
+        }
+
+        /// <summary>
+        /// Returns whether the target currently hosts the configured opposing mobile headquarters.
+        /// </summary>
+        private bool IsMobileHeadquartersTarget(
+            GameRoot game,
+            GameConfig.EspionageConfig config,
+            Planet targetPlanet
+        )
+        {
+            Faction headquartersFaction = game.Factions.FirstOrDefault(candidate =>
+                candidate.InstanceID == config.MobileHeadquartersFactionInstanceID
+            );
+            return headquartersFaction != null
+                && headquartersFaction.InstanceID != OwnerInstanceID
+                && headquartersFaction.Settings.Headquarters.IsMobile
+                && headquartersFaction.HQInstanceID == targetPlanet.InstanceID;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Results/GameResults.cs
+++ b/Assets/Scripts/Game/Results/GameResults.cs
@@ -226,6 +226,17 @@ namespace Rebellion.Game.Results
     }
 
     /// <summary>
+    /// A mobile headquarters was destroyed when its planet fell to an enemy faction.
+    /// </summary>
+    public class HeadquartersDestroyedResult : GameResult
+    {
+        public Building Headquarters { get; set; }
+        public Planet Planet { get; set; }
+        public Faction Defender { get; set; }
+        public Faction Attacker { get; set; }
+    }
+
+    /// <summary>
     /// The active regiment garrison at a planet changed.
     /// </summary>
     public class PlanetGarrisonChangedResult : GameResult

--- a/Assets/Scripts/Game/Units/Building.cs
+++ b/Assets/Scripts/Game/Units/Building.cs
@@ -17,6 +17,7 @@ namespace Rebellion.Game.Units
         ConstructionFacility,
         Defense,
         Weapon,
+        Headquarters,
     }
 
     /// <summary>
@@ -52,6 +53,7 @@ namespace Rebellion.Game.Units
         public int WeaponPower { get; set; }
         public DefenseFacilityClass DefenseFacilityClass { get; set; }
         public int ProductionModifier { get; set; }
+        public bool CanBeManufactured { get; set; } = true;
 
         // Manufacturing Info.
         public string ProducerOwnerID { get; set; }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -37,7 +37,7 @@ public sealed class GameManager
     private ManufacturingSystem _manufacturingSystem;
     private MaintenanceSystem _maintenanceSystem;
     private ResourceProductionSystem _resourceProductionSystem;
-    private PlayerAutomationSystem _playerAutomationSystem;
+    private FactionAutomationSystem _factionAutomationSystem;
 
     // Planetary Systems.
     private PlanetaryControlSystem _planetaryControlSystem;
@@ -207,7 +207,7 @@ public sealed class GameManager
         _messageSystem.ProcessTick();
         GameLogger.Debug("Tick: " + _game.CurrentTick);
 
-        _playerAutomationSystem.ProcessTick();
+        _factionAutomationSystem.ProcessTick();
         ProcessResults(_resourceProductionSystem.ProcessTick());
         ProcessResults(_manufacturingSystem.ProcessTick());
         ProcessResults(_maintenanceSystem.ProcessTick());
@@ -308,7 +308,7 @@ public sealed class GameManager
         _movementSystem = new MovementSystem(_game, _fogOfWarSystem, _fleetSystem, _blockadeSystem);
         _headquartersSystem = new HeadquartersSystem(_game, _movementSystem);
         _manufacturingSystem = new ManufacturingSystem(_game, _fleetSystem, _movementSystem);
-        _playerAutomationSystem = new PlayerAutomationSystem(
+        _factionAutomationSystem = new FactionAutomationSystem(
             _game,
             _gameData,
             _manufacturingSystem
@@ -365,6 +365,8 @@ public sealed class GameManager
         _resultProcessor = new GameResultProcessor();
         _resultProcessor.Subscribe<BlockadeChangedResult>(_movementSystem);
         _resultProcessor.Subscribe<UnitArrivedResult>(_headquartersSystem);
+        _resultProcessor.Subscribe<PlanetOwnershipChangedResult>(_headquartersSystem);
+        _resultProcessor.Subscribe<HeadquartersDestroyedResult>(_victorySystem);
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_planetaryControlSystem);
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_uprisingSystem);
         _resultProcessor.Subscribe<PlanetUprisingStartedResult>(_missionSystem);

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -31,11 +31,13 @@ public sealed class GameManager
     private FleetSystem _fleetSystem;
     private PersonnelSystem _personnelSystem;
     private MovementSystem _movementSystem;
+    private HeadquartersSystem _headquartersSystem;
 
     // Economy Systems.
     private ManufacturingSystem _manufacturingSystem;
     private MaintenanceSystem _maintenanceSystem;
     private ResourceProductionSystem _resourceProductionSystem;
+    private PlayerAutomationSystem _playerAutomationSystem;
 
     // Planetary Systems.
     private PlanetaryControlSystem _planetaryControlSystem;
@@ -77,6 +79,7 @@ public sealed class GameManager
     internal PersonnelSystem PersonnelSystem => _personnelSystem;
 
     internal MovementSystem MovementSystem => _movementSystem;
+    internal HeadquartersSystem HeadquartersSystem => _headquartersSystem;
 
     internal ManufacturingSystem ManufacturingSystem => _manufacturingSystem;
 
@@ -204,6 +207,7 @@ public sealed class GameManager
         _messageSystem.ProcessTick();
         GameLogger.Debug("Tick: " + _game.CurrentTick);
 
+        _playerAutomationSystem.ProcessTick();
         ProcessResults(_resourceProductionSystem.ProcessTick());
         ProcessResults(_manufacturingSystem.ProcessTick());
         ProcessResults(_maintenanceSystem.ProcessTick());
@@ -302,7 +306,13 @@ public sealed class GameManager
         _fleetSystem = new FleetSystem(_game);
         _personnelSystem = new PersonnelSystem(_game);
         _movementSystem = new MovementSystem(_game, _fogOfWarSystem, _fleetSystem, _blockadeSystem);
+        _headquartersSystem = new HeadquartersSystem(_game, _movementSystem);
         _manufacturingSystem = new ManufacturingSystem(_game, _fleetSystem, _movementSystem);
+        _playerAutomationSystem = new PlayerAutomationSystem(
+            _game,
+            _gameData,
+            _manufacturingSystem
+        );
         _maintenanceSystem = new MaintenanceSystem(_game, _randomProvider, _fleetSystem);
         _resourceProductionSystem = new ResourceProductionSystem(_game);
         _planetaryControlSystem = new PlanetaryControlSystem(
@@ -354,6 +364,7 @@ public sealed class GameManager
     {
         _resultProcessor = new GameResultProcessor();
         _resultProcessor.Subscribe<BlockadeChangedResult>(_movementSystem);
+        _resultProcessor.Subscribe<UnitArrivedResult>(_headquartersSystem);
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_planetaryControlSystem);
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_uprisingSystem);
         _resultProcessor.Subscribe<PlanetUprisingStartedResult>(_missionSystem);

--- a/Assets/Scripts/SceneGraph/BaseGameEntity.cs
+++ b/Assets/Scripts/SceneGraph/BaseGameEntity.cs
@@ -45,6 +45,14 @@ namespace Rebellion.SceneGraph
         public string EncyclopediaDescription { get; set; }
 
         /// <summary>
+        /// Gets whether this entity defines any encyclopedia presentation data.
+        /// </summary>
+        public bool HasEncyclopediaData =>
+            !string.IsNullOrEmpty(EncyclopediaImagePath)
+            || !string.IsNullOrEmpty(EncyclopediaDescription)
+            || EncyclopediaStats?.Count > 0;
+
+        /// <summary>
         /// Returns the instance ID of the entity.
         /// </summary>
         /// <returns>The instance ID of the entity.</returns>

--- a/Assets/Scripts/Systems/BombardmentSystem.cs
+++ b/Assets/Scripts/Systems/BombardmentSystem.cs
@@ -739,7 +739,7 @@ namespace Rebellion.Systems
                 && !string.IsNullOrEmpty(defenderId)
                 && _game
                     .GetFactionByOwnerInstanceID(defenderId)
-                    .Settings.HeadquartersCanBeBombarded;
+                    .Settings.Headquarters?.IsBombardable == true;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/FactionAutomationSystem.cs
+++ b/Assets/Scripts/Systems/FactionAutomationSystem.cs
@@ -12,19 +12,19 @@ namespace Rebellion.Systems
     /// <summary>
     /// Performs the optional strategic chores delegated to the protocol advisor.
     /// </summary>
-    public sealed class PlayerAutomationSystem
+    public sealed class FactionAutomationSystem
     {
         private readonly GameRoot _game;
         private readonly GameDataCatalog _gameData;
         private readonly ManufacturingSystem _manufacturing;
 
         /// <summary>
-        /// Creates the player automation system.
+        /// Creates the faction automation system.
         /// </summary>
         /// <param name="game">The active game.</param>
         /// <param name="gameData">Templates available to the selected content pack.</param>
         /// <param name="manufacturing">The manufacturing system used to place orders.</param>
-        public PlayerAutomationSystem(
+        public FactionAutomationSystem(
             GameRoot game,
             GameDataCatalog gameData,
             ManufacturingSystem manufacturing
@@ -320,9 +320,7 @@ namespace Rebellion.Systems
         /// <returns>The total facility count.</returns>
         private static int CountBuildings(IEnumerable<Planet> planets, BuildingType buildingType)
         {
-            return planets.Sum(planet =>
-                planet.Buildings.Count(building => building.BuildingType == buildingType)
-            );
+            return planets.Sum(planet => planet.GetTotalBuildingTypeCount(buildingType));
         }
     }
 }

--- a/Assets/Scripts/Systems/FogOfWarSystem.cs
+++ b/Assets/Scripts/Systems/FogOfWarSystem.cs
@@ -162,6 +162,8 @@ namespace Rebellion.Systems
 
                     MergeOwnLiveUnits(viewPlanet, masterPlanet, faction);
 
+                    AddObservedMissions(viewPlanet, planetSnapshot);
+
                     foreach (
                         Mission mission in masterPlanet.Missions.Where(mission =>
                             mission.GetOwnerInstanceID() == faction.InstanceID
@@ -183,6 +185,24 @@ namespace Rebellion.Systems
             }
 
             return factionView;
+        }
+
+        /// <summary>
+        /// Adds enemy missions revealed by the latest espionage snapshot.
+        /// </summary>
+        /// <param name="viewPlanet">The faction-view planet receiving mission copies.</param>
+        /// <param name="snapshot">The latest intelligence snapshot, if any.</param>
+        private static void AddObservedMissions(Planet viewPlanet, PlanetSnapshot snapshot)
+        {
+            if (snapshot?.HasEspionageIntelligence != true)
+                return;
+
+            foreach (Mission mission in snapshot.Missions)
+            {
+                Mission viewMission = FogOfWarRecorder.CopyEntityForSnapshot(mission);
+                viewMission.SetParent(viewPlanet);
+                viewPlanet.Missions.Add(viewMission);
+            }
         }
 
         /// <summary>
@@ -414,6 +434,8 @@ namespace Rebellion.Systems
                 viewPlanet.ManufacturingQueue = CopyLiveManufacturingQueue(masterPlanet);
             else
                 ApplyManufacturingIntelligence(viewPlanet, planetSnapshot);
+
+            ApplyIncomingFleetIntelligence(viewPlanet, planetSnapshot, faction);
         }
 
         /// <summary>
@@ -446,7 +468,8 @@ namespace Rebellion.Systems
             viewPlanet.Officers.AddRange(
                 planetSnapshot
                     .Officers.Where(officer =>
-                        FogOfWarRecorder.IsObservableAtPlanet(officer, faction.InstanceID)
+                        planetSnapshot.HasEspionageIntelligence
+                        || FogOfWarRecorder.IsObservableAtPlanet(officer, faction.InstanceID)
                     )
                     .Select(FogOfWarRecorder.CopyOfficerForSnapshot)
             );
@@ -461,7 +484,8 @@ namespace Rebellion.Systems
                         FogOfWarRecorder.CopyObservedFleetForSnapshot(
                             fleet,
                             faction.InstanceID,
-                            includeManufacturing: true
+                            includeManufacturing: true,
+                            includeInTransit: planetSnapshot.HasEspionageIntelligence
                         )
                     )
                     .Where(fleet => fleet != null)
@@ -469,32 +493,69 @@ namespace Rebellion.Systems
             viewPlanet.Regiments.AddRange(
                 planetSnapshot
                     .Regiments.Where(regiment =>
-                        FogOfWarRecorder.IsObservableAtPlanet(regiment, faction.InstanceID)
+                        planetSnapshot.HasEspionageIntelligence
+                        || FogOfWarRecorder.IsObservableAtPlanet(regiment, faction.InstanceID)
                     )
                     .Select(FogOfWarRecorder.CopyEntityForSnapshot)
             );
             viewPlanet.SpecialForces.AddRange(
                 planetSnapshot
                     .SpecialForces.Where(specialForces =>
-                        FogOfWarRecorder.IsObservableAtPlanet(specialForces, faction.InstanceID)
+                        planetSnapshot.HasEspionageIntelligence
+                        || FogOfWarRecorder.IsObservableAtPlanet(specialForces, faction.InstanceID)
                     )
                     .Select(FogOfWarRecorder.CopyEntityForSnapshot)
             );
             viewPlanet.Starfighters.AddRange(
                 planetSnapshot
                     .Starfighters.Where(starfighter =>
-                        FogOfWarRecorder.IsObservableAtPlanet(starfighter, faction.InstanceID)
+                        planetSnapshot.HasEspionageIntelligence
+                        || FogOfWarRecorder.IsObservableAtPlanet(starfighter, faction.InstanceID)
                     )
                     .Select(FogOfWarRecorder.CopyEntityForSnapshot)
             );
             viewPlanet.Buildings.AddRange(
                 planetSnapshot
                     .Buildings.Where(building =>
-                        FogOfWarRecorder.IsObservableAtPlanet(building, faction.InstanceID)
+                        planetSnapshot.HasEspionageIntelligence
+                        || FogOfWarRecorder.IsObservableAtPlanet(building, faction.InstanceID)
                     )
                     .Select(FogOfWarRecorder.CopyEntityForSnapshot)
             );
             ApplyManufacturingQueue(viewPlanet, planetSnapshot);
+        }
+
+        /// <summary>
+        /// Adds incoming enemy fleets revealed by espionage to an otherwise live planet view.
+        /// </summary>
+        /// <param name="viewPlanet">The faction-view planet receiving known incoming fleets.</param>
+        /// <param name="snapshot">The latest intelligence snapshot, if any.</param>
+        /// <param name="faction">The faction whose view is being built.</param>
+        private static void ApplyIncomingFleetIntelligence(
+            Planet viewPlanet,
+            PlanetSnapshot snapshot,
+            Faction faction
+        )
+        {
+            if (snapshot?.HasEspionageIntelligence != true)
+                return;
+
+            foreach (
+                Fleet fleet in snapshot.Fleets.Where(fleet =>
+                    fleet.Movement != null
+                    && viewPlanet.Fleets.All(current => current.InstanceID != fleet.InstanceID)
+                )
+            )
+            {
+                Fleet fleetCopy = FogOfWarRecorder.CopyObservedFleetForSnapshot(
+                    fleet,
+                    faction.InstanceID,
+                    includeManufacturing: true,
+                    includeInTransit: true
+                );
+                if (fleetCopy != null)
+                    viewPlanet.Fleets.Add(fleetCopy);
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/HeadquartersSystem.cs
+++ b/Assets/Scripts/Systems/HeadquartersSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Rebellion.Game;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
@@ -10,9 +11,11 @@ using Rebellion.SceneGraph;
 namespace Rebellion.Systems
 {
     /// <summary>
-    /// Validates mobile-headquarters orders and updates the faction headquarters on arrival.
+    /// Owns mobile-headquarters relocation, arrival, and destruction policy.
     /// </summary>
-    public sealed class HeadquartersSystem : IGameResultHandler<UnitArrivedResult>
+    public sealed class HeadquartersSystem
+        : IGameResultHandler<UnitArrivedResult>,
+            IGameResultHandler<PlanetOwnershipChangedResult>
     {
         private readonly GameRoot _game;
         private readonly MovementSystem _movement;
@@ -21,6 +24,24 @@ namespace Rebellion.Systems
         {
             _game = game ?? throw new ArgumentNullException(nameof(game));
             _movement = movement ?? throw new ArgumentNullException(nameof(movement));
+            _movement.SetCompletedBuildingMovementPolicy(CanMove);
+        }
+
+        /// <summary>
+        /// Determines whether a completed building is the owning faction's active mobile headquarters.
+        /// </summary>
+        /// <param name="building">The completed building requesting movement.</param>
+        /// <returns>True when headquarters policy permits the building to move.</returns>
+        private bool CanMove(Building building)
+        {
+            if (building?.BuildingType != BuildingType.Headquarters || building.Movement != null)
+                return false;
+
+            Faction faction = _game.GetFactionByOwnerInstanceID(building.OwnerInstanceID);
+            Planet origin = building.GetParentOfType<Planet>();
+            return faction?.Settings?.Headquarters?.IsMobile == true
+                && origin != null
+                && faction.HQInstanceID == origin.InstanceID;
         }
 
         /// <summary>
@@ -32,8 +53,7 @@ namespace Rebellion.Systems
         public bool CanRelocate(Building headquarters, Planet destination)
         {
             if (
-                headquarters?.BuildingType != BuildingType.Headquarters
-                || headquarters.Movement != null
+                !CanMove(headquarters)
                 || destination?.IsDestroyed != false
                 || destination?.IsColonized != true
             )
@@ -41,11 +61,7 @@ namespace Rebellion.Systems
 
             Faction faction = _game.GetFactionByOwnerInstanceID(headquarters.OwnerInstanceID);
             Planet origin = headquarters.GetParentOfType<Planet>();
-            return faction?.Settings?.Headquarters?.IsMobile == true
-                && headquarters.TypeID == faction.Settings.Headquarters.FacilityTypeID
-                && origin != null
-                && faction.HQInstanceID == origin.InstanceID
-                && destination != origin
+            return destination != origin
                 && destination.OwnerInstanceID == faction.InstanceID
                 && destination.CanAcceptChild(headquarters);
         }
@@ -90,7 +106,7 @@ namespace Rebellion.Systems
 
                 Faction faction = _game.GetFactionByOwnerInstanceID(hq.OwnerInstanceID);
                 Planet destination = result.Destination;
-                if (faction == null || destination == null)
+                if (faction?.Settings?.Headquarters?.IsMobile != true || destination == null)
                     continue;
 
                 Planet previous = _game.GetSceneNodeByInstanceID<Planet>(faction.HQInstanceID);
@@ -102,6 +118,83 @@ namespace Rebellion.Systems
             }
 
             return new List<GameResult>();
+        }
+
+        /// <summary>
+        /// Destroys a mobile headquarters when an enemy takes control of its planet.
+        /// </summary>
+        /// <param name="results">The completed planetary ownership changes.</param>
+        /// <returns>Headquarters destruction results caused by hostile captures.</returns>
+        public List<GameResult> HandleResults(IReadOnlyList<PlanetOwnershipChangedResult> results)
+        {
+            List<GameResult> reactions = new List<GameResult>();
+            foreach (
+                PlanetOwnershipChangedResult result in results
+                    ?? Array.Empty<PlanetOwnershipChangedResult>()
+            )
+            {
+                UpdateFixedHeadquartersMarker(result);
+
+                Faction defender = result?.PreviousOwner;
+                Faction attacker = result?.NewOwner;
+                Planet planet = result?.Planet;
+                HeadquartersSettings settings = defender?.Settings?.Headquarters;
+                if (
+                    settings?.IsMobile != true
+                    || attacker == null
+                    || attacker == defender
+                    || planet == null
+                )
+                    continue;
+
+                Building headquarters = planet
+                    .GetChildren<Building>(_ => true, recurse: false)
+                    .SingleOrDefault(building =>
+                        building.BuildingType == BuildingType.Headquarters
+                    );
+                if (headquarters == null)
+                    continue;
+
+                _game.DetachNode(headquarters);
+
+                planet.IsHeadquarters = false;
+                defender.HQInstanceID = null;
+                reactions.Add(
+                    new HeadquartersDestroyedResult
+                    {
+                        Headquarters = headquarters,
+                        Planet = planet,
+                        Defender = defender,
+                        Attacker = attacker,
+                        Tick = _game.CurrentTick,
+                    }
+                );
+            }
+
+            return reactions;
+        }
+
+        /// <summary>
+        /// Clears or restores a fixed headquarters marker when its configured planet changes hands.
+        /// The faction's headquarters location remains configured so recapture can restore it.
+        /// </summary>
+        /// <param name="result">The planetary ownership change to apply.</param>
+        private void UpdateFixedHeadquartersMarker(PlanetOwnershipChangedResult result)
+        {
+            Planet planet = result?.Planet;
+            if (planet == null)
+                return;
+
+            Faction fixedHeadquartersFaction = _game
+                .GetFactions()
+                .SingleOrDefault(faction =>
+                    faction.Settings?.Headquarters?.IsMobile != true
+                    && faction.HQInstanceID == planet.InstanceID
+                );
+            if (fixedHeadquartersFaction == null)
+                return;
+
+            planet.IsHeadquarters = result.NewOwner == fixedHeadquartersFaction;
         }
     }
 }

--- a/Assets/Scripts/Systems/HeadquartersSystem.cs
+++ b/Assets/Scripts/Systems/HeadquartersSystem.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using Rebellion.Game;
+using Rebellion.Game.Factions;
+using Rebellion.Game.Galaxy;
+using Rebellion.Game.Results;
+using Rebellion.Game.Units;
+using Rebellion.SceneGraph;
+
+namespace Rebellion.Systems
+{
+    /// <summary>
+    /// Validates mobile-headquarters orders and updates the faction headquarters on arrival.
+    /// </summary>
+    public sealed class HeadquartersSystem : IGameResultHandler<UnitArrivedResult>
+    {
+        private readonly GameRoot _game;
+        private readonly MovementSystem _movement;
+
+        public HeadquartersSystem(GameRoot game, MovementSystem movement)
+        {
+            _game = game ?? throw new ArgumentNullException(nameof(game));
+            _movement = movement ?? throw new ArgumentNullException(nameof(movement));
+        }
+
+        /// <summary>
+        /// Determines whether a headquarters building may relocate to a friendly planet.
+        /// </summary>
+        /// <param name="headquarters">The headquarters building to move.</param>
+        /// <param name="destination">The requested destination planet.</param>
+        /// <returns>True when the relocation order is valid.</returns>
+        public bool CanRelocate(Building headquarters, Planet destination)
+        {
+            if (
+                headquarters?.BuildingType != BuildingType.Headquarters
+                || headquarters.Movement != null
+                || destination?.IsDestroyed != false
+                || destination?.IsColonized != true
+            )
+                return false;
+
+            Faction faction = _game.GetFactionByOwnerInstanceID(headquarters.OwnerInstanceID);
+            Planet origin = headquarters.GetParentOfType<Planet>();
+            return faction?.Settings?.Headquarters?.IsMobile == true
+                && headquarters.TypeID == faction.Settings.Headquarters.FacilityTypeID
+                && origin != null
+                && faction.HQInstanceID == origin.InstanceID
+                && destination != origin
+                && destination.OwnerInstanceID == faction.InstanceID
+                && destination.CanAcceptChild(headquarters);
+        }
+
+        /// <summary>
+        /// Starts a validated headquarters relocation and clears its planetary marker in transit.
+        /// </summary>
+        /// <param name="headquarters">The headquarters building to move.</param>
+        /// <param name="destination">The requested destination planet.</param>
+        /// <returns>True when the movement order was accepted.</returns>
+        public bool TryRelocate(Building headquarters, Planet destination)
+        {
+            if (!CanRelocate(headquarters, destination))
+                return false;
+
+            Planet origin = headquarters.GetParentOfType<Planet>();
+            bool moved = _movement.TryRequestMove(
+                new List<ISceneNode> { headquarters },
+                destination,
+                headquarters.OwnerInstanceID
+            );
+            if (!moved || headquarters.Movement == null)
+                return false;
+
+            origin.IsHeadquarters = false;
+            Faction faction = _game.GetFactionByOwnerInstanceID(headquarters.OwnerInstanceID);
+            faction.HQInstanceID = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Assigns an arriving headquarters building to its destination planet.
+        /// </summary>
+        /// <param name="results">The unit arrivals produced by the movement system.</param>
+        /// <returns>No additional game results.</returns>
+        public List<GameResult> HandleResults(IReadOnlyList<UnitArrivedResult> results)
+        {
+            foreach (UnitArrivedResult result in results ?? Array.Empty<UnitArrivedResult>())
+            {
+                if (result?.Unit is not Building { BuildingType: BuildingType.Headquarters } hq)
+                    continue;
+
+                Faction faction = _game.GetFactionByOwnerInstanceID(hq.OwnerInstanceID);
+                Planet destination = result.Destination;
+                if (faction == null || destination == null)
+                    continue;
+
+                Planet previous = _game.GetSceneNodeByInstanceID<Planet>(faction.HQInstanceID);
+                if (previous != null)
+                    previous.IsHeadquarters = false;
+
+                destination.IsHeadquarters = true;
+                faction.HQInstanceID = destination.InstanceID;
+            }
+
+            return new List<GameResult>();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -882,7 +882,7 @@ namespace Rebellion.Systems
         /// </summary>
         /// <param name="unit">The unit to check.</param>
         /// <returns>True if the unit can receive the order.</returns>
-        private static bool CanReceiveMoveOrder(IMovable unit)
+        private bool CanReceiveMoveOrder(IMovable unit)
         {
             if (!IsUnderConstruction(unit) && unit.GetTransitMovement() != null)
             {
@@ -892,7 +892,10 @@ namespace Rebellion.Systems
                 return false;
             }
 
-            if (IsCompletedBuilding(unit))
+            if (
+                IsCompletedBuilding(unit)
+                && (unit is not Building building || !IsMobileHeadquarters(building))
+            )
             {
                 GameLogger.Warning(
                     $"RequestMove rejected: {unit.GetDisplayName()} is a completed building."
@@ -901,6 +904,17 @@ namespace Rebellion.Systems
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Returns whether a completed building is the owning faction's configured mobile HQ.
+        /// </summary>
+        private bool IsMobileHeadquarters(Building building)
+        {
+            Faction faction = _game.GetFactionByOwnerInstanceID(building?.OwnerInstanceID);
+            return building?.BuildingType == BuildingType.Headquarters
+                && faction?.Settings?.Headquarters?.IsMobile == true
+                && building.TypeID == faction.Settings.Headquarters.FacilityTypeID;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -27,11 +27,23 @@ namespace Rebellion.Systems
         private readonly BlockadeSystem _blockade;
         private readonly FleetSystem _fleetSystem;
         private readonly List<GameResult> _pendingResults = new List<GameResult>();
+        private Func<Building, bool> _completedBuildingMovementPolicy;
 
         /// <summary>
         /// Raised after an immediate movement command produces results.
         /// </summary>
         public event Action<IReadOnlyList<GameResult>> ResultsProduced;
+
+        /// <summary>
+        /// Registers the domain policy that may authorize movement for a completed building.
+        /// Completed buildings remain immobile when no policy is registered.
+        /// </summary>
+        /// <param name="policy">The completed-building movement policy.</param>
+        internal void SetCompletedBuildingMovementPolicy(Func<Building, bool> policy)
+        {
+            _completedBuildingMovementPolicy =
+                policy ?? throw new ArgumentNullException(nameof(policy));
+        }
 
         /// <summary>
         /// Initializes a new instance of the MovementSystem class.
@@ -894,7 +906,10 @@ namespace Rebellion.Systems
 
             if (
                 IsCompletedBuilding(unit)
-                && (unit is not Building building || !IsMobileHeadquarters(building))
+                && (
+                    unit is not Building building
+                    || _completedBuildingMovementPolicy?.Invoke(building) != true
+                )
             )
             {
                 GameLogger.Warning(
@@ -904,17 +919,6 @@ namespace Rebellion.Systems
             }
 
             return true;
-        }
-
-        /// <summary>
-        /// Returns whether a completed building is the owning faction's configured mobile HQ.
-        /// </summary>
-        private bool IsMobileHeadquarters(Building building)
-        {
-            Faction faction = _game.GetFactionByOwnerInstanceID(building?.OwnerInstanceID);
-            return building?.BuildingType == BuildingType.Headquarters
-                && faction?.Settings?.Headquarters?.IsMobile == true
-                && building.TypeID == faction.Settings.Headquarters.FacilityTypeID;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/PlanetaryAssaultSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryAssaultSystem.cs
@@ -410,7 +410,10 @@ namespace Rebellion.Systems
         {
             List<CollateralTarget> targets = planet
                 .GetAllBuildings()
-                .Where(IsActiveAssaultUnit)
+                .Where(building =>
+                    building.BuildingType != BuildingType.Headquarters
+                    && IsActiveAssaultUnit(building)
+                )
                 .Select(building =>
                 {
                     return new CollateralTarget

--- a/Assets/Scripts/Systems/PlayerAutomationSystem.cs
+++ b/Assets/Scripts/Systems/PlayerAutomationSystem.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rebellion.Game;
+using Rebellion.Game.Factions;
+using Rebellion.Game.Galaxy;
+using Rebellion.Game.Units;
+using Rebellion.Generation;
+
+namespace Rebellion.Systems
+{
+    /// <summary>
+    /// Performs the optional strategic chores delegated to the protocol advisor.
+    /// </summary>
+    public sealed class PlayerAutomationSystem
+    {
+        private readonly GameRoot _game;
+        private readonly GameDataCatalog _gameData;
+        private readonly ManufacturingSystem _manufacturing;
+
+        /// <summary>
+        /// Creates the player automation system.
+        /// </summary>
+        /// <param name="game">The active game.</param>
+        /// <param name="gameData">Templates available to the selected content pack.</param>
+        /// <param name="manufacturing">The manufacturing system used to place orders.</param>
+        public PlayerAutomationSystem(
+            GameRoot game,
+            GameDataCatalog gameData,
+            ManufacturingSystem manufacturing
+        )
+        {
+            _game = game ?? throw new ArgumentNullException(nameof(game));
+            _gameData = gameData ?? throw new ArgumentNullException(nameof(gameData));
+            _manufacturing =
+                manufacturing ?? throw new ArgumentNullException(nameof(manufacturing));
+        }
+
+        /// <summary>
+        /// Fills currently idle manufacturing capacity with the advisor's delegated work.
+        /// </summary>
+        public void ProcessTick()
+        {
+            foreach (Faction faction in _game.GetFactions())
+            {
+                if (faction.ManageGarrisons)
+                {
+                    while (QueueGarrisonRegiment(faction)) { }
+                }
+
+                if (faction.ManageProduction)
+                {
+                    while (QueueProductionFacility(faction)) { }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Queues one regiment for the faction's highest-priority garrison shortage.
+        /// </summary>
+        /// <param name="faction">The faction delegating garrison management.</param>
+        /// <returns>True when an order was queued.</returns>
+        private bool QueueGarrisonRegiment(Faction faction)
+        {
+            List<Planet> ownedPlanets = GetOwnedPlanets(faction);
+            Planet destination = ownedPlanets
+                .Select(planet => new
+                {
+                    Planet = planet,
+                    Deficit = GetGarrisonTarget(planet, faction)
+                        - CountFactionRegiments(planet, faction),
+                })
+                .Where(candidate => candidate.Deficit > 0)
+                .OrderByDescending(candidate => candidate.Planet.IsInUprising)
+                .ThenByDescending(candidate => candidate.Deficit)
+                .ThenByDescending(candidate => HasManufacturingFacilities(candidate.Planet))
+                .ThenBy(candidate => candidate.Planet.InstanceID, StringComparer.Ordinal)
+                .Select(candidate => candidate.Planet)
+                .FirstOrDefault();
+            if (destination == null)
+                return false;
+
+            Regiment template = GetAvailableRegiment(faction);
+            Planet producer = FindProducer(ownedPlanets, ManufacturingType.Troop);
+            return template != null
+                && producer != null
+                && _manufacturing.StartManufacturing(
+                    producer,
+                    template,
+                    destination,
+                    1,
+                    faction.InstanceID
+                );
+        }
+
+        /// <summary>
+        /// Queues the next mine or refinery needed to expand paired production.
+        /// </summary>
+        /// <param name="faction">The faction delegating production management.</param>
+        /// <returns>True when an order was queued.</returns>
+        private bool QueueProductionFacility(Faction faction)
+        {
+            List<Planet> ownedPlanets = GetOwnedPlanets(faction);
+            int mineCount = CountBuildings(ownedPlanets, BuildingType.Mine);
+            int refineryCount = CountBuildings(ownedPlanets, BuildingType.Refinery);
+            BuildingType nextType =
+                mineCount <= refineryCount ? BuildingType.Mine : BuildingType.Refinery;
+            if (
+                !TryFindResourceFacilityOrder(
+                    ownedPlanets,
+                    nextType,
+                    out Planet producer,
+                    out Planet destination
+                )
+            )
+                return false;
+
+            Building template = GetAvailableBuilding(faction, nextType);
+            return template != null
+                && _manufacturing.StartManufacturing(
+                    producer,
+                    template,
+                    destination,
+                    1,
+                    faction.InstanceID
+                );
+        }
+
+        /// <summary>
+        /// Returns the faction's colonized planets in stable order.
+        /// </summary>
+        /// <param name="faction">The faction whose planets are requested.</param>
+        /// <returns>The owned planets.</returns>
+        private List<Planet> GetOwnedPlanets(Faction faction)
+        {
+            return _game
+                .GetSceneNodesByType<Planet>()
+                .Where(planet =>
+                    planet.IsColonized
+                    && string.Equals(
+                        planet.GetOwnerInstanceID(),
+                        faction.InstanceID,
+                        StringComparison.Ordinal
+                    )
+                )
+                .OrderBy(planet => planet.InstanceID, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Calculates the advisor's desired garrison for one planet.
+        /// </summary>
+        /// <param name="planet">The planet to protect.</param>
+        /// <param name="faction">The controlling faction.</param>
+        /// <returns>The desired regiment count.</returns>
+        private int GetGarrisonTarget(Planet planet, Faction faction)
+        {
+            int required = UprisingSystem.CalculateGarrisonRequirement(
+                planet,
+                faction,
+                _game.Config.AI.Garrison
+            );
+            int manufacturingDefense = HasManufacturingFacilities(planet) ? 1 : 0;
+            return Math.Max(1, required) + manufacturingDefense;
+        }
+
+        /// <summary>
+        /// Counts stationary regiments owned by the controlling faction, including pending orders.
+        /// </summary>
+        /// <param name="planet">The planet to inspect.</param>
+        /// <param name="faction">The controlling faction.</param>
+        /// <returns>The regiment count.</returns>
+        private static int CountFactionRegiments(Planet planet, Faction faction)
+        {
+            return planet
+                .GetAllRegiments()
+                .Count(regiment =>
+                    string.Equals(
+                        regiment.GetOwnerInstanceID(),
+                        faction.InstanceID,
+                        StringComparison.Ordinal
+                    )
+                    && regiment.Movement == null
+                );
+        }
+
+        /// <summary>
+        /// Returns whether a planet contains strategically important manufacturing capacity.
+        /// </summary>
+        /// <param name="planet">The planet to inspect.</param>
+        /// <returns>True when a manufacturing facility is present.</returns>
+        private static bool HasManufacturingFacilities(Planet planet)
+        {
+            return planet.Buildings.Any(building =>
+                building.BuildingType
+                    is BuildingType.ConstructionFacility
+                        or BuildingType.Shipyard
+                        or BuildingType.TrainingFacility
+            );
+        }
+
+        /// <summary>
+        /// Selects an owned planet with free production capacity.
+        /// </summary>
+        /// <param name="planets">Candidate planets.</param>
+        /// <param name="manufacturingType">The required production type.</param>
+        /// <returns>The selected producer, or null.</returns>
+        private static Planet FindProducer(
+            IEnumerable<Planet> planets,
+            ManufacturingType manufacturingType
+        )
+        {
+            return planets
+                .Where(planet => planet.GetAvailableManufacturingCapacity(manufacturingType) > 0)
+                .OrderByDescending(planet =>
+                    planet.GetAvailableManufacturingCapacity(manufacturingType)
+                )
+                .ThenBy(planet => planet.InstanceID, StringComparer.Ordinal)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Selects the closest valid resource slot to any idle construction yard.
+        /// </summary>
+        /// <param name="planets">Candidate planets.</param>
+        /// <param name="buildingType">The resource facility being placed.</param>
+        /// <param name="producer">The selected construction-yard planet.</param>
+        /// <param name="destination">The selected resource-facility destination.</param>
+        /// <returns>True when a valid order was found.</returns>
+        private static bool TryFindResourceFacilityOrder(
+            IEnumerable<Planet> planets,
+            BuildingType buildingType,
+            out Planet producer,
+            out Planet destination
+        )
+        {
+            List<Planet> producers = planets
+                .Where(planet =>
+                    planet.GetAvailableManufacturingCapacity(ManufacturingType.Building) > 0
+                )
+                .ToList();
+            IEnumerable<Planet> destinations = planets.Where(planet =>
+                planet.GetAvailableEnergy() > 0
+            );
+            if (buildingType == BuildingType.Mine)
+                destinations = destinations.Where(planet =>
+                    planet.GetUnminedResourceNodeCount() > 0
+                );
+
+            var order = producers
+                .SelectMany(source =>
+                    destinations.Select(target => new
+                    {
+                        Producer = source,
+                        Destination = target,
+                        Distance = source.GetRawDistanceTo(target),
+                    })
+                )
+                .OrderBy(candidate => candidate.Distance)
+                .ThenBy(candidate => candidate.Producer.InstanceID, StringComparer.Ordinal)
+                .ThenBy(candidate => candidate.Destination.InstanceID, StringComparer.Ordinal)
+                .FirstOrDefault();
+            producer = order?.Producer;
+            destination = order?.Destination;
+            return producer != null && destination != null;
+        }
+
+        /// <summary>
+        /// Selects the scenario's configured standard garrison regiment.
+        /// </summary>
+        /// <param name="faction">The faction placing the order.</param>
+        /// <returns>The selected regiment template, or null.</returns>
+        private Regiment GetAvailableRegiment(Faction faction)
+        {
+            FactionSetup factionSetup =
+                _gameData.GenerationConfig.GalaxyClassification.FactionSetups.FirstOrDefault(
+                    setup =>
+                        string.Equals(setup.FactionID, faction.InstanceID, StringComparison.Ordinal)
+                );
+            if (string.IsNullOrEmpty(factionSetup?.GarrisonTroopTypeID))
+                return null;
+
+            int unlockedOrder = faction.GetHighestUnlockedOrder(ManufacturingType.Troop);
+            return _gameData.Regiments.FirstOrDefault(template =>
+                string.Equals(
+                    template.TypeID,
+                    factionSetup.GarrisonTroopTypeID,
+                    StringComparison.Ordinal
+                )
+                && template.HasAllowedOwnerInstanceID(faction.InstanceID)
+                && template.ResearchOrder <= unlockedOrder
+            );
+        }
+
+        /// <summary>
+        /// Selects the most advanced unlocked resource-facility template.
+        /// </summary>
+        /// <param name="faction">The faction placing the order.</param>
+        /// <param name="buildingType">The required resource-facility type.</param>
+        /// <returns>The selected building template, or null.</returns>
+        private Building GetAvailableBuilding(Faction faction, BuildingType buildingType)
+        {
+            int unlockedOrder = faction.GetHighestUnlockedOrder(ManufacturingType.Building);
+            return _gameData
+                .Buildings.Where(template =>
+                    template.BuildingType == buildingType
+                    && template.HasAllowedOwnerInstanceID(faction.InstanceID)
+                    && template.ResearchOrder <= unlockedOrder
+                )
+                .OrderByDescending(template => template.ResearchOrder)
+                .ThenBy(template => template.TypeID, StringComparer.Ordinal)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Counts existing and queued resource facilities across the supplied planets.
+        /// </summary>
+        /// <param name="planets">Planets to inspect.</param>
+        /// <param name="buildingType">The facility type to count.</param>
+        /// <returns>The total facility count.</returns>
+        private static int CountBuildings(IEnumerable<Planet> planets, BuildingType buildingType)
+        {
+            return planets.Sum(planet =>
+                planet.Buildings.Count(building => building.BuildingType == buildingType)
+            );
+        }
+    }
+}

--- a/Assets/Scripts/Systems/VictorySystem.cs
+++ b/Assets/Scripts/Systems/VictorySystem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Rebellion.Game;
@@ -12,7 +13,7 @@ namespace Rebellion.Systems
     /// <summary>
     /// Manages victory condition checking during each game tick.
     /// </summary>
-    public class VictorySystem
+    public class VictorySystem : IGameResultHandler<HeadquartersDestroyedResult>
     {
         private readonly GameRoot _game;
 
@@ -44,6 +45,21 @@ namespace Rebellion.Systems
             }
 
             return new List<GameResult>();
+        }
+
+        /// <summary>
+        /// Applies the configured victory condition after a mobile headquarters is destroyed.
+        /// </summary>
+        /// <param name="results">The headquarters destruction results.</param>
+        /// <returns>Any victories caused by the headquarters losses.</returns>
+        public List<GameResult> HandleResults(IReadOnlyList<HeadquartersDestroyedResult> results)
+        {
+            return (results ?? Array.Empty<HeadquartersDestroyedResult>())
+                .Where(result => result?.Attacker != null && result.Defender != null)
+                .Select(result => BuildHQVictory(result.Attacker, result.Defender))
+                .Where(result => result != null)
+                .Cast<GameResult>()
+                .ToList();
         }
 
         /// <summary>
@@ -79,29 +95,37 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Checks ownership or destruction of a faction's mobile headquarters building.
+        /// Checks ownership of a faction's mobile headquarters building.
         /// </summary>
+        /// <param name="defender">The faction whose mobile headquarters is checked.</param>
+        /// <returns>A victory when an opposing faction owns the headquarters; otherwise null.</returns>
         private VictoryResult CheckMobileHQCapture(Faction defender)
         {
             Building headquarters = _game
                 .GetSceneNodesByType<Building>()
-                .FirstOrDefault(building =>
-                    building.TypeID == defender.Settings.Headquarters.FacilityTypeID
+                .SingleOrDefault(building =>
+                    building.BuildingType == BuildingType.Headquarters
+                    && building.TypeID == defender.Settings.Headquarters.FacilityTypeID
                 );
-            if (headquarters?.OwnerInstanceID == defender.InstanceID)
+            if (
+                headquarters == null
+                || string.IsNullOrEmpty(headquarters.OwnerInstanceID)
+                || headquarters.OwnerInstanceID == defender.InstanceID
+            )
                 return null;
 
-            string attackerId = headquarters?.OwnerInstanceID;
             Faction attacker = _game.Factions.FirstOrDefault(faction =>
-                faction.InstanceID == attackerId
+                faction.InstanceID == headquarters.OwnerInstanceID
             );
-            attacker ??= _game.Factions.FirstOrDefault(faction => faction != defender);
             return attacker == null ? null : BuildHQVictory(attacker, defender);
         }
 
         /// <summary>
         /// Builds an HQ victory after applying the selected victory-mode requirements.
         /// </summary>
+        /// <param name="attacker">The faction that defeated the headquarters owner.</param>
+        /// <param name="defender">The faction that lost its headquarters.</param>
+        /// <returns>A victory when all mode requirements are met; otherwise null.</returns>
         private VictoryResult BuildHQVictory(Faction attacker, Faction defender)
         {
             GameVictoryCondition victoryMode = _game.Summary.VictoryCondition;

--- a/Assets/Scripts/Systems/VictorySystem.cs
+++ b/Assets/Scripts/Systems/VictorySystem.cs
@@ -101,11 +101,13 @@ namespace Rebellion.Systems
         /// <returns>A victory when an opposing faction owns the headquarters; otherwise null.</returns>
         private VictoryResult CheckMobileHQCapture(Faction defender)
         {
-            Building headquarters = _game
-                .GetSceneNodesByType<Building>()
-                .SingleOrDefault(building =>
-                    building.BuildingType == BuildingType.Headquarters
-                    && building.TypeID == defender.Settings.Headquarters.FacilityTypeID
+            Planet headquartersPlanet = _game.GetSceneNodeByInstanceID<Planet>(
+                defender.HQInstanceID
+            );
+            Building headquarters = headquartersPlanet
+                ?.GetChildren<Building>(_ => true, recurse: false)
+                .FirstOrDefault(building =>
+                    building.BuildingType == BuildingType.Headquarters && building.Movement == null
                 );
             if (
                 headquarters == null

--- a/Assets/Scripts/Systems/VictorySystem.cs
+++ b/Assets/Scripts/Systems/VictorySystem.cs
@@ -53,6 +53,9 @@ namespace Rebellion.Systems
         /// <returns>A victory result if the HQ was captured, or null.</returns>
         private VictoryResult CheckHQCapture(Faction defender)
         {
+            if (defender.Settings?.Headquarters?.IsMobile == true)
+                return CheckMobileHQCapture(defender);
+
             string hqInstanceId = defender.GetHQInstanceID();
             if (string.IsNullOrEmpty(hqInstanceId))
                 return null;
@@ -72,15 +75,41 @@ namespace Rebellion.Systems
             if (attacker == null)
                 return null;
 
-            GameVictoryCondition victoryMode = _game.Summary.VictoryCondition;
+            return BuildHQVictory(attacker, defender);
+        }
 
-            if (victoryMode == GameVictoryCondition.Conquest)
-            {
-                if (!CheckAllMainCharactersCaptured(defender))
-                {
-                    return null;
-                }
-            }
+        /// <summary>
+        /// Checks ownership or destruction of a faction's mobile headquarters building.
+        /// </summary>
+        private VictoryResult CheckMobileHQCapture(Faction defender)
+        {
+            Building headquarters = _game
+                .GetSceneNodesByType<Building>()
+                .FirstOrDefault(building =>
+                    building.TypeID == defender.Settings.Headquarters.FacilityTypeID
+                );
+            if (headquarters?.OwnerInstanceID == defender.InstanceID)
+                return null;
+
+            string attackerId = headquarters?.OwnerInstanceID;
+            Faction attacker = _game.Factions.FirstOrDefault(faction =>
+                faction.InstanceID == attackerId
+            );
+            attacker ??= _game.Factions.FirstOrDefault(faction => faction != defender);
+            return attacker == null ? null : BuildHQVictory(attacker, defender);
+        }
+
+        /// <summary>
+        /// Builds an HQ victory after applying the selected victory-mode requirements.
+        /// </summary>
+        private VictoryResult BuildHQVictory(Faction attacker, Faction defender)
+        {
+            GameVictoryCondition victoryMode = _game.Summary.VictoryCondition;
+            if (
+                victoryMode == GameVictoryCondition.Conquest
+                && !CheckAllMainCharactersCaptured(defender)
+            )
+                return null;
 
             return new VictoryResult
             {

--- a/Assets/Scripts/UI/Components/ContextMenu/ContextMenuCommandView.cs
+++ b/Assets/Scripts/UI/Components/ContextMenu/ContextMenuCommandView.cs
@@ -256,7 +256,7 @@ public sealed class ContextMenuCommandView
     private RectInt GetIconRect(Texture texture, bool centerNativeIcon)
     {
         if (!centerNativeIcon || texture == null)
-            return iconTemplateRect;
+            return CenterVertically(iconTemplateRect.width, iconTemplateRect.height, 4);
 
         Vector2Int size = UILayout.GetTextureSourceSize(texture);
         if (size.x <= 0 || size.y <= 0)
@@ -265,11 +265,23 @@ public sealed class ContextMenuCommandView
         if (size.y >= rootTemplateRect.height)
             return new RectInt(textTemplateRect.x, 0, size.x, size.y);
 
+        return CenterVertically(size.x, size.y, 0);
+    }
+
+    /// <summary>
+    /// Centers an authored icon size within the command row.
+    /// </summary>
+    /// <param name="width">The icon width.</param>
+    /// <param name="height">The icon height.</param>
+    /// <param name="verticalOffset">The authored vertical adjustment.</param>
+    /// <returns>The centered icon rectangle.</returns>
+    private RectInt CenterVertically(int width, int height, int verticalOffset)
+    {
         return new RectInt(
             iconTemplateRect.x,
-            iconTemplateRect.y + Mathf.Max(0, (rootTemplateRect.height - size.y) / 2),
-            size.x,
-            size.y
+            Mathf.Max(0, (rootTemplateRect.height - height) / 2 + verticalOffset),
+            width,
+            height
         );
     }
 }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Advisor/AdvisorReportBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Advisor/AdvisorReportBuilder.cs
@@ -253,6 +253,15 @@ public static class AdvisorReportBuilder
             .FirstOrDefault(item =>
                 string.Equals(item.InstanceID, factionInstanceId, StringComparison.Ordinal)
             );
+        if (faction?.Settings?.Headquarters?.IsMobile == true)
+        {
+            return game.GetSceneNodesByType<Building>()
+                .Any(building =>
+                    building.TypeID == faction.Settings.Headquarters.FacilityTypeID
+                    && building.OwnerInstanceID == faction.InstanceID
+                );
+        }
+
         return faction != null
             && IsPlanetOwnedByFaction(game, faction.HQInstanceID, faction.InstanceID);
     }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
@@ -106,6 +106,8 @@ public enum StrategyMenuAction
     AdvisorBuildFacilities,
     AdvisorGalaxyOverview,
     AdvisorObjectives,
+    AdvisorManageGarrisons,
+    AdvisorManageProduction,
     AdvisorTranslateCounterpart,
     AdvisorAgentAdvice,
     AdvisorMessages,

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Finder/FinderWindowRowBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Finder/FinderWindowRowBuilder.cs
@@ -184,7 +184,7 @@ public sealed class FinderWindowRowBuilder
     }
 
     /// <summary>
-    /// Projects officers and special forces across missions, fleets, and planets.
+    /// Projects officers across missions, fleets, and planets.
     /// </summary>
     /// <param name="tab">The active faction tab.</param>
     /// <returns>Alphabetically ordered personnel rows.</returns>
@@ -205,7 +205,7 @@ public sealed class FinderWindowRowBuilder
                     seen,
                     planet,
                     PlanetIcon.Mission,
-                    mission.MainParticipants.OfType<ISceneNode>(),
+                    mission.MainParticipants.OfType<Officer>(),
                     mission: mission
                 );
                 AddPersonnelRows(
@@ -213,7 +213,7 @@ public sealed class FinderWindowRowBuilder
                     seen,
                     planet,
                     PlanetIcon.Mission,
-                    mission.DecoyParticipants.OfType<ISceneNode>(),
+                    mission.DecoyParticipants.OfType<Officer>(),
                     mission: mission
                 );
             }
@@ -228,18 +228,9 @@ public sealed class FinderWindowRowBuilder
                     fleet.GetOfficers(),
                     fleet: fleet
                 );
-                AddPersonnelRows(
-                    rows,
-                    seen,
-                    planet,
-                    PlanetIcon.Fleet,
-                    fleet.GetSpecialForces(),
-                    fleet: fleet
-                );
             }
 
             AddPersonnelRows(rows, seen, planet, PlanetIcon.Defense, planet.Planet.Officers);
-            AddPersonnelRows(rows, seen, planet, PlanetIcon.Defense, planet.Planet.SpecialForces);
         }
 
         return rows.Where(row =>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -259,6 +259,18 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
                 faction != null
             ),
             CreateToggleCommand(
+                StrategyMenuAction.AdvisorManageGarrisons,
+                "Manage Garrisons",
+                faction != null,
+                faction?.ManageGarrisons == true
+            ),
+            CreateToggleCommand(
+                StrategyMenuAction.AdvisorManageProduction,
+                "Manage Production",
+                faction != null,
+                faction?.ManageProduction == true
+            ),
+            CreateToggleCommand(
                 StrategyMenuAction.AdvisorTranslateCounterpart,
                 "Translate Counterpart",
                 faction != null,
@@ -403,6 +415,12 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
 
         switch (menuCommand.Action)
         {
+            case StrategyMenuAction.AdvisorManageGarrisons:
+                faction.ManageGarrisons = !faction.ManageGarrisons;
+                break;
+            case StrategyMenuAction.AdvisorManageProduction:
+                faction.ManageProduction = !faction.ManageProduction;
+                break;
             case StrategyMenuAction.AdvisorTranslateCounterpart:
                 faction.TranslateCounterpart = !faction.TranslateCounterpart;
                 break;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Messages/MessagesDetailPanelView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Messages/MessagesDetailPanelView.cs
@@ -218,7 +218,7 @@ public sealed class MessagesDetailPanelView : MonoBehaviour, IContentInitializab
     }
 
     /// <summary>
-    /// Calculates the displayed detail-art rectangle within an authored width.
+    /// Calculates the displayed detail-art rectangle within its authored width.
     /// </summary>
     /// <param name="texture">The displayed artwork.</param>
     /// <param name="template">The authored artwork rectangle.</param>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowContextMenuBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowContextMenuBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 
 /// <summary>
@@ -12,6 +13,7 @@ internal static class PlanetSystemWindowContextMenuBuilder
     /// <param name="hit">The active semantic planet hit.</param>
     /// <param name="fleetItems">The player-controlled fleet items at the hit planet.</param>
     /// <param name="playerFactionId">The player faction identifier.</param>
+    /// <param name="mobileHeadquarters">The mobile headquarters selected at the hit planet.</param>
     /// <param name="canBombard">Whether the fleets can bombard the hit planet.</param>
     /// <param name="canDestroySystem">Whether the fleets can destroy the hit planet.</param>
     /// <param name="canAssault">Whether the fleets can assault the hit planet.</param>
@@ -20,6 +22,7 @@ internal static class PlanetSystemWindowContextMenuBuilder
         PlanetSystemWindowHit hit,
         List<ISceneNode> fleetItems,
         string playerFactionId,
+        Building mobileHeadquarters = null,
         bool canBombard = false,
         bool canDestroySystem = false,
         bool canAssault = false
@@ -27,6 +30,16 @@ internal static class PlanetSystemWindowContextMenuBuilder
     {
         if (hit?.GalaxyMapPlanet == null)
             return CreatePlanetInformationCommands(false);
+        if (mobileHeadquarters != null)
+        {
+            return new List<StrategyMenuCommand>
+            {
+                new StrategyMenuCommand(StrategyMenuAction.Move, "Move", true),
+                new StrategyMenuCommand(StrategyMenuAction.MoveConfirm, "Confirmed Move", true),
+                new StrategyMenuCommand(StrategyMenuAction.Encyclopedia, "Encyclopedia", true),
+                new StrategyMenuCommand(StrategyMenuAction.Status, "Status", true),
+            };
+        }
         if (hit.PlanetImage || hit.Icon == PlanetIcon.None)
             return CreatePlanetInformationCommands(true);
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowController.cs
@@ -419,11 +419,16 @@ public sealed class PlanetSystemWindowController
         PlanetSystemWindowSession session = GetSession(view);
         CaptureContextTarget(view, session, context.EventData);
         PlanetSystemWindowHit hit = session.GetContextHit();
-        List<ISceneNode> items = GetPlayerFleetItems(hit?.Planet);
+        Building mobileHeadquarters = GetMobileHeadquarters(hit);
+        List<ISceneNode> items =
+            mobileHeadquarters != null
+                ? new List<ISceneNode> { mobileHeadquarters }
+                : GetPlayerFleetItems(hit?.Planet);
         List<StrategyMenuCommand> commands = PlanetSystemWindowContextMenuBuilder.Create(
             hit,
             items,
             GetUIContext().GetPlayerFactionInstanceID(),
+            mobileHeadquarters,
             fleetCommandController.CanExecutePlanetaryCombat(
                 items,
                 hit?.Planet,
@@ -448,7 +453,9 @@ public sealed class PlanetSystemWindowController
             context.X,
             context.Y,
             items,
-            GetStatusTarget(view)
+            mobileHeadquarters == null
+                ? GetStatusTarget(view)
+                : new StrategyStatusTarget(hit.GalaxyMapPlanet, mobileHeadquarters)
         );
         request = new ContextMenuRequest(
             source,
@@ -457,6 +464,32 @@ public sealed class PlanetSystemWindowController
         );
         width = context.Layout.PlanetSystemMenuWidth;
         return true;
+    }
+
+    /// <summary>
+    /// Resolves the player's stationary mobile-HQ building for an HQ-planet hit.
+    /// </summary>
+    private Building GetMobileHeadquarters(PlanetSystemWindowHit hit)
+    {
+        if (hit?.PlanetImage != true || hit.Planet?.IsHeadquarters != true)
+            return null;
+
+        string playerFactionId = GetUIContext().GetPlayerFactionInstanceID();
+        if (
+            GetUIContext()
+                .Game.GetFactionByOwnerInstanceID(playerFactionId)
+                ?.Settings?.Headquarters?.IsMobile != true
+        )
+            return null;
+
+        return hit
+            .Planet.GetChildren<Building>(
+                building =>
+                    building.BuildingType == BuildingType.Headquarters
+                    && building.OwnerInstanceID == playerFactionId,
+                recurse: false
+            )
+            .SingleOrDefault();
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
@@ -469,14 +470,17 @@ public sealed class PlanetSystemWindowController
     /// <summary>
     /// Resolves the player's stationary mobile-HQ building for an HQ-planet hit.
     /// </summary>
+    /// <param name="hit">The planet-system hit being inspected.</param>
+    /// <returns>The player's stationary mobile headquarters, or null when unavailable.</returns>
     private Building GetMobileHeadquarters(PlanetSystemWindowHit hit)
     {
         if (hit?.PlanetImage != true || hit.Planet?.IsHeadquarters != true)
             return null;
 
-        string playerFactionId = GetUIContext().GetPlayerFactionInstanceID();
+        UIContext context = GetUIContext();
+        string playerFactionId = context.GetPlayerFactionInstanceID();
         if (
-            GetUIContext()
+            context
                 .Game.GetFactionByOwnerInstanceID(playerFactionId)
                 ?.Settings?.Headquarters?.IsMobile != true
         )
@@ -486,7 +490,8 @@ public sealed class PlanetSystemWindowController
             .Planet.GetChildren<Building>(
                 building =>
                     building.BuildingType == BuildingType.Headquarters
-                    && building.OwnerInstanceID == playerFactionId,
+                    && building.OwnerInstanceID == playerFactionId
+                    && building.Movement == null,
                 recurse: false
             )
             .SingleOrDefault();

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -418,7 +418,8 @@ public sealed class StrategyController
             PlaySfx,
             ClearWindowSelection,
             RebuildSnapshot,
-            MarkDirty
+            MarkDirty,
+            () => gameManager.HeadquartersSystem
         );
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandController.cs
@@ -17,6 +17,7 @@ public sealed class StrategyWindowCommandController
     private readonly ConfirmDialogWindowController confirmDialogWindowController;
     private readonly Func<GameRoot> getGame;
     private readonly Func<MovementSystem> getMovementSystem;
+    private readonly Func<HeadquartersSystem> getHeadquartersSystem;
     private readonly Func<MaintenanceSystem> getMaintenanceSystem;
     private readonly Func<ManufacturingSystem> getManufacturingSystem;
     private readonly Func<PersonnelSystem> getPersonnelSystem;
@@ -39,6 +40,7 @@ public sealed class StrategyWindowCommandController
     /// <param name="clearWindowSelection">Clears selection owned by a source window.</param>
     /// <param name="rebuildSnapshot">Rebuilds the visible strategy snapshot.</param>
     /// <param name="markDirty">Invalidates the strategy presentation.</param>
+    /// <param name="getHeadquartersSystem">Returns the mobile-headquarters system.</param>
     public StrategyWindowCommandController(
         MissionCreateWindowController missionCreateWindowController,
         ConfirmDialogWindowController confirmDialogWindowController,
@@ -50,7 +52,8 @@ public sealed class StrategyWindowCommandController
         Action<string> playSfx,
         Action<UIWindow> clearWindowSelection,
         Action rebuildSnapshot,
-        Action markDirty
+        Action markDirty,
+        Func<HeadquartersSystem> getHeadquartersSystem = null
     )
     {
         this.missionCreateWindowController =
@@ -62,6 +65,7 @@ public sealed class StrategyWindowCommandController
         this.getGame = getGame ?? throw new ArgumentNullException(nameof(getGame));
         this.getMovementSystem =
             getMovementSystem ?? throw new ArgumentNullException(nameof(getMovementSystem));
+        this.getHeadquartersSystem = getHeadquartersSystem;
         this.getMaintenanceSystem =
             getMaintenanceSystem ?? throw new ArgumentNullException(nameof(getMaintenanceSystem));
         this.getManufacturingSystem =
@@ -274,13 +278,17 @@ public sealed class StrategyWindowCommandController
     /// <returns>True when the movement order was accepted.</returns>
     private bool TryMove(StrategyMissionTarget target, IReadOnlyList<ISceneNode> items)
     {
+        Building headquarters = items?.Count == 1 ? items[0] as Building : null;
         bool moved =
-            getMovementSystem()
-                ?.TryRequestMove(
-                    items,
-                    target?.GetMoveDestination() as ContainerNode,
-                    GetPlayerFactionID()
-                ) == true;
+            headquarters?.BuildingType == BuildingType.Headquarters
+                ? getHeadquartersSystem?.Invoke()?.TryRelocate(headquarters, target?.Planet?.Planet)
+                    == true
+                : getMovementSystem()
+                    ?.TryRequestMove(
+                        items,
+                        target?.GetMoveDestination() as ContainerNode,
+                        GetPlayerFactionID()
+                    ) == true;
         if (moved)
             PlayMoveVoice(items);
 

--- a/Assets/Tests/EditMode/Content/ContentAssetsTests.cs
+++ b/Assets/Tests/EditMode/Content/ContentAssetsTests.cs
@@ -39,6 +39,22 @@ namespace Rebellion.Tests.Content
         }
 
         [Test]
+        public void GetReadableTexture_ApplicationCursor_RemainsReadableAndCached()
+        {
+            ContentPack pack = ContentPackLoader.OpenActive();
+            using ContentAssets assets = CreateAssets(pack);
+            const string address = "Application/Common/UI/ui_common_cursor_default";
+
+            Texture2D first = assets.GetReadableTexture(address);
+            Texture2D second = assets.GetReadableTexture(address);
+
+            Assert.IsNotNull(first);
+            Assert.IsTrue(first.isReadable);
+            Assert.AreSame(first, second);
+            Assert.AreNotSame(first, assets.GetTexture(address));
+        }
+
+        [Test]
         public async System.Threading.Tasks.Task PreloadAsync_TextureDirectory_CachesExtensionlessAddressAsync()
         {
             ContentPack pack = ContentPackLoader.OpenActive();

--- a/Assets/Tests/EditMode/Content/ContentAssetsTests.cs
+++ b/Assets/Tests/EditMode/Content/ContentAssetsTests.cs
@@ -43,7 +43,7 @@ namespace Rebellion.Tests.Content
         {
             ContentPack pack = ContentPackLoader.OpenActive();
             using ContentAssets assets = CreateAssets(pack);
-            const string address = "Application/Common/UI/ui_common_cursor_default";
+            const string address = "Application/Common/UI/ui_common_cursor_default_outlined";
 
             Texture2D first = assets.GetReadableTexture(address);
             Texture2D second = assets.GetReadableTexture(address);

--- a/Assets/Tests/EditMode/Content/ContentModelCacheTests.cs
+++ b/Assets/Tests/EditMode/Content/ContentModelCacheTests.cs
@@ -8,7 +8,7 @@ public sealed class ContentModelCacheTests
     private const string _planetAddress = "Application/MainMenu/Models/planet";
 
     [Test]
-    public async Task InstantiateAsync_PreloadedModel_CreatesIndependentInstances()
+    public async Task InstantiateAsync_PreloadedModel_CreatesIndependentInstancesAsync()
     {
         ContentPack pack = ContentPackLoader.OpenActive();
         using ContentAssets assets = new ContentAssets(pack.ContentRootPath, pack.PackRootPath);

--- a/Assets/Tests/EditMode/Content/ContentModelLoaderTests.cs
+++ b/Assets/Tests/EditMode/Content/ContentModelLoaderTests.cs
@@ -8,7 +8,7 @@ public sealed class ContentModelLoaderTests
     private const string _planetAddress = "Application/MainMenu/Models/planet";
 
     [Test]
-    public async Task LoadAsync_ValidGlb_ReturnsDisposableModel()
+    public async Task LoadAsync_ValidGlb_ReturnsDisposableModelAsync()
     {
         ContentPack pack = ContentPackLoader.OpenActive();
         using ContentAssets assets = new ContentAssets(pack.ContentRootPath, pack.PackRootPath);

--- a/Assets/Tests/EditMode/Game/Encyclopedia/EncyclopediaCatalogBuilderTests.cs
+++ b/Assets/Tests/EditMode/Game/Encyclopedia/EncyclopediaCatalogBuilderTests.cs
@@ -50,7 +50,7 @@ namespace Rebellion.Tests.Game.Encyclopedia
         }
 
         [Test]
-        public void Build_WithEntityWithoutEncyclopediaImage_DoesNotUseDisplayImage()
+        public void Build_WithEntityWithoutEncyclopediaData_OmitsEntry()
         {
             Building building = new Building
             {
@@ -67,11 +67,7 @@ namespace Rebellion.Tests.Game.Encyclopedia
 
             EncyclopediaEntry entry = catalog.FindEntry("BUILDING1", null);
 
-            Assert.IsNotNull(entry);
-            Assert.AreEqual("Construction Yard", entry.DisplayName);
-            Assert.AreEqual(EncyclopediaEntryCategory.Facility, entry.Category);
-            Assert.IsNull(entry.ImagePath);
-            Assert.AreEqual("Static building description.", entry.Description);
+            Assert.IsNull(entry);
         }
 
         [Test]
@@ -100,8 +96,8 @@ namespace Rebellion.Tests.Game.Encyclopedia
             EncyclopediaEntry entry = catalog.FindEntry("BUILDING1", null);
 
             Assert.IsNotNull(entry);
-            Assert.AreEqual("Construction Yard", entry.DisplayName);
-            Assert.AreEqual(EncyclopediaEntryCategory.Facility, entry.Category);
+            Assert.AreEqual("Authored Facility", entry.DisplayName);
+            Assert.AreEqual(EncyclopediaEntryCategory.Concept, entry.Category);
         }
 
         [Test]
@@ -194,6 +190,7 @@ namespace Rebellion.Tests.Game.Encyclopedia
                 TypeID = "FIGHTER1",
                 DisplayName = "A-Wing Squadron",
                 AllowedOwnerInstanceIDs = new List<string> { "FNALL1" },
+                EncyclopediaImagePath = "Pack/Starfighters/a-wing/encyclopedia",
             };
 
             EncyclopediaCatalog catalog = BuildCatalog(
@@ -215,13 +212,19 @@ namespace Rebellion.Tests.Game.Encyclopedia
                 Planets = new List<Planet>
                 {
                     null,
-                    new Planet { TypeID = "PLANET1", DisplayName = "Balmorra" },
+                    new Planet
+                    {
+                        TypeID = "PLANET1",
+                        DisplayName = "Balmorra",
+                        EncyclopediaImagePath = "Pack/Systems/Balmorra/encyclopedia",
+                    },
                 },
             };
             Building building = new Building
             {
                 TypeID = "BUILDING1",
                 DisplayName = "Construction Yard",
+                EncyclopediaImagePath = "Pack/Facilities/construction-yard/encyclopedia",
             };
 
             EncyclopediaCatalog catalog = BuildCatalog(

--- a/Assets/Tests/EditMode/Game/Factions/FactionTests.cs
+++ b/Assets/Tests/EditMode/Game/Factions/FactionTests.cs
@@ -610,6 +610,8 @@ namespace Rebellion.Tests.Game.Factions
             _faction.ToggleAdvisorMessageNotification(MessageType.Fleet);
             _faction.TranslateCounterpart = false;
             _faction.AgentAdvice = false;
+            _faction.ManageGarrisons = true;
+            _faction.ManageProduction = true;
             _faction.RawMaterialStockpile = 17;
             _faction.RefinedMaterialStockpile = 23;
             _faction.PendingRawMaterialFacilityIDs.AddRange(new[] { "REFINERY1", "REFINERY2" });
@@ -645,6 +647,8 @@ namespace Rebellion.Tests.Game.Factions
             Assert.IsTrue(deserialized.IsAdvisorMessageNotificationEnabled(MessageType.Mission));
             Assert.IsFalse(deserialized.TranslateCounterpart);
             Assert.IsFalse(deserialized.AgentAdvice);
+            Assert.IsTrue(deserialized.ManageGarrisons);
+            Assert.IsTrue(deserialized.ManageProduction);
             Assert.AreEqual(_faction.RawMaterialStockpile, deserialized.RawMaterialStockpile);
             Assert.AreEqual(
                 _faction.RefinedMaterialStockpile,

--- a/Assets/Tests/EditMode/Game/GameConfigTests.cs
+++ b/Assets/Tests/EditMode/Game/GameConfigTests.cs
@@ -24,6 +24,7 @@ namespace Rebellion.Tests.Game
             Assert.IsNotNull(config.Victory, "VictoryConfig should not be null");
             Assert.IsNotNull(config.GameSpeed, "GameSpeedConfig should not be null");
             Assert.IsNotNull(config.Messages, "MessageConfig should not be null");
+            Assert.IsNotNull(config.Espionage, "EspionageConfig should not be null");
             Assert.IsNotNull(
                 config.ProbabilityTables,
                 "ProbabilityTablesConfig should not be null"
@@ -71,6 +72,14 @@ namespace Rebellion.Tests.Game
             Assert.AreEqual(60f, config.GameSpeed.SlowTickIntervalSeconds);
             Assert.AreEqual(120f, config.GameSpeed.VerySlowTickIntervalSeconds);
             Assert.AreEqual(300, config.Messages.RetentionTicks);
+            Assert.AreEqual("CORUSCANT", config.Espionage.CapitalPlanetInstanceID);
+            Assert.AreEqual("FNALL1", config.Espionage.CapitalObserverFactionInstanceID);
+            Assert.AreEqual(1, config.Espionage.CoreSystemBonus.Base);
+            Assert.AreEqual(0, config.Espionage.CoreSystemBonus.Spread);
+            Assert.AreEqual(1, config.Espionage.CapitalBonus.Base);
+            Assert.AreEqual(5, config.Espionage.CapitalBonus.Spread);
+            Assert.AreEqual(1, config.Espionage.MobileHeadquartersBonus.Base);
+            Assert.AreEqual(5, config.Espionage.MobileHeadquartersBonus.Spread);
             Assert.AreEqual(50, config.ProbabilityTables.Mission.DefaultKillOrCaptureProbability);
             Assert.AreEqual(1, config.SupportShift.DiplomacyCompletionSupportBonus);
             Assert.AreEqual(1, config.SupportShift.DiplomacyOwnedPlanetSupportBase);

--- a/Assets/Tests/EditMode/Game/Messages/MessageFactoryTests.cs
+++ b/Assets/Tests/EditMode/Game/Messages/MessageFactoryTests.cs
@@ -1608,7 +1608,7 @@ namespace Rebellion.Tests.Game.Messages
         }
 
         [Test]
-        public void CreateMessages_OfficerCapture_UsesTargetOfficerImage()
+        public void CreateMessages_OfficerCapture_DoesNotOverlayTargetOfficerImage()
         {
             (GameRoot game, Faction alliance, Planet origin, _) = BuildMessageScene();
             Officer target = new Officer
@@ -1652,7 +1652,7 @@ namespace Rebellion.Tests.Game.Messages
 
             Assert.AreEqual("captured:Target:Coruscant", message.Title);
             Assert.AreEqual("fallback-card", message.DisplayImagePath);
-            Assert.AreEqual("target-card", message.OverlayImagePath);
+            Assert.IsNull(message.OverlayImagePath);
         }
 
         [Test]
@@ -1705,8 +1705,8 @@ namespace Rebellion.Tests.Game.Messages
             Assert.AreEqual("captor:Target:Coruscant", captorMessage.Body);
             Assert.AreEqual("alliance-image", ownerMessage.DisplayImagePath);
             Assert.AreEqual("empire-image", captorMessage.DisplayImagePath);
-            Assert.AreEqual("target-card", ownerMessage.OverlayImagePath);
-            Assert.AreEqual("target-card", captorMessage.OverlayImagePath);
+            Assert.IsNull(ownerMessage.OverlayImagePath);
+            Assert.IsNull(captorMessage.OverlayImagePath);
             Assert.AreEqual(
                 AdvisorSubjectNotification.Captured,
                 captorMessage.AdvisorSubjectNotification

--- a/Assets/Tests/EditMode/Game/Messages/MessageFactoryTests.cs
+++ b/Assets/Tests/EditMode/Game/Messages/MessageFactoryTests.cs
@@ -1587,7 +1587,8 @@ namespace Rebellion.Tests.Game.Messages
                             MessageType.Mission,
                             "recruited:{officer}:{system}",
                             "body:{officer}:{system}",
-                            DefaultImage("fallback-card")
+                            DefaultImage("fallback-card"),
+                            showOfficerOverlay: true
                         ),
                     },
                     new OfficerRecruitedResult
@@ -1737,7 +1738,8 @@ namespace Rebellion.Tests.Game.Messages
                             MessageType.Mission,
                             "recovered:{officer}:{system}",
                             "body:{officer}:{system}",
-                            DefaultImage("fallback-card")
+                            DefaultImage("fallback-card"),
+                            showOfficerOverlay: true
                         ),
                     },
                     new OfficerInjuredResult { Officer = officer, Severity = 0 }
@@ -2754,7 +2756,8 @@ namespace Rebellion.Tests.Game.Messages
             string imageKey = null,
             string voicePath = null,
             Dictionary<string, string> imagePaths = null,
-            Dictionary<string, string> voicePaths = null
+            Dictionary<string, string> voicePaths = null,
+            bool showOfficerOverlay = false
         )
         {
             MessageDefinition definition = new MessageDefinition
@@ -2769,6 +2772,7 @@ namespace Rebellion.Tests.Game.Messages
                 ManufacturingType = manufacturingType,
                 TitleTemplate = titleTemplate,
                 BodyTemplate = bodyTemplate,
+                ShowOfficerOverlay = showOfficerOverlay,
                 ImageKey = imageKey,
                 ImagePath = imagePath,
                 ImagePaths = imagePaths ?? new Dictionary<string, string>(),

--- a/Assets/Tests/EditMode/Game/Missions/EspionageMissionTests.cs
+++ b/Assets/Tests/EditMode/Game/Missions/EspionageMissionTests.cs
@@ -233,7 +233,6 @@ namespace Rebellion.Tests.Game.Missions
             Faction rebels = game.GetFactionByOwnerInstanceID("rebels");
             rebels.HQInstanceID = enemyPlanet.InstanceID;
             rebels.Settings.Headquarters.IsMobile = true;
-            game.Config.Espionage.MobileHeadquartersFactionInstanceID = rebels.InstanceID;
             game.Config.Espionage.MobileHeadquartersBonus = new GameConfig.RandomCountConfig
             {
                 Base = 10,

--- a/Assets/Tests/EditMode/Game/Missions/EspionageMissionTests.cs
+++ b/Assets/Tests/EditMode/Game/Missions/EspionageMissionTests.cs
@@ -45,6 +45,7 @@ namespace Rebellion.Tests.Game.Missions
                 FogOfWarSystem fog
             ) = MissionSceneBuilder.Build();
 
+            game.Config.Espionage.CoreSystemBonus = new GameConfig.RandomCountConfig();
             enemyPlanet.VisitingFactionIDs.Add("empire");
 
             Mission mission = CreateMission(
@@ -63,6 +64,10 @@ namespace Rebellion.Tests.Game.Missions
             Assert.IsTrue(
                 empire.Fog.Snapshots.ContainsKey("sys1"),
                 "Espionage success should capture a FOW snapshot for the faction"
+            );
+            CollectionAssert.AreEquivalent(
+                new[] { enemyPlanet.InstanceID },
+                RevealedPlanetIDs(empire)
             );
         }
 
@@ -100,6 +105,191 @@ namespace Rebellion.Tests.Game.Missions
             Faction empire = game.GetFactionByOwnerInstanceID("empire");
             PlanetSnapshot snapshot = empire.Fog.Snapshots["sys1"].Planets["enemy_planet"];
             Assert.IsTrue(snapshot.Buildings.Any(item => item.InstanceID == "enemy_building"));
+        }
+
+        [Test]
+        public void Execute_EnemyPlanetTarget_RevealsEnemyMissions()
+        {
+            (
+                GameRoot game,
+                Planet empPlanet,
+                Planet enemyPlanet,
+                Officer officer,
+                FogOfWarSystem fog
+            ) = MissionSceneBuilder.Build();
+
+            enemyPlanet.VisitingFactionIDs.Add("empire");
+            Mission enemyMission = EntityFactory.CreateMission(
+                "enemy_mission",
+                "rebels",
+                enemyPlanet.InstanceID
+            );
+            game.AttachNode(enemyMission, enemyPlanet);
+
+            Mission espionageMission = CreateMission(
+                game,
+                "empire",
+                enemyPlanet,
+                new List<IMissionParticipant> { officer },
+                new List<IMissionParticipant>()
+            );
+            game.AttachNode(espionageMission, enemyPlanet);
+            espionageMission.Initiate(0);
+
+            MissionSceneBuilder.RunToSuccess(espionageMission, game);
+
+            Faction empire = game.GetFactionByOwnerInstanceID("empire");
+            PlanetSnapshot snapshot = empire.Fog.Snapshots["sys1"].Planets["enemy_planet"];
+            Assert.AreEqual(1, snapshot.Missions.Count);
+            Assert.AreEqual(enemyMission.InstanceID, snapshot.Missions[0].InstanceID);
+        }
+
+        [Test]
+        public void Execute_CoreTarget_RevealsSameAllegianceCorePlanets()
+        {
+            (
+                GameRoot game,
+                Planet empPlanet,
+                Planet enemyPlanet,
+                Officer officer,
+                FogOfWarSystem fog
+            ) = MissionSceneBuilder.Build();
+            PlanetSystem targetSystem = enemyPlanet.GetParentOfType<PlanetSystem>();
+            targetSystem.SystemType = PlanetSystemType.CoreSystem;
+            AddSystem(game, "core2", "core_planet2", PlanetSystemType.CoreSystem);
+            AddSystem(game, "core3", "core_planet3", PlanetSystemType.CoreSystem);
+            AddSystem(game, "rim1", "rim_planet1", PlanetSystemType.OuterRim);
+            game.Config.Espionage.CoreSystemBonus = new GameConfig.RandomCountConfig
+            {
+                Base = 2,
+                Spread = 0,
+            };
+            enemyPlanet.VisitingFactionIDs.Add("empire");
+
+            Mission mission = CreateMission(
+                game,
+                "empire",
+                enemyPlanet,
+                new List<IMissionParticipant> { officer },
+                new List<IMissionParticipant>()
+            );
+            game.AttachNode(mission, enemyPlanet);
+            mission.Initiate(0);
+
+            MissionSceneBuilder.RunToSuccess(mission, game);
+
+            Faction empire = game.GetFactionByOwnerInstanceID("empire");
+            CollectionAssert.AreEquivalent(
+                new[] { "enemy_planet", "core_planet2", "core_planet3" },
+                RevealedPlanetIDs(empire)
+            );
+        }
+
+        [Test]
+        public void Execute_OuterRimTarget_DoesNotRevealBonusPlanets()
+        {
+            (
+                GameRoot game,
+                Planet empPlanet,
+                Planet enemyPlanet,
+                Officer officer,
+                FogOfWarSystem fog
+            ) = MissionSceneBuilder.Build();
+            enemyPlanet.GetParentOfType<PlanetSystem>().SystemType = PlanetSystemType.OuterRim;
+            AddSystem(game, "core2", "core_planet2", PlanetSystemType.CoreSystem);
+            game.Config.Espionage.CoreSystemBonus = new GameConfig.RandomCountConfig { Base = 10 };
+            enemyPlanet.VisitingFactionIDs.Add("empire");
+
+            Mission mission = CreateMission(
+                game,
+                "empire",
+                enemyPlanet,
+                new List<IMissionParticipant> { officer },
+                new List<IMissionParticipant>()
+            );
+            game.AttachNode(mission, enemyPlanet);
+            mission.Initiate(0);
+
+            MissionSceneBuilder.RunToSuccess(mission, game);
+
+            Faction empire = game.GetFactionByOwnerInstanceID("empire");
+            CollectionAssert.AreEquivalent(new[] { "enemy_planet" }, RevealedPlanetIDs(empire));
+        }
+
+        [Test]
+        public void Execute_MobileHeadquartersTarget_CanRevealCoreAndOuterRimPlanets()
+        {
+            (
+                GameRoot game,
+                Planet empPlanet,
+                Planet enemyPlanet,
+                Officer officer,
+                FogOfWarSystem fog
+            ) = MissionSceneBuilder.Build();
+            enemyPlanet.GetParentOfType<PlanetSystem>().SystemType = PlanetSystemType.CoreSystem;
+            AddSystem(game, "core2", "core_planet2", PlanetSystemType.CoreSystem);
+            AddSystem(game, "rim1", "rim_planet1", PlanetSystemType.OuterRim);
+            AddSystem(game, "neutral1", "neutral_planet1", PlanetSystemType.OuterRim, null);
+            Faction rebels = game.GetFactionByOwnerInstanceID("rebels");
+            rebels.HQInstanceID = enemyPlanet.InstanceID;
+            rebels.Settings.Headquarters.IsMobile = true;
+            game.Config.Espionage.MobileHeadquartersFactionInstanceID = rebels.InstanceID;
+            game.Config.Espionage.MobileHeadquartersBonus = new GameConfig.RandomCountConfig
+            {
+                Base = 10,
+            };
+            enemyPlanet.VisitingFactionIDs.Add("empire");
+
+            Mission mission = CreateMission(
+                game,
+                "empire",
+                enemyPlanet,
+                new List<IMissionParticipant> { officer },
+                new List<IMissionParticipant>()
+            );
+            game.AttachNode(mission, enemyPlanet);
+            mission.Initiate(0);
+
+            MissionSceneBuilder.RunToSuccess(mission, game);
+
+            Faction empire = game.GetFactionByOwnerInstanceID("empire");
+            CollectionAssert.AreEquivalent(
+                new[] { "enemy_planet", "core_planet2", "rim_planet1" },
+                RevealedPlanetIDs(empire)
+            );
+        }
+
+        [Test]
+        public void Execute_CapitalTarget_CanRevealCoreAndOuterRimPlanets()
+        {
+            (
+                GameRoot game,
+                Planet empPlanet,
+                Planet enemyPlanet,
+                Officer officer,
+                FogOfWarSystem fog
+            ) = MissionSceneBuilder.Build();
+            enemyPlanet.GetParentOfType<PlanetSystem>().SystemType = PlanetSystemType.CoreSystem;
+            AddSystem(game, "rim1", "rim_planet1", PlanetSystemType.OuterRim);
+            game.Config.Espionage.CapitalPlanetInstanceID = enemyPlanet.InstanceID;
+            game.Config.Espionage.CapitalObserverFactionInstanceID = "empire";
+            game.Config.Espionage.CapitalBonus = new GameConfig.RandomCountConfig { Base = 10 };
+            enemyPlanet.VisitingFactionIDs.Add("empire");
+
+            Mission mission = CreateMission(
+                game,
+                "empire",
+                enemyPlanet,
+                new List<IMissionParticipant> { officer },
+                new List<IMissionParticipant>()
+            );
+            game.AttachNode(mission, enemyPlanet);
+            mission.Initiate(0);
+
+            MissionSceneBuilder.RunToSuccess(mission, game);
+
+            Faction empire = game.GetFactionByOwnerInstanceID("empire");
+            CollectionAssert.Contains(RevealedPlanetIDs(empire), "rim_planet1");
         }
 
         [Test]
@@ -356,6 +546,39 @@ namespace Rebellion.Tests.Game.Missions
                 mission,
                 "TryCreate should succeed for a visited planet regardless of ownership"
             );
+        }
+
+        private static PlanetSystem AddSystem(
+            GameRoot game,
+            string systemInstanceID,
+            string planetInstanceID,
+            PlanetSystemType systemType,
+            string ownerInstanceID = "rebels"
+        )
+        {
+            PlanetSystem system = new PlanetSystem
+            {
+                InstanceID = systemInstanceID,
+                SystemType = systemType,
+            };
+            game.AttachNode(system, game.Galaxy);
+            game.AttachNode(
+                new Planet
+                {
+                    InstanceID = planetInstanceID,
+                    OwnerInstanceID = ownerInstanceID,
+                    IsColonized = true,
+                },
+                system
+            );
+            return system;
+        }
+
+        private static List<string> RevealedPlanetIDs(Faction faction)
+        {
+            return faction
+                .Fog.Snapshots.Values.SelectMany(snapshot => snapshot.Planets.Keys)
+                .ToList();
         }
 
         [Test]

--- a/Assets/Tests/EditMode/Systems/CombatTestBase.cs
+++ b/Assets/Tests/EditMode/Systems/CombatTestBase.cs
@@ -64,7 +64,7 @@ namespace Rebellion.Tests.Systems
                     {
                         InvertSupportShift = true,
                         WeakSupportPenaltyTrigger = SupportShiftCondition.Negative,
-                        HeadquartersCanBeBombarded = false,
+                        Headquarters = new HeadquartersSettings { IsBombardable = false },
                     },
                 }
             );
@@ -77,7 +77,7 @@ namespace Rebellion.Tests.Systems
                     {
                         InvertSupportShift = false,
                         WeakSupportPenaltyTrigger = SupportShiftCondition.Positive,
-                        HeadquartersCanBeBombarded = true,
+                        Headquarters = new HeadquartersSettings { IsBombardable = true },
                     },
                 }
             );

--- a/Assets/Tests/EditMode/Systems/FactionAutomationSystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/FactionAutomationSystemTests.cs
@@ -9,13 +9,13 @@ using Rebellion.Systems;
 namespace Rebellion.Tests.Systems
 {
     [TestFixture]
-    public class PlayerAutomationSystemTests
+    public class FactionAutomationSystemTests
     {
         private GameRoot _game;
         private Faction _faction;
         private Planet _producer;
         private Planet _destination;
-        private PlayerAutomationSystem _automation;
+        private FactionAutomationSystem _automation;
 
         [SetUp]
         public void SetUp()
@@ -45,7 +45,7 @@ namespace Rebellion.Tests.Systems
                 _game,
                 new FleetSystem(_game)
             );
-            _automation = new PlayerAutomationSystem(_game, TestContent.Data, manufacturing);
+            _automation = new FactionAutomationSystem(_game, TestContent.Data, manufacturing);
         }
 
         [Test]
@@ -67,6 +67,22 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_ManageGarrisons_PrioritizesUprising()
+        {
+            _faction.ManageProduction = false;
+            AddCompletedRegiment(_producer, "GARRISON_1");
+            AddCompletedRegiment(_producer, "GARRISON_2");
+            Planet uprising = CreatePlanet("UPRISING", 10, 0);
+            uprising.IsInUprising = true;
+            _game.AttachNode(uprising, _destination.GetParent());
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(1, uprising.GetAllRegiments().Count);
+            Assert.IsEmpty(_destination.GetAllRegiments());
+        }
+
+        [Test]
         public void ProcessTick_ManageProduction_FillsCapacityWithMatchedPair()
         {
             _faction.ManageGarrisons = false;
@@ -75,18 +91,6 @@ namespace Rebellion.Tests.Systems
 
             Assert.AreEqual(11, CountResourceFacilities(BuildingType.Mine));
             Assert.AreEqual(11, CountResourceFacilities(BuildingType.Refinery));
-        }
-
-        [Test]
-        public void ProcessTick_ManageProductionWithoutMineCapacity_DoesNotAddRefinery()
-        {
-            _faction.ManageGarrisons = false;
-            _destination.NumRawResourceNodes = 0;
-            int refineryCount = CountResourceFacilities(BuildingType.Refinery);
-
-            _automation.ProcessTick();
-
-            Assert.AreEqual(refineryCount, CountResourceFacilities(BuildingType.Refinery));
         }
 
         [Test]
@@ -105,19 +109,15 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_ManageGarrisons_PrioritizesUprising()
+        public void ProcessTick_ManageProductionWithoutMineCapacity_DoesNotAddRefinery()
         {
-            _faction.ManageProduction = false;
-            AddCompletedRegiment(_producer, "GARRISON_1");
-            AddCompletedRegiment(_producer, "GARRISON_2");
-            Planet uprising = CreatePlanet("UPRISING", 10, 0);
-            uprising.IsInUprising = true;
-            _game.AttachNode(uprising, _destination.GetParent());
+            _faction.ManageGarrisons = false;
+            _destination.NumRawResourceNodes = 0;
+            int refineryCount = CountResourceFacilities(BuildingType.Refinery);
 
             _automation.ProcessTick();
 
-            Assert.AreEqual(1, uprising.GetAllRegiments().Count);
-            Assert.IsEmpty(_destination.GetAllRegiments());
+            Assert.AreEqual(refineryCount, CountResourceFacilities(BuildingType.Refinery));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/Systems/FogOfWarSystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/FogOfWarSystemTests.cs
@@ -1250,12 +1250,12 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void RecordPlanetManufacturingSnapshot_EspionageIntel_RevealsManufacturing()
+        public void RecordEspionageSnapshot_RevealsManufacturing()
         {
             AddQueuedBuilding(_coruscant, _empire, "REVEALED_BUILDING", 25);
             FogOfWarRecorder recorder = new FogOfWarRecorder();
 
-            recorder.RecordPlanetManufacturingSnapshot(_alliance, _coruscant, _coreSystem, 10);
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
 
             GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
             Planet viewCoruscant = view
@@ -1272,11 +1272,89 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void RecordEspionageSnapshot_RevealsEnemyMissions()
+        {
+            Mission empireMission = CreateMission("M1", _empire, _coruscant);
+            _game.AttachNode(empireMission, _coruscant);
+            FogOfWarRecorder recorder = new FogOfWarRecorder();
+
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
+
+            GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
+            Planet viewCoruscant = view
+                .PlanetSystems.First(system => system.InstanceID == _coreSystem.InstanceID)
+                .Planets.First(planet => planet.InstanceID == _coruscant.InstanceID);
+
+            Assert.AreEqual(1, viewCoruscant.Missions.Count);
+            Assert.AreEqual(empireMission.InstanceID, viewCoruscant.Missions[0].InstanceID);
+        }
+
+        [Test]
+        public void RecordEspionageSnapshot_RevealsIncomingEnemyFleet()
+        {
+            Fleet empireFleet = CreateFleet("INCOMING_FLEET", _empire);
+            _game.AttachNode(empireFleet, _coruscant);
+            AddCapitalShip(empireFleet, _empire, "INCOMING_SHIP");
+            empireFleet.Movement = new MovementState { TransitTicks = 10, TicksElapsed = 5 };
+            FogOfWarRecorder recorder = new FogOfWarRecorder();
+
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
+
+            GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
+            Planet viewCoruscant = view
+                .PlanetSystems.First(system => system.InstanceID == _coreSystem.InstanceID)
+                .Planets.First(planet => planet.InstanceID == _coruscant.InstanceID);
+
+            Assert.AreEqual(1, viewCoruscant.Fleets.Count);
+            Assert.AreEqual(empireFleet.InstanceID, viewCoruscant.Fleets[0].InstanceID);
+            Assert.IsNotNull(viewCoruscant.Fleets[0].Movement);
+        }
+
+        [Test]
+        public void CaptureSnapshot_AfterEspionage_PreservesIncomingEnemyFleet()
+        {
+            Fleet empireFleet = CreateFleet("INCOMING_FLEET", _empire);
+            _game.AttachNode(empireFleet, _coruscant);
+            AddCapitalShip(empireFleet, _empire, "INCOMING_SHIP");
+            empireFleet.Movement = new MovementState { TransitTicks = 10, TicksElapsed = 5 };
+            FogOfWarRecorder recorder = new FogOfWarRecorder();
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
+
+            _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSystem, 20);
+
+            GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
+            Planet viewCoruscant = view
+                .PlanetSystems.First(system => system.InstanceID == _coreSystem.InstanceID)
+                .Planets.First(planet => planet.InstanceID == _coruscant.InstanceID);
+            Fleet viewFleet = viewCoruscant.Fleets.Single(fleet =>
+                fleet.InstanceID == empireFleet.InstanceID
+            );
+            Assert.IsNotNull(viewFleet.Movement);
+        }
+
+        [Test]
+        public void CaptureSnapshot_AfterEspionage_PreservesMissionIntelligence()
+        {
+            Mission empireMission = CreateMission("M1", _empire, _coruscant);
+            _game.AttachNode(empireMission, _coruscant);
+            FogOfWarRecorder recorder = new FogOfWarRecorder();
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
+
+            _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSystem, 20);
+
+            PlanetSnapshot snapshot = _alliance.Fog.Snapshots[_coreSystem.InstanceID].Planets[
+                _coruscant.InstanceID
+            ];
+            Assert.AreEqual(1, snapshot.Missions.Count);
+            Assert.AreEqual(empireMission.InstanceID, snapshot.Missions[0].InstanceID);
+        }
+
+        [Test]
         public void CaptureSnapshot_AfterEspionage_PreservesStaleManufacturingIntel()
         {
             Building knownBuilding = AddQueuedBuilding(_coruscant, _empire, "KNOWN_BUILDING", 25);
             FogOfWarRecorder recorder = new FogOfWarRecorder();
-            recorder.RecordPlanetManufacturingSnapshot(_alliance, _coruscant, _coreSystem, 10);
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
 
             knownBuilding.ManufacturingProgress = 75;
             AddQueuedBuilding(_coruscant, _empire, "UNKNOWN_BUILDING", 10);
@@ -1300,7 +1378,7 @@ namespace Rebellion.Tests.Systems
         {
             Building knownBuilding = AddQueuedBuilding(_coruscant, _empire, "KNOWN_BUILDING", 25);
             FogOfWarRecorder recorder = new FogOfWarRecorder();
-            recorder.RecordPlanetManufacturingSnapshot(_alliance, _coruscant, _coreSystem, 10);
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
 
             _coruscant.ManufacturingQueue[ManufacturingType.Building].Remove(knownBuilding);
             _game.DetachNode(knownBuilding);
@@ -1336,7 +1414,7 @@ namespace Rebellion.Tests.Systems
             _game.AttachNode(knownShip, fleet);
             _game.AttachNode(departedRegiment, knownShip);
             FogOfWarRecorder recorder = new FogOfWarRecorder();
-            recorder.RecordPlanetManufacturingSnapshot(_alliance, _coruscant, _coreSystem, 10);
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
 
             _game.DetachNode(departedRegiment);
             _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSystem, 20);
@@ -1364,7 +1442,7 @@ namespace Rebellion.Tests.Systems
             _game.AttachNode(fleet, _coruscant);
             _game.AttachNode(knownShip, fleet);
             FogOfWarRecorder recorder = new FogOfWarRecorder();
-            recorder.RecordPlanetManufacturingSnapshot(_alliance, _coruscant, _coreSystem, 10);
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
 
             knownShip.ManufacturingProgress = 75;
             _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSystem, 20);
@@ -1401,7 +1479,7 @@ namespace Rebellion.Tests.Systems
             _game.AttachNode(fleet, _coruscant);
             _game.AttachNode(knownShip, fleet);
             FogOfWarRecorder recorder = new FogOfWarRecorder();
-            recorder.RecordPlanetManufacturingSnapshot(_alliance, _coruscant, _coreSystem, 10);
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
 
             _game.DetachNode(knownShip);
             _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSystem, 20);
@@ -1526,17 +1604,16 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void BuildFactionView_LivePlanet_EnemyMissionsNeverVisible()
+        public void BuildFactionView_LivePlanet_EspionageMissionIntelligenceRemainsVisible()
         {
-            // Alliance takes a snapshot of coruscant (e.g. via espionage) then gets live intel.
-            // Enemy missions must never be visible — not from snapshot, not from live sight.
             Officer vader = CreateOfficer("VADER", _empire);
             _game.AttachNode(vader, _coruscant);
 
             Mission empireMission = CreateMission("M1", _empire, _coruscant);
             _game.AttachNode(empireMission, _coruscant);
 
-            _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSystem, 10);
+            FogOfWarRecorder recorder = new FogOfWarRecorder();
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
 
             Fleet allianceFleet = CreateFleet("FLEET1", _alliance);
             _game.AttachNode(allianceFleet, _coruscant);
@@ -1554,9 +1631,9 @@ namespace Rebellion.Tests.Systems
                 "Live officer (Vader) should be visible"
             );
             Assert.AreEqual(
-                0,
+                1,
                 viewCoruscant.Missions.Count,
-                "Enemy missions must never be visible"
+                "A mission revealed by espionage should remain visible with live planet intel"
             );
         }
 
@@ -1816,7 +1893,7 @@ namespace Rebellion.Tests.Systems
             Assert.AreEqual(
                 0,
                 viewCoruscant.Missions.Count,
-                "Enemy missions must never be visible"
+                "An ordinary observation should not reveal enemy missions"
             );
         }
 
@@ -2158,14 +2235,13 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void BuildFactionView_LivePlanet_SnapshotEnemyMission_NeverSurfaced()
+        public void BuildFactionView_LivePlanet_EspionageSnapshotEnemyMission_IsSurfaced()
         {
-            // Even if a snapshot captured an enemy mission, and the planet is later live,
-            // enemy missions must never appear in the faction view.
             Mission empireMission = CreateMission("M1", _empire, _coruscant);
             _game.AttachNode(empireMission, _coruscant);
 
-            _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSystem, 10);
+            FogOfWarRecorder recorder = new FogOfWarRecorder();
+            recorder.RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
 
             Fleet allianceFleet = CreateFleet("FLEET1", _alliance);
             _game.AttachNode(allianceFleet, _coruscant);
@@ -2178,9 +2254,9 @@ namespace Rebellion.Tests.Systems
                 .Planets.First(p => p.InstanceID == "CORUSCANT");
 
             Assert.AreEqual(
-                0,
+                1,
                 viewCoruscant.Missions.Count,
-                "Enemy missions must never be surfaced"
+                "Enemy missions captured by espionage should be surfaced"
             );
         }
 

--- a/Assets/Tests/EditMode/Systems/HeadquartersSystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/HeadquartersSystemTests.cs
@@ -55,6 +55,87 @@ namespace Rebellion.Tests.Systems
             Assert.AreEqual(destination.InstanceID, faction.HQInstanceID);
         }
 
+        [Test]
+        public void HandleResults_FixedHeadquartersCaptured_ClearsMarkerAndPreservesLocation()
+        {
+            (GameRoot game, Faction faction, Planet origin, _, _) = CreateGame(isMobile: false);
+            Faction attacker = new Faction { InstanceID = "empire" };
+            game.Factions.Add(attacker);
+
+            CreateSystem(game)
+                .HandleResults(
+                    new List<PlanetOwnershipChangedResult>
+                    {
+                        new PlanetOwnershipChangedResult
+                        {
+                            Planet = origin,
+                            PreviousOwner = faction,
+                            NewOwner = attacker,
+                        },
+                    }
+                );
+
+            Assert.IsFalse(origin.IsHeadquarters);
+            Assert.AreEqual(origin.InstanceID, faction.HQInstanceID);
+        }
+
+        [Test]
+        public void HandleResults_FixedHeadquartersRecaptured_RestoresMarker()
+        {
+            (GameRoot game, Faction faction, Planet origin, _, _) = CreateGame(isMobile: false);
+            Faction attacker = new Faction { InstanceID = "empire" };
+            game.Factions.Add(attacker);
+            origin.IsHeadquarters = false;
+
+            CreateSystem(game)
+                .HandleResults(
+                    new List<PlanetOwnershipChangedResult>
+                    {
+                        new PlanetOwnershipChangedResult
+                        {
+                            Planet = origin,
+                            PreviousOwner = attacker,
+                            NewOwner = faction,
+                        },
+                    }
+                );
+
+            Assert.IsTrue(origin.IsHeadquarters);
+            Assert.AreEqual(origin.InstanceID, faction.HQInstanceID);
+        }
+
+        [Test]
+        public void HandleResults_HostilePlanetCapture_DestroysMobileHeadquarters()
+        {
+            (GameRoot game, Faction faction, Planet origin, _, Building hq) = CreateGame(
+                isMobile: true
+            );
+            Faction attacker = new Faction { InstanceID = "empire" };
+            game.Factions.Add(attacker);
+
+            List<GameResult> results = CreateSystem(game)
+                .HandleResults(
+                    new List<PlanetOwnershipChangedResult>
+                    {
+                        new PlanetOwnershipChangedResult
+                        {
+                            Planet = origin,
+                            PreviousOwner = faction,
+                            NewOwner = attacker,
+                        },
+                    }
+                );
+
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Building>(hq.InstanceID));
+            Assert.IsFalse(origin.IsHeadquarters);
+            Assert.IsNull(faction.HQInstanceID);
+            HeadquartersDestroyedResult destroyed = results[0] as HeadquartersDestroyedResult;
+            Assert.IsNotNull(destroyed);
+            Assert.AreSame(hq, destroyed.Headquarters);
+            Assert.AreSame(faction, destroyed.Defender);
+            Assert.AreSame(attacker, destroyed.Attacker);
+        }
+
         private static HeadquartersSystem CreateSystem(GameRoot game)
         {
             MovementSystem movement = new MovementSystem(

--- a/Assets/Tests/EditMode/Systems/HeadquartersSystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/HeadquartersSystemTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Rebellion.Game;
+using Rebellion.Game.Factions;
+using Rebellion.Game.Galaxy;
+using Rebellion.Game.Results;
+using Rebellion.Game.Units;
+using Rebellion.Systems;
+
+namespace Rebellion.Tests.Systems
+{
+    [TestFixture]
+    public class HeadquartersSystemTests
+    {
+        [Test]
+        public void TryRelocate_MobileHeadquarters_DepartsAndClearsPlanetMarker()
+        {
+            (GameRoot game, Faction faction, Planet origin, Planet destination, Building hq) =
+                CreateGame(isMobile: true);
+            HeadquartersSystem system = CreateSystem(game);
+
+            Assert.IsTrue(system.TryRelocate(hq, destination));
+            Assert.IsNotNull(hq.Movement);
+            Assert.IsFalse(origin.IsHeadquarters);
+            Assert.IsNull(faction.HQInstanceID);
+        }
+
+        [Test]
+        public void TryRelocate_FixedHeadquarters_IsRejected()
+        {
+            (GameRoot game, Faction faction, Planet origin, Planet destination, Building hq) =
+                CreateGame(isMobile: false);
+
+            Assert.IsFalse(CreateSystem(game).TryRelocate(hq, destination));
+            Assert.AreSame(origin, hq.GetParent());
+            Assert.AreEqual(origin.InstanceID, faction.HQInstanceID);
+        }
+
+        [Test]
+        public void HandleResults_HeadquartersArrival_AssignsDestination()
+        {
+            (GameRoot game, Faction faction, Planet origin, Planet destination, Building hq) =
+                CreateGame(isMobile: true);
+            HeadquartersSystem system = CreateSystem(game);
+            Assert.IsTrue(system.TryRelocate(hq, destination));
+
+            system.HandleResults(
+                new List<UnitArrivedResult>
+                {
+                    new UnitArrivedResult { Unit = hq, Destination = destination },
+                }
+            );
+
+            Assert.IsTrue(destination.IsHeadquarters);
+            Assert.AreEqual(destination.InstanceID, faction.HQInstanceID);
+        }
+
+        private static HeadquartersSystem CreateSystem(GameRoot game)
+        {
+            MovementSystem movement = new MovementSystem(
+                game,
+                new FogOfWarSystem(game),
+                new FleetSystem(game)
+            );
+            return new HeadquartersSystem(game, movement);
+        }
+
+        private static (GameRoot, Faction, Planet, Planet, Building) CreateGame(bool isMobile)
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            Faction faction = new Faction
+            {
+                InstanceID = "alliance",
+                HQInstanceID = "origin",
+                Settings = new FactionSettings
+                {
+                    Headquarters = new HeadquartersSettings
+                    {
+                        FacilityTypeID = "BDHQ01",
+                        IsMobile = isMobile,
+                    },
+                },
+            };
+            game.Factions.Add(faction);
+
+            PlanetSystem planetSystem = new PlanetSystem { InstanceID = "system" };
+            game.AttachNode(planetSystem, game.GetGalaxyMap());
+            Planet origin = new Planet
+            {
+                InstanceID = "origin",
+                OwnerInstanceID = faction.InstanceID,
+                IsColonized = true,
+                IsHeadquarters = true,
+                EnergyCapacity = 1,
+            };
+            Planet destination = new Planet
+            {
+                InstanceID = "destination",
+                OwnerInstanceID = faction.InstanceID,
+                IsColonized = true,
+                EnergyCapacity = 2,
+                PositionX = 100,
+            };
+            game.AttachNode(origin, planetSystem);
+            game.AttachNode(destination, planetSystem);
+
+            Building headquarters = new Building
+            {
+                InstanceID = "headquarters",
+                TypeID = "BDHQ01",
+                OwnerInstanceID = faction.InstanceID,
+                BuildingType = BuildingType.Headquarters,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(headquarters, origin);
+            return (game, faction, origin, destination, headquarters);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Systems/PlanetaryAssaultSystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/PlanetaryAssaultSystemTests.cs
@@ -226,7 +226,7 @@ namespace Rebellion.Tests.Systems
         public void Execute_CollateralDamage_CanDestroyCivilianFacilityAndExcludesHeadquarters()
         {
             GameRoot game = CreateGame();
-            (Planet planet, _) = CreatePlanet(game, "p1", "alliance", energy: 1);
+            (Planet planet, _) = CreatePlanet(game, "p1", "alliance", energy: 2);
             planet.IsHeadquarters = true;
             Building mine = AddCollateralBuilding(game, planet, "mine");
             Building headquarters = new Building
@@ -252,7 +252,7 @@ namespace Rebellion.Tests.Systems
                 game.GetSceneNodeByInstanceID<Building>(headquarters.InstanceID)
             );
             CollectionAssert.Contains(result.CollateralDestroyedBuildings, mine);
-            Assert.AreEqual(1, planet.EnergyCapacity);
+            Assert.AreEqual(2, planet.EnergyCapacity);
             Assert.IsFalse(result.Success);
         }
 

--- a/Assets/Tests/EditMode/Systems/PlanetaryAssaultSystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/PlanetaryAssaultSystemTests.cs
@@ -229,6 +229,14 @@ namespace Rebellion.Tests.Systems
             (Planet planet, _) = CreatePlanet(game, "p1", "alliance", energy: 1);
             planet.IsHeadquarters = true;
             Building mine = AddCollateralBuilding(game, planet, "mine");
+            Building headquarters = new Building
+            {
+                InstanceID = "headquarters",
+                OwnerInstanceID = "alliance",
+                BuildingType = BuildingType.Headquarters,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(headquarters, planet);
             AddDefender(game, planet, "defender");
             Fleet fleet = AddAssaultFleet(game, planet, "empire", regimentCount: 1);
 
@@ -239,6 +247,10 @@ namespace Rebellion.Tests.Systems
                 .Execute(new List<Fleet> { fleet }, planet);
 
             Assert.IsTrue(planet.IsHeadquarters);
+            Assert.AreSame(
+                headquarters,
+                game.GetSceneNodeByInstanceID<Building>(headquarters.InstanceID)
+            );
             CollectionAssert.Contains(result.CollateralDestroyedBuildings, mine);
             Assert.AreEqual(1, planet.EnergyCapacity);
             Assert.IsFalse(result.Success);

--- a/Assets/Tests/EditMode/Systems/PlayerAutomationSystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/PlayerAutomationSystemTests.cs
@@ -1,0 +1,215 @@
+using System.Linq;
+using NUnit.Framework;
+using Rebellion.Game;
+using Rebellion.Game.Factions;
+using Rebellion.Game.Galaxy;
+using Rebellion.Game.Units;
+using Rebellion.Systems;
+
+namespace Rebellion.Tests.Systems
+{
+    [TestFixture]
+    public class PlayerAutomationSystemTests
+    {
+        private GameRoot _game;
+        private Faction _faction;
+        private Planet _producer;
+        private Planet _destination;
+        private PlayerAutomationSystem _automation;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _game = new GameRoot(TestContent.Data.GameConfig);
+            _faction = new Faction
+            {
+                InstanceID = "FNALL1",
+                ManageGarrisons = true,
+                ManageProduction = true,
+            };
+            _game.Factions.Add(_faction);
+
+            PlanetSystem system = new PlanetSystem { InstanceID = "SYSTEM" };
+            _game.AttachNode(system, _game.Galaxy);
+            _producer = CreatePlanet("PRODUCER", 100, 10);
+            _destination = CreatePlanet("DESTINATION", 10, 10);
+            _game.AttachNode(_producer, system);
+            _game.AttachNode(_destination, system);
+
+            AddProductionFacility(_producer, "TRAINING", ManufacturingType.Troop);
+            AddProductionFacility(_producer, "CONSTRUCTION", ManufacturingType.Building);
+            AddProductionFacility(_producer, "CONSTRUCTION_2", ManufacturingType.Building);
+            AddResourcePairs(_producer, 10);
+
+            ManufacturingSystem manufacturing = new ManufacturingSystem(
+                _game,
+                new FleetSystem(_game)
+            );
+            _automation = new PlayerAutomationSystem(_game, TestContent.Data, manufacturing);
+        }
+
+        [Test]
+        public void ProcessTick_ManageGarrisons_QueuesTroopForUnguardedPlanet()
+        {
+            _faction.ManageProduction = false;
+            _destination.SetFullPopularSupport(_faction.InstanceID);
+            AddCompletedRegiment(_producer, "GARRISON_1");
+            AddCompletedRegiment(_producer, "GARRISON_2");
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(1, _destination.GetAllRegiments().Count);
+            Assert.AreEqual(
+                ManufacturingStatus.Building,
+                _destination.GetAllRegiments().Single().ManufacturingStatus
+            );
+            Assert.AreEqual("REAL002", _destination.GetAllRegiments().Single().TypeID);
+        }
+
+        [Test]
+        public void ProcessTick_ManageProduction_FillsCapacityWithMatchedPair()
+        {
+            _faction.ManageGarrisons = false;
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(11, CountResourceFacilities(BuildingType.Mine));
+            Assert.AreEqual(11, CountResourceFacilities(BuildingType.Refinery));
+        }
+
+        [Test]
+        public void ProcessTick_ManageProductionWithoutMineCapacity_DoesNotAddRefinery()
+        {
+            _faction.ManageGarrisons = false;
+            _destination.NumRawResourceNodes = 0;
+            int refineryCount = CountResourceFacilities(BuildingType.Refinery);
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(refineryCount, CountResourceFacilities(BuildingType.Refinery));
+        }
+
+        [Test]
+        public void ProcessTick_ManageProduction_UsesClosestAvailableResourceSlot()
+        {
+            _faction.ManageGarrisons = false;
+            _destination.PositionX = 1;
+            Planet distant = CreatePlanet("DISTANT", 50, 50);
+            distant.PositionX = 100;
+            _game.AttachNode(distant, _destination.GetParent());
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(1, _destination.GetTotalBuildingTypeCount(BuildingType.Mine));
+            Assert.AreEqual(0, distant.GetTotalBuildingTypeCount(BuildingType.Mine));
+        }
+
+        [Test]
+        public void ProcessTick_ManageGarrisons_PrioritizesUprising()
+        {
+            _faction.ManageProduction = false;
+            AddCompletedRegiment(_producer, "GARRISON_1");
+            AddCompletedRegiment(_producer, "GARRISON_2");
+            Planet uprising = CreatePlanet("UPRISING", 10, 0);
+            uprising.IsInUprising = true;
+            _game.AttachNode(uprising, _destination.GetParent());
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(1, uprising.GetAllRegiments().Count);
+            Assert.IsEmpty(_destination.GetAllRegiments());
+        }
+
+        [Test]
+        public void ProcessTick_DisabledAutomation_DoesNotQueueWork()
+        {
+            _faction.ManageGarrisons = false;
+            _faction.ManageProduction = false;
+
+            _automation.ProcessTick();
+
+            Assert.IsEmpty(_destination.GetAllRegiments());
+            Assert.AreEqual(0, _destination.GetTotalBuildingTypeCount(BuildingType.Mine));
+        }
+
+        private Planet CreatePlanet(string instanceId, int energy, int resources)
+        {
+            Planet planet = new Planet
+            {
+                InstanceID = instanceId,
+                OwnerInstanceID = _faction.InstanceID,
+                IsColonized = true,
+                EnergyCapacity = energy,
+                NumRawResourceNodes = resources,
+            };
+            planet.SetFullPopularSupport(_faction.InstanceID);
+            return planet;
+        }
+
+        private void AddProductionFacility(Planet planet, string instanceId, ManufacturingType type)
+        {
+            _game.AttachNode(
+                new Building
+                {
+                    InstanceID = instanceId,
+                    OwnerInstanceID = _faction.InstanceID,
+                    BuildingType =
+                        type == ManufacturingType.Troop
+                            ? BuildingType.TrainingFacility
+                            : BuildingType.ConstructionFacility,
+                    ProductionType = type,
+                    ProcessRate = 1,
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                },
+                planet
+            );
+        }
+
+        private void AddResourcePairs(Planet planet, int count)
+        {
+            for (int index = 0; index < count; index++)
+            {
+                AddResourceFacility(planet, $"MINE_{index}", BuildingType.Mine);
+                AddResourceFacility(planet, $"REFINERY_{index}", BuildingType.Refinery);
+            }
+        }
+
+        private void AddCompletedRegiment(Planet planet, string instanceId)
+        {
+            _game.AttachNode(
+                new Regiment
+                {
+                    InstanceID = instanceId,
+                    OwnerInstanceID = _faction.InstanceID,
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                },
+                planet
+            );
+        }
+
+        private void AddResourceFacility(
+            Planet planet,
+            string instanceId,
+            BuildingType buildingType
+        )
+        {
+            _game.AttachNode(
+                new Building
+                {
+                    InstanceID = instanceId,
+                    OwnerInstanceID = _faction.InstanceID,
+                    BuildingType = buildingType,
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                },
+                planet
+            );
+        }
+
+        private int CountResourceFacilities(BuildingType buildingType)
+        {
+            return new[] { _producer, _destination }.Sum(planet =>
+                planet.GetTotalBuildingTypeCount(buildingType)
+            );
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Systems/VictorySystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/VictorySystemTests.cs
@@ -284,6 +284,77 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_MultipleMobileHeadquarters_UsesDefenderHeadquarters()
+        {
+            (GameRoot game, Faction empire, Faction rebels, Planet empireHQ, VictorySystem system) =
+                BuildScene(rebelsCaptureEmpireHQ: false);
+            empire.Settings = new FactionSettings
+            {
+                Headquarters = new HeadquartersSettings
+                {
+                    FacilityTypeID = "BDHQ01",
+                    IsMobile = true,
+                },
+            };
+            empireHQ.OwnerInstanceID = rebels.InstanceID;
+            empireHQ.EnergyCapacity = 1;
+            game.AttachNode(
+                new Building
+                {
+                    InstanceID = "empire-mobile-hq",
+                    TypeID = "BDHQ01",
+                    OwnerInstanceID = rebels.InstanceID,
+                    BuildingType = BuildingType.Headquarters,
+                },
+                empireHQ
+            );
+
+            Faction thirdFaction = new Faction
+            {
+                InstanceID = "third-faction",
+                HQInstanceID = "third-hq-planet",
+                Settings = new FactionSettings
+                {
+                    Headquarters = new HeadquartersSettings
+                    {
+                        FacilityTypeID = "BDHQ01",
+                        IsMobile = true,
+                    },
+                },
+            };
+            game.Factions.Add(thirdFaction);
+            Planet thirdHeadquartersPlanet = new Planet
+            {
+                InstanceID = thirdFaction.HQInstanceID,
+                OwnerInstanceID = thirdFaction.InstanceID,
+                IsColonized = true,
+                EnergyCapacity = 1,
+            };
+            game.AttachNode(
+                thirdHeadquartersPlanet,
+                game.GetSceneNodeByInstanceID<PlanetSystem>("sys1")
+            );
+            game.AttachNode(
+                new Building
+                {
+                    InstanceID = "third-mobile-hq",
+                    TypeID = "BDHQ01",
+                    OwnerInstanceID = thirdFaction.InstanceID,
+                    BuildingType = BuildingType.Headquarters,
+                },
+                thirdHeadquartersPlanet
+            );
+
+            List<GameResult> results = system.ProcessTick();
+
+            Assert.AreEqual(1, results.Count);
+            VictoryResult victory = results[0] as VictoryResult;
+            Assert.IsNotNull(victory);
+            Assert.AreSame(rebels, victory.Winner);
+            Assert.AreSame(empire, victory.Loser);
+        }
+
+        [Test]
         public void HandleResults_MobileHeadquartersDestroyed_ReturnsVictory()
         {
             (GameRoot game, Faction empire, Faction rebels, Planet empireHQ, VictorySystem system) =

--- a/Assets/Tests/EditMode/Systems/VictorySystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/VictorySystemTests.cs
@@ -222,35 +222,6 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_MobileHeadquartersOwnerIsUnknown_ReturnsEmpty()
-        {
-            (GameRoot game, Faction empire, _, Planet empireHQ, VictorySystem system) = BuildScene(
-                rebelsCaptureEmpireHQ: false
-            );
-            empire.Settings = new FactionSettings
-            {
-                Headquarters = new HeadquartersSettings
-                {
-                    FacilityTypeID = "BDHQ01",
-                    IsMobile = true,
-                },
-            };
-            empireHQ.EnergyCapacity = 1;
-            Building headquarters = new Building
-            {
-                InstanceID = "mobile-hq",
-                TypeID = "BDHQ01",
-                OwnerInstanceID = "unknown-faction",
-                BuildingType = BuildingType.Headquarters,
-            };
-            game.AttachNode(headquarters, empireHQ);
-
-            List<GameResult> results = system.ProcessTick();
-
-            Assert.AreEqual(0, results.Count);
-        }
-
-        [Test]
         public void ProcessTick_MobileHeadquartersCaptured_ReturnsVictoryResult()
         {
             (GameRoot game, Faction empire, Faction rebels, Planet empireHQ, VictorySystem system) =

--- a/Assets/Tests/EditMode/Systems/VictorySystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/VictorySystemTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Rebellion.Game;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
+using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using Rebellion.Systems;
@@ -171,6 +172,70 @@ namespace Rebellion.Tests.Systems
             VictoryResult victory = results[0] as VictoryResult;
             Assert.IsNotNull(victory);
             Assert.AreEqual(rebels, victory.Winner);
+        }
+
+        [Test]
+        public void ProcessTick_MobileHeadquartersInTransit_ReturnsEmpty()
+        {
+            (GameRoot game, Faction empire, _, Planet empireHQ, VictorySystem system) = BuildScene(
+                rebelsCaptureEmpireHQ: false
+            );
+            empire.Settings = new FactionSettings
+            {
+                Headquarters = new HeadquartersSettings
+                {
+                    FacilityTypeID = "BDHQ01",
+                    IsMobile = true,
+                },
+            };
+            empire.HQInstanceID = null;
+            empireHQ.EnergyCapacity = 1;
+            Building headquarters = new Building
+            {
+                InstanceID = "mobile-hq",
+                TypeID = "BDHQ01",
+                OwnerInstanceID = empire.InstanceID,
+                BuildingType = BuildingType.Headquarters,
+                Movement = new MovementState { TransitTicks = 10, TicksElapsed = 5 },
+            };
+            game.AttachNode(headquarters, empireHQ);
+
+            List<GameResult> results = system.ProcessTick();
+
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [Test]
+        public void ProcessTick_MobileHeadquartersCaptured_ReturnsVictoryResult()
+        {
+            (GameRoot game, Faction empire, Faction rebels, Planet empireHQ, VictorySystem system) =
+                BuildScene(rebelsCaptureEmpireHQ: false);
+            empire.Settings = new FactionSettings
+            {
+                Headquarters = new HeadquartersSettings
+                {
+                    FacilityTypeID = "BDHQ01",
+                    IsMobile = true,
+                },
+            };
+            empireHQ.OwnerInstanceID = rebels.InstanceID;
+            empireHQ.EnergyCapacity = 1;
+            Building headquarters = new Building
+            {
+                InstanceID = "mobile-hq",
+                TypeID = "BDHQ01",
+                OwnerInstanceID = rebels.InstanceID,
+                BuildingType = BuildingType.Headquarters,
+            };
+            game.AttachNode(headquarters, empireHQ);
+
+            List<GameResult> results = system.ProcessTick();
+
+            Assert.AreEqual(1, results.Count);
+            VictoryResult victory = results[0] as VictoryResult;
+            Assert.IsNotNull(victory);
+            Assert.AreEqual(rebels, victory.Winner);
+            Assert.AreEqual(empire, victory.Loser);
         }
     }
 }

--- a/Assets/Tests/EditMode/Systems/VictorySystemTests.cs
+++ b/Assets/Tests/EditMode/Systems/VictorySystemTests.cs
@@ -13,8 +13,6 @@ namespace Rebellion.Tests.Systems
     [TestFixture]
     public class VictorySystemTests
     {
-        // Builds a two-faction scene where rebels own empire's HQ by default.
-        // Call site controls VictoryCondition and whether to flip the HQ.
         private (
             GameRoot game,
             Faction empire,
@@ -103,7 +101,6 @@ namespace Rebellion.Tests.Systems
                 GameVictoryCondition.Conquest
             );
 
-            // Leader must live on an empire-owned planet, not the captured HQ.
             Planet empirePlanet = new Planet
             {
                 InstanceID = "p_empire",
@@ -161,7 +158,6 @@ namespace Rebellion.Tests.Systems
         [Test]
         public void ProcessTick_HQCapturedConquestMode_NoMainCharacters_ReturnsVictoryResult()
         {
-            // If a faction has no main characters at all, treat as all captured (prevents softlock).
             (_, _, Faction rebels, _, VictorySystem system) = BuildScene(
                 GameVictoryCondition.Conquest
             );
@@ -206,6 +202,55 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_MobileHeadquartersMissing_ReturnsEmpty()
+        {
+            (_, Faction empire, _, _, VictorySystem system) = BuildScene(
+                rebelsCaptureEmpireHQ: false
+            );
+            empire.Settings = new FactionSettings
+            {
+                Headquarters = new HeadquartersSettings
+                {
+                    FacilityTypeID = "BDHQ01",
+                    IsMobile = true,
+                },
+            };
+
+            List<GameResult> results = system.ProcessTick();
+
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [Test]
+        public void ProcessTick_MobileHeadquartersOwnerIsUnknown_ReturnsEmpty()
+        {
+            (GameRoot game, Faction empire, _, Planet empireHQ, VictorySystem system) = BuildScene(
+                rebelsCaptureEmpireHQ: false
+            );
+            empire.Settings = new FactionSettings
+            {
+                Headquarters = new HeadquartersSettings
+                {
+                    FacilityTypeID = "BDHQ01",
+                    IsMobile = true,
+                },
+            };
+            empireHQ.EnergyCapacity = 1;
+            Building headquarters = new Building
+            {
+                InstanceID = "mobile-hq",
+                TypeID = "BDHQ01",
+                OwnerInstanceID = "unknown-faction",
+                BuildingType = BuildingType.Headquarters,
+            };
+            game.AttachNode(headquarters, empireHQ);
+
+            List<GameResult> results = system.ProcessTick();
+
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [Test]
         public void ProcessTick_MobileHeadquartersCaptured_ReturnsVictoryResult()
         {
             (GameRoot game, Faction empire, Faction rebels, Planet empireHQ, VictorySystem system) =
@@ -236,6 +281,30 @@ namespace Rebellion.Tests.Systems
             Assert.IsNotNull(victory);
             Assert.AreEqual(rebels, victory.Winner);
             Assert.AreEqual(empire, victory.Loser);
+        }
+
+        [Test]
+        public void HandleResults_MobileHeadquartersDestroyed_ReturnsVictory()
+        {
+            (GameRoot game, Faction empire, Faction rebels, Planet empireHQ, VictorySystem system) =
+                BuildScene(rebelsCaptureEmpireHQ: false);
+
+            List<GameResult> results = system.HandleResults(
+                new List<HeadquartersDestroyedResult>
+                {
+                    new HeadquartersDestroyedResult
+                    {
+                        Planet = empireHQ,
+                        Defender = empire,
+                        Attacker = rebels,
+                    },
+                }
+            );
+
+            VictoryResult victory = results[0] as VictoryResult;
+            Assert.IsNotNull(victory);
+            Assert.AreSame(rebels, victory.Winner);
+            Assert.AreSame(empire, victory.Loser);
         }
     }
 }

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/ContextMenus/StrategyContextMenuPresenterTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/ContextMenus/StrategyContextMenuPresenterTests.cs
@@ -104,6 +104,10 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.ContextMenus
                 .GetComponentsInChildren<RawImage>(true)
                 .Single(image => image.name == "IconImage");
             RectInt parentIconRect = UILayout.GetSourceRect(parentIcon.rectTransform);
+            RawImage checkIcon = rootRows[2]
+                .GetComponentsInChildren<RawImage>(true)
+                .Single(image => image.name == "IconImage");
+            RectInt checkIconRect = UILayout.GetSourceRect(checkIcon.rectTransform);
 
             Assert.IsTrue(_presenter.Open);
             Assert.AreSame(_window, _presenter.Window);
@@ -113,6 +117,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.ContextMenus
             Assert.AreEqual("Checked", FindCommandText(rootRows[2]).text);
             Assert.AreEqual("Child", FindCommandText(childRow).text);
             Assert.AreEqual(new RectInt(6, 0, 17, 20), parentIconRect);
+            Assert.AreEqual(new RectInt(4, 7, 14, 14), checkIconRect);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Finder/FinderWindowRowBuilderTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Finder/FinderWindowRowBuilderTests.cs
@@ -321,6 +321,46 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Finder
         }
 
         [Test]
+        public void GetRows_Personnel_ExcludesSpecialForcesShownByDedicatedPanel()
+        {
+            SpecialForces missionUnit = CreateSpecialForces(
+                "mission-spy",
+                "Mission Spy",
+                _playerFactionId
+            );
+            _alpha.Missions.Add(
+                new DiplomacyMission
+                {
+                    InstanceID = "mission",
+                    MainParticipants = new List<IMissionParticipant> { missionUnit },
+                }
+            );
+            CapitalShip ship = CreateCapitalShip("ship", "Ship", _playerFactionId);
+            ship.SpecialForces.Add(
+                CreateSpecialForces("fleet-commando", "Fleet Commando", _playerFactionId)
+            );
+            _alpha.Fleets.Add(CreateFleet("fleet", "Fleet", _playerFactionId, ship));
+            _alpha.SpecialForces.Add(
+                CreateSpecialForces("planet-commando", "Planet Commando", _playerFactionId)
+            );
+
+            List<FinderWindowRow> personnelRows = _builder.GetRows(
+                FinderMode.Personnel,
+                false,
+                FinderWindowTab.Faction(_playerFactionId, "Player")
+            );
+            List<FinderWindowRow> specialForcesRows = _builder.GetRows(
+                FinderMode.Personnel,
+                true,
+                FinderWindowTab.Faction(_playerFactionId, "Player")
+            );
+
+            Assert.IsEmpty(personnelRows);
+            Assert.AreEqual(1, specialForcesRows.Count);
+            CollectionAssert.AreEqual(new[] { 1, 1, 1 }, specialForcesRows[0].Counts);
+        }
+
+        [Test]
         public void GetRows_SpecialForces_AggregatesPlanetMissionAndFleetUnits()
         {
             _alpha.SpecialForces.Add(

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -31,6 +31,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                     "Build Facilities",
                     "Galaxy Overview",
                     "Objectives",
+                    "Manage Garrisons",
+                    "Manage Production",
                     "Translate Counterpart",
                     "Agent Advice",
                 },
@@ -43,6 +45,10 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             Assert.AreEqual(
                 StrategyContextMenuIconKeys.CheckMark,
                 commands.Single(command => command.Text == "Agent Advice").IconKey
+            );
+            Assert.AreEqual(
+                StrategyContextMenuIconKeys.None,
+                commands.Single(command => command.Text == "Manage Garrisons").IconKey
             );
         }
 

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowContextMenuBuilderTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowContextMenuBuilderTests.cs
@@ -81,6 +81,30 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSystem
         }
 
         [Test]
+        public void Create_MobileHeadquarters_ReturnsMoveCommands()
+        {
+            PlanetSystemWindowHit hit = CreateHit(PlanetIcon.None, true);
+            Building headquarters = new Building
+            {
+                BuildingType = BuildingType.Headquarters,
+                OwnerInstanceID = _playerFactionId,
+            };
+
+            List<StrategyMenuCommand> commands = PlanetSystemWindowContextMenuBuilder.Create(
+                hit,
+                new List<ISceneNode> { headquarters },
+                _playerFactionId,
+                headquarters
+            );
+
+            Assert.AreEqual(4, commands.Count);
+            Assert.AreEqual(StrategyMenuAction.Move, commands[0].Action);
+            Assert.IsTrue(commands[0].Enabled);
+            Assert.AreEqual(StrategyMenuAction.MoveConfirm, commands[1].Action);
+            Assert.IsTrue(commands[1].Enabled);
+        }
+
+        [Test]
         public void Create_EmptyFleetHit_ReturnsDisabledFleetCommands()
         {
             PlanetSystemWindowHit hit = CreateHit(PlanetIcon.Fleet, false);


### PR DESCRIPTION
## Summary

- Adds data-driven mobile headquarters behavior and Alliance HQ movement.
- Restores advisor automation controls for garrisons and production.
- Aligns espionage intelligence, message presentation, and personnel filtering with the original game.
- Omits entities from the encyclopedia unless their content explicitly defines encyclopedia data.
- Adds the original cursor support and corresponding runtime and UI fixes.

## Why

Several Strategy View systems remain incomplete or differ from the original game's behavior. This change completes those workflows while keeping faction and encyclopedia behavior content-driven.

## Validation

- Passes the standalone macOS player build.
- Passes 3,629 Unity EditMode tests.
- Passes formatting, analyzers, assembly builds, and lint.
- Reports 91.75% coverage in the real test session; the aggregate coverage command reports 78.8% because it also merges the zero-visit prefab-generation session.

Depends on the matching rebellion2-media content PR.