### PR TITLE
Adding modifiable faction briefings.

### DIFF
--- a/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
@@ -824,6 +824,22 @@ public static class StrategyViewPrefabBuilder
             CreateGalacticInformationDisplayView(root.transform);
 
         StrategyContextMenuPresenter contextMenu = CreateContextMenu(root.transform);
+        SaveMenuConfirmDialogView briefingSkipConfirmation =
+            SaveMenuPrefabBuilder.CreateConfirmDialog(root.transform);
+        RectTransform briefingConfirmationRect =
+            briefingSkipConfirmation.transform as RectTransform;
+        briefingConfirmationRect.anchorMin = new Vector2(0.5f, 0.5f);
+        briefingConfirmationRect.anchorMax = new Vector2(0.5f, 0.5f);
+        briefingConfirmationRect.pivot = new Vector2(0.5f, 0.5f);
+        briefingConfirmationRect.sizeDelta = new Vector2(_screenWidth, _screenHeight);
+        briefingConfirmationRect.anchoredPosition = Vector2.zero;
+        float briefingHorizontalOffset = (_screenWidth - 640f) / 2f;
+        foreach (RectTransform child in briefingConfirmationRect)
+        {
+            if (child.name != "InputBlocker")
+                child.anchoredPosition += Vector2.right * briefingHorizontalOffset;
+        }
+        briefingSkipConfirmation.transform.SetAsLastSibling();
 
         AssignReference(controller, "contentGroup", rootContentGroup);
         AssignReference(controller, "strategySurface", surfaceRect);
@@ -841,6 +857,7 @@ public static class StrategyViewPrefabBuilder
         AssignReference(windowsView, "modalBackgroundDimImage", modalBackgroundDim);
         AssignReference(controller, "galaxyMap", galaxyMapView);
         AssignReference(controller, "bookmarkBar", bookmarkBarView);
+        AssignReference(controller, "briefingSkipConfirmation", briefingSkipConfirmation);
         AssignReference(bookmarkBarView, "slotTemplate", bookmarkSlotTemplate);
         AssignWindowPrefabs(
             windowsView,

--- a/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
@@ -418,13 +418,13 @@ public static class StrategyViewPrefabBuilder
         RawImage protocolImage = CreateRawImage(
             "ProtocolImage",
             root.transform,
-            theme.GetFramePath(theme.ProtocolIdleBitmapID, 0, false),
+            theme.GetFramePath(theme.ProtocolIdleAnimation, 0, false),
             theme.ProtocolSourceLayout
         );
         RawImage droidImage = CreateRawImage(
             "DroidImage",
             root.transform,
-            theme.GetFramePath(theme.DroidIdleBitmapID, 0, true),
+            theme.GetFramePath(theme.DroidIdleAnimation, 0, true),
             theme.DroidSourceLayout
         );
         UIRaycastArea protocolInput = CreateHudButtonView(

--- a/Assets/Scripts/App/AppBootstrap.cs
+++ b/Assets/Scripts/App/AppBootstrap.cs
@@ -127,6 +127,7 @@ public sealed class AppBootstrap : MonoBehaviour
         if (_cutsceneManager == null)
             _cutsceneManager = gameObject.AddComponent<CutsceneManager>();
         _cutsceneManager.InitializeContent(_contentAssets);
+        _cutsceneManager.InitializeAudio(audioManager);
 
 #if UNITY_EDITOR
         GameObject cutscenePrefab = AssetDatabase.LoadAssetAtPath<GameObject>(

--- a/Assets/Scripts/App/SceneLoader.cs
+++ b/Assets/Scripts/App/SceneLoader.cs
@@ -27,6 +27,7 @@ public sealed class SceneLoader : MonoBehaviour
         if (_loadCoroutine != null)
             return;
 
+        AudioManager.Instance?.StopSfx();
         _loadCoroutine = StartCoroutine(LoadScene(sceneName));
     }
 

--- a/Assets/Scripts/Managers/AudioManager.cs
+++ b/Assets/Scripts/Managers/AudioManager.cs
@@ -38,6 +38,10 @@ public sealed class AudioManager : MonoBehaviour
     [SerializeField]
     private float ambienceVolume = 1f;
 
+    [Range(0f, 1f)]
+    [SerializeField]
+    private float videoVolume = 1f;
+
     private readonly Dictionary<string, AudioClip> _preloadedSfx = new Dictionary<
         string,
         AudioClip
@@ -98,6 +102,16 @@ public sealed class AudioManager : MonoBehaviour
     /// Gets the sound effect channel volume.
     /// </summary>
     public float SfxVolume => sfxVolume;
+
+    /// <summary>
+    /// Gets the unscaled video volume.
+    /// </summary>
+    public float VideoVolume => videoVolume;
+
+    /// <summary>
+    /// Gets the video volume after applying the master channel.
+    /// </summary>
+    public float EffectiveVideoVolume => videoVolume * masterVolume;
 
     /// <summary>
     /// Gets the ambience channel volume.
@@ -431,6 +445,15 @@ public sealed class AudioManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Stops sound-effect playback immediately.
+    /// </summary>
+    public void StopSfx()
+    {
+        EnsureAudioSources();
+        sfxSource.Stop();
+    }
+
+    /// <summary>
     /// Plays ambience from an already loaded clip.
     /// </summary>
     /// <param name="clip">The ambience clip to play.</param>
@@ -460,6 +483,7 @@ public sealed class AudioManager : MonoBehaviour
         musicVolume = settings.MusicVolume;
         sfxVolume = settings.SfxVolume;
         ambienceVolume = settings.AmbienceVolume;
+        videoVolume = settings.VideoVolume;
 
         ApplyVolumes();
     }
@@ -476,6 +500,7 @@ public sealed class AudioManager : MonoBehaviour
             MusicVolume = musicVolume,
             SfxVolume = sfxVolume,
             AmbienceVolume = ambienceVolume,
+            VideoVolume = videoVolume,
         };
     }
 
@@ -517,6 +542,15 @@ public sealed class AudioManager : MonoBehaviour
     {
         ambienceVolume = Mathf.Clamp01(volume);
         ApplyVolumes();
+    }
+
+    /// <summary>
+    /// Sets the video channel volume.
+    /// </summary>
+    /// <param name="volume">The requested volume.</param>
+    public void SetVideoVolume(float volume)
+    {
+        videoVolume = Mathf.Clamp01(volume);
     }
 
     /// <summary>

--- a/Assets/Scripts/Managers/AudioManager.cs
+++ b/Assets/Scripts/Managers/AudioManager.cs
@@ -454,6 +454,24 @@ public sealed class AudioManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Pauses active sound-effect playback without resetting its position.
+    /// </summary>
+    public void PauseSfx()
+    {
+        EnsureAudioSources();
+        sfxSource.Pause();
+    }
+
+    /// <summary>
+    /// Resumes sound-effect playback from its paused position.
+    /// </summary>
+    public void ResumeSfx()
+    {
+        EnsureAudioSources();
+        sfxSource.UnPause();
+    }
+
+    /// <summary>
     /// Plays ambience from an already loaded clip.
     /// </summary>
     /// <param name="clip">The ambience clip to play.</param>

--- a/Assets/Scripts/UI/Runtime/Themes/FactionTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/FactionTheme.cs
@@ -26,6 +26,8 @@ public class FactionTheme
 
     public StrategyAdvisorTheme StrategyAdvisor { get; set; }
 
+    public StrategyBriefingTheme StrategyBriefing { get; set; }
+
     public GalaxyBackground GalaxyBackground { get; set; }
 
     public GalacticInformationDisplayTheme GalacticInformationDisplay { get; set; }

--- a/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
@@ -17,14 +17,29 @@ public class StrategyAdvisorAnimationTheme
     public float DelayBeforeSeconds { get; set; }
 
     public bool RequiresAnnouncementsEnabled { get; set; }
+}
 
-    public StrategyBriefingFocus BriefingFocus { get; set; }
+/// <summary>
+/// Defines one ordered briefing segment and its galaxy-map presentation.
+/// </summary>
+[PersistableObject(Name = "Segment")]
+public class StrategyBriefingSegmentTheme
+{
+    public string Animation { get; set; }
 
-    public StrategyBriefingMapMode BriefingMapMode { get; set; }
+    public int FrameCount { get; set; }
 
-    public string BriefingTargetInstanceID { get; set; }
+    public string Audio { get; set; }
 
-    public string BriefingLabel { get; set; }
+    public float DelayBeforeSeconds { get; set; }
+
+    public StrategyBriefingFocus Focus { get; set; }
+
+    public StrategyBriefingMapMode MapMode { get; set; }
+
+    public string TargetInstanceID { get; set; }
+
+    public string Label { get; set; }
 }
 
 public enum StrategyBriefingFocus
@@ -64,10 +79,10 @@ public class StrategyBriefingTheme
 
     public string AudioRoot { get; set; }
 
-    public List<StrategyAdvisorAnimationTheme> Segments { get; set; } =
-        new List<StrategyAdvisorAnimationTheme>();
+    public List<StrategyBriefingSegmentTheme> Segments { get; set; } =
+        new List<StrategyBriefingSegmentTheme>();
 
-    public StrategyAdvisorAnimationTheme Skip { get; set; }
+    public StrategyBriefingSegmentTheme Skip { get; set; }
 
     /// <summary>
     /// Builds the active faction's briefing preload manifest so playback never performs disk
@@ -117,7 +132,7 @@ public class StrategyBriefingTheme
     /// <param name="audioNames">The audio names already added.</param>
     /// <param name="manifest">The manifest receiving distinct content addresses.</param>
     private void AddPreloadAssets(
-        StrategyAdvisorAnimationTheme segment,
+        StrategyBriefingSegmentTheme segment,
         ISet<string> animations,
         ISet<string> audioNames,
         ContentPreloadManifest manifest

--- a/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
@@ -62,8 +62,6 @@ public class StrategyBriefingTheme
 
     public string AnimationImageRoot { get; set; }
 
-    public string AnimationFilePrefix { get; set; }
-
     public string AudioRoot { get; set; }
 
     public string AudioFilePrefix { get; set; }
@@ -100,7 +98,7 @@ public class StrategyBriefingTheme
     /// <returns>The external content address for the frame.</returns>
     public string GetFramePath(int bitmapID, int frameIndex)
     {
-        return $"{AnimationImageRoot}/{bitmapID}/{AnimationFilePrefix}-protocol-{bitmapID}-frame-{frameIndex:D3}";
+        return $"{AnimationImageRoot}/{bitmapID}/frame-{frameIndex:D3}";
     }
 
     /// <summary>
@@ -206,8 +204,6 @@ public class StrategyAdvisorTheme
 
     public string AnimationImageRoot { get; set; }
 
-    public string AnimationFilePrefix { get; set; }
-
     public string AudioRoot { get; set; }
 
     public string AudioFilePrefix { get; set; }
@@ -296,9 +292,8 @@ public class StrategyAdvisorTheme
     /// <returns>The animation frame resource path.</returns>
     public string GetFramePath(int bitmapID, int frameIndex, bool droid)
     {
-        string roleDirectory = droid ? "Droid" : "Protocol";
-        string roleName = droid ? "droid" : "protocol";
-        return $"{AnimationImageRoot}/{roleDirectory}/{bitmapID}/{AnimationFilePrefix}-{roleName}-{bitmapID}-frame-{frameIndex:D3}";
+        string roleDirectory = droid ? "Alert" : "Report";
+        return $"{AnimationImageRoot}/{roleDirectory}/{bitmapID}/frame-{frameIndex:D3}";
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
@@ -42,6 +42,9 @@ public class StrategyBriefingSegmentTheme
     public string Label { get; set; }
 }
 
+/// <summary>
+/// Identifies the game object or galaxy region emphasized during a briefing segment.
+/// </summary>
 public enum StrategyBriefingFocus
 {
     None,

--- a/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
@@ -8,11 +8,11 @@ using Rebellion.Util.Serialization;
 [PersistableObject]
 public class StrategyAdvisorAnimationTheme
 {
-    public int BitmapID { get; set; }
+    public string Animation { get; set; }
 
     public int FrameCount { get; set; }
 
-    public int WaveID { get; set; }
+    public string Audio { get; set; }
 
     public float DelayBeforeSeconds { get; set; }
 
@@ -64,8 +64,6 @@ public class StrategyBriefingTheme
 
     public string AudioRoot { get; set; }
 
-    public string AudioFilePrefix { get; set; }
-
     public List<StrategyAdvisorAnimationTheme> Segments { get; set; } =
         new List<StrategyAdvisorAnimationTheme>();
 
@@ -82,56 +80,56 @@ public class StrategyBriefingTheme
         {
             TexturesPerFrame = _texturesPerFrame,
         };
-        HashSet<int> bitmapIDs = new HashSet<int>();
-        HashSet<int> waveIDs = new HashSet<int>();
+        HashSet<string> animations = new HashSet<string>();
+        HashSet<string> audioNames = new HashSet<string>();
         for (int i = 0; i < Segments.Count; i++)
-            AddPreloadAssets(Segments[i], bitmapIDs, waveIDs, manifest);
-        AddPreloadAssets(Skip, bitmapIDs, waveIDs, manifest);
+            AddPreloadAssets(Segments[i], animations, audioNames, manifest);
+        AddPreloadAssets(Skip, animations, audioNames, manifest);
         return manifest;
     }
 
     /// <summary>
     /// Builds the content address for one briefing animation frame.
     /// </summary>
-    /// <param name="bitmapID">The source animation bitmap identifier.</param>
+    /// <param name="animation">The configured animation name.</param>
     /// <param name="frameIndex">The zero-based frame index.</param>
     /// <returns>The external content address for the frame.</returns>
-    public string GetFramePath(int bitmapID, int frameIndex)
+    public string GetFramePath(string animation, int frameIndex)
     {
-        return $"{AnimationImageRoot}/{bitmapID}/frame-{frameIndex:D3}";
+        return $"{AnimationImageRoot}/{animation}/frame-{frameIndex:D3}";
     }
 
     /// <summary>
     /// Builds the content address for one briefing voice clip.
     /// </summary>
-    /// <param name="waveID">The source wave resource identifier.</param>
+    /// <param name="audio">The configured audio name.</param>
     /// <returns>The external content address for the voice clip.</returns>
-    public string GetAudioPath(int waveID)
+    public string GetAudioPath(string audio)
     {
-        return $"{AudioRoot}/{AudioFilePrefix}-{waveID:D4}";
+        return $"{AudioRoot}/{audio}";
     }
 
     /// <summary>
     /// Adds one segment's distinct animation directory and voice clip to a preload manifest.
     /// </summary>
     /// <param name="segment">The configured briefing segment.</param>
-    /// <param name="bitmapIDs">The bitmap identifiers already added.</param>
-    /// <param name="waveIDs">The wave identifiers already added.</param>
+    /// <param name="animations">The animation names already added.</param>
+    /// <param name="audioNames">The audio names already added.</param>
     /// <param name="manifest">The manifest receiving distinct content addresses.</param>
     private void AddPreloadAssets(
         StrategyAdvisorAnimationTheme segment,
-        ISet<int> bitmapIDs,
-        ISet<int> waveIDs,
+        ISet<string> animations,
+        ISet<string> audioNames,
         ContentPreloadManifest manifest
     )
     {
         if (segment == null)
             return;
 
-        if (segment.BitmapID > 0 && bitmapIDs.Add(segment.BitmapID))
-            manifest.TextureDirectories.Add($"{AnimationImageRoot}/{segment.BitmapID}");
-        if (segment.WaveID > 0 && waveIDs.Add(segment.WaveID))
-            manifest.Audio.Add(GetAudioPath(segment.WaveID));
+        if (!string.IsNullOrWhiteSpace(segment.Animation) && animations.Add(segment.Animation))
+            manifest.TextureDirectories.Add($"{AnimationImageRoot}/{segment.Animation}");
+        if (!string.IsNullOrWhiteSpace(segment.Audio) && audioNames.Add(segment.Audio))
+            manifest.Audio.Add(GetAudioPath(segment.Audio));
     }
 }
 
@@ -206,11 +204,9 @@ public class StrategyAdvisorTheme
 
     public string AudioRoot { get; set; }
 
-    public string AudioFilePrefix { get; set; }
+    public string ProtocolIdleAnimation { get; set; }
 
-    public int ProtocolIdleBitmapID { get; set; }
-
-    public int DroidIdleBitmapID { get; set; }
+    public string DroidIdleAnimation { get; set; }
 
     public float FrameIntervalSeconds { get; set; }
 
@@ -286,23 +282,23 @@ public class StrategyAdvisorTheme
     /// <summary>
     /// Builds the resource path for an advisor animation frame.
     /// </summary>
-    /// <param name="bitmapID">The animation bitmap identifier.</param>
+    /// <param name="animation">The configured animation name.</param>
     /// <param name="frameIndex">The zero-based frame index.</param>
     /// <param name="droid">Whether the frame belongs to the droid advisor.</param>
     /// <returns>The animation frame resource path.</returns>
-    public string GetFramePath(int bitmapID, int frameIndex, bool droid)
+    public string GetFramePath(string animation, int frameIndex, bool droid)
     {
         string roleDirectory = droid ? "Alert" : "Report";
-        return $"{AnimationImageRoot}/{roleDirectory}/{bitmapID}/frame-{frameIndex:D3}";
+        return $"{AnimationImageRoot}/{roleDirectory}/{animation}/frame-{frameIndex:D3}";
     }
 
     /// <summary>
     /// Builds the resource path for an advisor audio clip.
     /// </summary>
-    /// <param name="waveID">The audio wave identifier.</param>
+    /// <param name="audio">The configured audio name.</param>
     /// <returns>The advisor audio resource path.</returns>
-    public string GetAudioPath(int waveID)
+    public string GetAudioPath(string audio)
     {
-        return $"{AudioRoot}/{AudioFilePrefix}-{waveID:D4}";
+        return $"{AudioRoot}/{audio}";
     }
 }

--- a/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
@@ -14,7 +14,127 @@ public class StrategyAdvisorAnimationTheme
 
     public int WaveID { get; set; }
 
+    public float DelayBeforeSeconds { get; set; }
+
     public bool RequiresAnnouncementsEnabled { get; set; }
+
+    public StrategyBriefingFocus BriefingFocus { get; set; }
+
+    public StrategyBriefingMapMode BriefingMapMode { get; set; }
+
+    public string BriefingTargetInstanceID { get; set; }
+
+    public string BriefingLabel { get; set; }
+}
+
+public enum StrategyBriefingFocus
+{
+    None,
+    Galaxy,
+    Target,
+    PlayerHeadquarters,
+    OpponentHeadquarters,
+}
+
+/// <summary>
+/// Identifies the galaxy-map presentation shown while one briefing segment plays.
+/// </summary>
+public enum StrategyBriefingMapMode
+{
+    Default,
+    PopularSupport,
+    PlayerLoyalty,
+    OpponentLoyalty,
+    MilitaryControl,
+    UnexploredSystems,
+    IdleFleets,
+    AllDefenses,
+    Spotlight,
+}
+
+/// <summary>
+/// Defines a faction's ordered new-game briefing using externally supplied advisor media.
+/// </summary>
+[PersistableObject]
+public class StrategyBriefingTheme
+{
+    private const int _texturesPerFrame = 64;
+
+    public string AnimationImageRoot { get; set; }
+
+    public string AnimationFilePrefix { get; set; }
+
+    public string AudioRoot { get; set; }
+
+    public string AudioFilePrefix { get; set; }
+
+    public List<StrategyAdvisorAnimationTheme> Segments { get; set; } =
+        new List<StrategyAdvisorAnimationTheme>();
+
+    public StrategyAdvisorAnimationTheme Skip { get; set; }
+
+    /// <summary>
+    /// Builds the active faction's briefing preload manifest so playback never performs disk
+    /// decoding between spoken segments.
+    /// </summary>
+    /// <returns>The textures and audio required by the complete briefing.</returns>
+    public ContentPreloadManifest CreatePreloadManifest()
+    {
+        ContentPreloadManifest manifest = new ContentPreloadManifest
+        {
+            TexturesPerFrame = _texturesPerFrame,
+        };
+        HashSet<int> bitmapIDs = new HashSet<int>();
+        HashSet<int> waveIDs = new HashSet<int>();
+        for (int i = 0; i < Segments.Count; i++)
+            AddPreloadAssets(Segments[i], bitmapIDs, waveIDs, manifest);
+        AddPreloadAssets(Skip, bitmapIDs, waveIDs, manifest);
+        return manifest;
+    }
+
+    /// <summary>
+    /// Builds the content address for one briefing animation frame.
+    /// </summary>
+    /// <param name="bitmapID">The source animation bitmap identifier.</param>
+    /// <param name="frameIndex">The zero-based frame index.</param>
+    /// <returns>The external content address for the frame.</returns>
+    public string GetFramePath(int bitmapID, int frameIndex)
+    {
+        return $"{AnimationImageRoot}/{bitmapID}/{AnimationFilePrefix}-protocol-{bitmapID}-frame-{frameIndex:D3}";
+    }
+
+    /// <summary>
+    /// Builds the content address for one briefing voice clip.
+    /// </summary>
+    /// <param name="waveID">The source wave resource identifier.</param>
+    /// <returns>The external content address for the voice clip.</returns>
+    public string GetAudioPath(int waveID)
+    {
+        return $"{AudioRoot}/{AudioFilePrefix}-{waveID:D4}";
+    }
+
+    /// <summary>
+    /// Adds one segment's distinct animation directory and voice clip to a preload manifest.
+    /// </summary>
+    /// <param name="segment">The configured briefing segment.</param>
+    /// <param name="bitmapIDs">The bitmap identifiers already added.</param>
+    /// <param name="waveIDs">The wave identifiers already added.</param>
+    /// <param name="manifest">The manifest receiving distinct content addresses.</param>
+    private void AddPreloadAssets(
+        StrategyAdvisorAnimationTheme segment,
+        ISet<int> bitmapIDs,
+        ISet<int> waveIDs,
+        ContentPreloadManifest manifest
+    )
+    {
+        if (segment == null)
+            return;
+
+        if (segment.BitmapID > 0 && bitmapIDs.Add(segment.BitmapID))
+            manifest.TextureDirectories.Add($"{AnimationImageRoot}/{segment.BitmapID}");
+        if (segment.WaveID > 0 && waveIDs.Add(segment.WaveID))
+            manifest.Audio.Add(GetAudioPath(segment.WaveID));
+    }
 }
 
 /// <summary>

--- a/Assets/Scripts/UI/SceneUI/Cutscenes/CutsceneManager.cs
+++ b/Assets/Scripts/UI/SceneUI/Cutscenes/CutsceneManager.cs
@@ -18,6 +18,7 @@ public sealed class CutsceneManager : MonoBehaviour
 
     private GameObject cutscenePrefab;
     private ContentAssets contentAssets;
+    private AudioManager audioManager;
 
     private CutscenePlayer activePlayer;
     private bool ownsTimePause;
@@ -41,6 +42,15 @@ public sealed class CutsceneManager : MonoBehaviour
     internal void InitializeContent(ContentAssets assets)
     {
         contentAssets = assets ?? throw new ArgumentNullException(nameof(assets));
+    }
+
+    /// <summary>
+    /// Binds the application audio settings used by cutscene playback.
+    /// </summary>
+    /// <param name="manager">The active application audio manager.</param>
+    internal void InitializeAudio(AudioManager manager)
+    {
+        audioManager = manager ?? throw new ArgumentNullException(nameof(manager));
     }
 
     /// <summary>
@@ -117,6 +127,7 @@ public sealed class CutsceneManager : MonoBehaviour
         }
 
         activePlayer = player;
+        player.SetVolume(GetVideoVolume());
         PauseTimeScale();
         try
         {
@@ -151,6 +162,7 @@ public sealed class CutsceneManager : MonoBehaviour
         }
 
         activePlayer = player;
+        player.SetVolume(GetVideoVolume());
         PauseTimeScale();
         try
         {
@@ -162,6 +174,15 @@ public sealed class CutsceneManager : MonoBehaviour
             RestoreTimeScale();
             throw;
         }
+    }
+
+    /// <summary>
+    /// Gets the effective volume for a newly created cutscene player.
+    /// </summary>
+    /// <returns>The master-scaled video volume.</returns>
+    private float GetVideoVolume()
+    {
+        return audioManager?.EffectiveVideoVolume ?? 1f;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/Cutscenes/CutscenePlayer.cs
+++ b/Assets/Scripts/UI/SceneUI/Cutscenes/CutscenePlayer.cs
@@ -28,6 +28,15 @@ public sealed class CutscenePlayer : MonoBehaviour
     private Color authoredScreenColor;
 
     /// <summary>
+    /// Applies the effective volume for video playback.
+    /// </summary>
+    /// <param name="volume">The master-scaled video volume.</param>
+    internal void SetVolume(float volume)
+    {
+        audioSource.volume = Mathf.Clamp01(volume);
+    }
+
+    /// <summary>
     /// Configures video playback defaults.
     /// </summary>
     private void Awake()

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapController.cs
@@ -46,6 +46,7 @@ public sealed class GalaxyMapController
     private IGalaxyMapActions actions;
     private GalaxyMapView view;
     private GalaxyMap visibleGalaxyMap;
+    private StrategyBriefingMapPresentation briefingPresentation;
     private string hoveredSystemInstanceId;
     private string playerFactionId = string.Empty;
 
@@ -143,8 +144,25 @@ public sealed class GalaxyMapController
         RebuildDomainLookups(sectors);
         GetRequiredView()
             .Render(
-                projector.Project(sectors, playerFactionId, filterMode, hoveredSystemInstanceId)
+                projector.Project(
+                    sectors,
+                    playerFactionId,
+                    filterMode,
+                    hoveredSystemInstanceId,
+                    briefingPresentation
+                )
             );
+    }
+
+    /// <summary>
+    /// Applies the transient galaxy presentation configured for one briefing segment.
+    /// </summary>
+    /// <param name="presentation">The segment presentation, or null to restore normal display.</param>
+    public void SetBriefingPresentation(StrategyBriefingMapPresentation presentation)
+    {
+        briefingPresentation = presentation;
+        hoveredSystemInstanceId = presentation?.TargetSystemInstanceID;
+        actions.RequestGalaxyMapRender();
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjector.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Rebellion.Game.Galaxy;
+using Rebellion.Game.Units;
+using Rebellion.Util.Extensions;
 using UnityEngine;
 
 /// <summary>
@@ -28,15 +31,18 @@ public sealed class GalaxyMapProjector
     /// <param name="playerFactionId">The viewing player's faction identifier.</param>
     /// <param name="filterMode">The active galactic-information filter.</param>
     /// <param name="hoveredSystemInstanceId">The planet-system identifier whose label is revealed.</param>
+    /// <param name="briefing">The transient briefing presentation, or null.</param>
     /// <returns>The complete immutable map presentation.</returns>
     public GalaxyMapRenderData Project(
         IReadOnlyList<GalaxyMapSector> sectors,
         string playerFactionId,
         GalacticInformationFilterMode filterMode,
-        string hoveredSystemInstanceId
+        string hoveredSystemInstanceId,
+        StrategyBriefingMapPresentation briefing = null
     )
     {
         UIContext context = GetRequiredContext();
+        hoveredSystemInstanceId = briefing?.TargetSystemInstanceID ?? hoveredSystemInstanceId;
         FactionTheme playerTheme = context.GetPlayerFactionTheme();
         GalacticInformationFilterTheme filter = ResolveFilter(playerTheme, filterMode);
         List<GalaxyMapClusterRenderData> clusters = ProjectClusters(
@@ -44,14 +50,19 @@ public sealed class GalaxyMapProjector
             playerFactionId,
             filter,
             hoveredSystemInstanceId,
-            context
+            context,
+            briefing
         );
 
         Texture2D backgroundTexture = context.GetTexture(playerTheme?.GalaxyBackground?.ImagePath);
         return new GalaxyMapRenderData(
             backgroundTexture,
             GetBackgroundBounds(backgroundTexture, playerTheme?.GalaxyBackground?.SourcePosition),
-            ProjectActiveFilterLabel(playerTheme?.GalacticInformationDisplay, filter),
+            ProjectActiveFilterLabel(
+                playerTheme?.GalacticInformationDisplay,
+                filter,
+                briefing?.Label
+            ),
             clusters
         );
     }
@@ -85,18 +96,21 @@ public sealed class GalaxyMapProjector
     /// </summary>
     /// <param name="theme">The active faction's galactic-information theme.</param>
     /// <param name="filter">The active filter, or null when display is off.</param>
+    /// <param name="labelOverride">The transient briefing label, or null.</param>
     /// <returns>The active filter label presentation.</returns>
     private static GalaxyMapActiveFilterLabelRenderData ProjectActiveFilterLabel(
         GalacticInformationDisplayTheme theme,
-        GalacticInformationFilterTheme filter
+        GalacticInformationFilterTheme filter,
+        string labelOverride
     )
     {
         SourceRectLayout layout = theme?.ActiveFilterLabelSourceLayout;
-        if (filter == null || layout == null)
+        string label = labelOverride ?? filter?.Label;
+        if (string.IsNullOrEmpty(label) || layout == null)
             return default;
 
         return new GalaxyMapActiveFilterLabelRenderData(
-            filter.Label,
+            label,
             theme.GetActiveFilterLabelColor(),
             new RectInt(layout.X, layout.Y, layout.Width, layout.Height),
             theme.ActiveFilterLabelFontSize
@@ -149,13 +163,15 @@ public sealed class GalaxyMapProjector
     /// <param name="filter">The active filter configuration, or null when display is off.</param>
     /// <param name="hoveredSystemInstanceId">The planet-system identifier whose label is revealed.</param>
     /// <param name="context">The current strategy UI context.</param>
+    /// <param name="briefing">The transient briefing presentation, or null.</param>
     /// <returns>The projected cluster presentations.</returns>
     private static List<GalaxyMapClusterRenderData> ProjectClusters(
         IReadOnlyList<GalaxyMapSector> sectors,
         string playerFactionId,
         GalacticInformationFilterTheme filter,
         string hoveredSystemInstanceId,
-        UIContext context
+        UIContext context,
+        StrategyBriefingMapPresentation briefing
     )
     {
         List<GalaxyMapClusterRenderData> clusters = new List<GalaxyMapClusterRenderData>();
@@ -179,7 +195,7 @@ public sealed class GalaxyMapProjector
                         hoveredSystemInstanceId,
                         StringComparison.Ordinal
                     ),
-                    ProjectStars(sector, playerFactionId, filter, context, systemPosition)
+                    ProjectStars(sector, playerFactionId, filter, context, systemPosition, briefing)
                 )
             );
         }
@@ -195,13 +211,15 @@ public sealed class GalaxyMapProjector
     /// <param name="filter">The active filter configuration, or null when display is off.</param>
     /// <param name="context">The current strategy UI context.</param>
     /// <param name="systemPosition">The sector's source-space map position.</param>
+    /// <param name="briefing">The transient briefing presentation, or null.</param>
     /// <returns>The projected marker presentations.</returns>
     private static List<GalaxyMapStarRenderData> ProjectStars(
         GalaxyMapSector sector,
         string playerFactionId,
         GalacticInformationFilterTheme filter,
         UIContext context,
-        System.Drawing.Point systemPosition
+        System.Drawing.Point systemPosition,
+        StrategyBriefingMapPresentation briefing
     )
     {
         List<GalaxyMapStarRenderData> stars = new List<GalaxyMapStarRenderData>();
@@ -211,18 +229,20 @@ public sealed class GalaxyMapProjector
                 continue;
 
             GalacticInformationMarker marker =
-                filter == null
+                briefing != null && briefing.Mode != StrategyBriefingMapMode.Default
+                    ? EvaluateBriefingMarker(planet.Planet, briefing, context)
+                : filter == null
                     ? new GalacticInformationMarker(
                         _defaultMarkerIndex,
                         planet.Planet.OwnerInstanceID,
                         false
                     )
-                    : GalacticInformationFilterEvaluator.Evaluate(
-                        context.Game,
-                        planet.Planet,
-                        playerFactionId,
-                        filter
-                    );
+                : GalacticInformationFilterEvaluator.Evaluate(
+                    context.Game,
+                    planet.Planet,
+                    playerFactionId,
+                    filter
+                );
             System.Drawing.Point planetPosition = planet.Planet.GetPosition();
             stars.Add(
                 new GalaxyMapStarRenderData(
@@ -236,6 +256,131 @@ public sealed class GalaxyMapProjector
         }
 
         return stars;
+    }
+
+    /// <summary>
+    /// Evaluates the original briefing-only map modes without exposing them in the player menu.
+    /// </summary>
+    /// <param name="planet">The visible planet snapshot.</param>
+    /// <param name="briefing">The active briefing map cue.</param>
+    /// <param name="context">The current strategy UI context.</param>
+    /// <returns>The briefing-specific marker presentation.</returns>
+    private static GalacticInformationMarker EvaluateBriefingMarker(
+        Planet planet,
+        StrategyBriefingMapPresentation briefing,
+        UIContext context
+    )
+    {
+        if (briefing.Mode == StrategyBriefingMapMode.Spotlight)
+        {
+            bool highlighted = string.Equals(
+                planet.InstanceID,
+                briefing.TargetPlanetInstanceID,
+                StringComparison.Ordinal
+            );
+            return new GalacticInformationMarker(
+                highlighted ? 3 : 0,
+                highlighted ? planet.OwnerInstanceID : null,
+                false
+            );
+        }
+
+        if (briefing.Mode == StrategyBriefingMapMode.PopularSupport)
+        {
+            GalacticInformationFilterTheme filter = context
+                .GetPlayerFactionTheme()
+                ?.GalacticInformationDisplay?.GetFilter(
+                    GalacticInformationFilterMode.PopularSupport
+                );
+            return GalacticInformationFilterEvaluator.Evaluate(
+                context.Game,
+                planet,
+                briefing.PlayerFactionInstanceID,
+                filter
+            );
+        }
+
+        if (briefing.Mode == StrategyBriefingMapMode.IdleFleets)
+        {
+            GalacticInformationFilterTheme filter = context
+                .GetPlayerFactionTheme()
+                ?.GalacticInformationDisplay?.GetFilter(GalacticInformationFilterMode.IdleFleets);
+            return GalacticInformationFilterEvaluator.Evaluate(
+                context.Game,
+                planet,
+                briefing.PlayerFactionInstanceID,
+                filter
+            );
+        }
+
+        string highlightedFaction = briefing.Mode switch
+        {
+            StrategyBriefingMapMode.PlayerLoyalty => briefing.PlayerFactionInstanceID,
+            StrategyBriefingMapMode.OpponentLoyalty => briefing.OpponentFactionInstanceID,
+            _ => null,
+        };
+        if (highlightedFaction != null)
+        {
+            string otherFaction = string.Equals(
+                highlightedFaction,
+                briefing.PlayerFactionInstanceID,
+                StringComparison.Ordinal
+            )
+                ? briefing.OpponentFactionInstanceID
+                : briefing.PlayerFactionInstanceID;
+            bool highlighted =
+                planet.GetPopularSupport(highlightedFaction)
+                > planet.GetPopularSupport(otherFaction);
+            return new GalacticInformationMarker(
+                highlighted ? 3 : 0,
+                highlighted ? highlightedFaction : planet.OwnerInstanceID,
+                false
+            );
+        }
+
+        if (briefing.Mode == StrategyBriefingMapMode.UnexploredSystems)
+        {
+            return new GalacticInformationMarker(
+                planet.IsUnexploredView ? 3 : 0,
+                planet.IsUnexploredView ? briefing.PlayerFactionInstanceID : planet.OwnerInstanceID,
+                false
+            );
+        }
+
+        if (briefing.Mode == StrategyBriefingMapMode.MilitaryControl)
+        {
+            bool controlled = !string.IsNullOrEmpty(planet.OwnerInstanceID);
+            return new GalacticInformationMarker(
+                controlled ? 3 : 0,
+                controlled ? planet.OwnerInstanceID : null,
+                false
+            );
+        }
+
+        int defenseCount =
+            planet.Regiments.Count(IsActive)
+            + planet.Starfighters.Count(IsActive)
+            + planet.Buildings.Count(building =>
+                building.ManufacturingStatus == ManufacturingStatus.Complete
+                && building.DefenseFacilityClass != DefenseFacilityClass.None
+            );
+        return new GalacticInformationMarker(
+            Math.Min(3, defenseCount),
+            planet.OwnerInstanceID,
+            false
+        );
+    }
+
+    /// <summary>
+    /// Determines whether a manufacturable unit is complete and stationary.
+    /// </summary>
+    /// <param name="entity">The unit or facility to inspect.</param>
+    /// <returns>True when the entity contributes to an active-defense count.</returns>
+    private static bool IsActive(IManufacturable entity)
+    {
+        return entity != null
+            && entity.GetManufacturingStatus() == ManufacturingStatus.Complete
+            && entity.GetTransitMovement() == null;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjector.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 public sealed class GalaxyMapProjector
 {
     private const int _defaultMarkerIndex = 0;
+    private static readonly Color _dimmedBackgroundColor = new Color(0.5f, 0.5f, 0.5f, 1f);
 
     private readonly Func<UIContext> getUIContext;
 
@@ -58,6 +59,7 @@ public sealed class GalaxyMapProjector
         return new GalaxyMapRenderData(
             backgroundTexture,
             GetBackgroundBounds(backgroundTexture, playerTheme?.GalaxyBackground?.SourcePosition),
+            briefing?.DimBackground == true ? _dimmedBackgroundColor : Color.white,
             ProjectActiveFilterLabel(
                 playerTheme?.GalacticInformationDisplay,
                 filter,
@@ -249,7 +251,12 @@ public sealed class GalaxyMapProjector
                     planet.Planet.InstanceID,
                     planetPosition.X - systemPosition.X,
                     planetPosition.Y - systemPosition.Y,
-                    ResolveStarTexture(context, planet.Planet, marker),
+                    ResolveStarTexture(
+                        context,
+                        planet.Planet,
+                        marker,
+                        briefing?.Mode == StrategyBriefingMapMode.UnexploredSystems
+                    ),
                     ResolveHeadquartersTexture(context, planet.Planet)
                 )
             );
@@ -342,7 +349,7 @@ public sealed class GalaxyMapProjector
         {
             return new GalacticInformationMarker(
                 planet.IsUnexploredView ? 3 : 0,
-                planet.IsUnexploredView ? briefing.PlayerFactionInstanceID : planet.OwnerInstanceID,
+                planet.IsUnexploredView ? null : planet.OwnerInstanceID,
                 false
             );
         }
@@ -357,17 +364,26 @@ public sealed class GalaxyMapProjector
             );
         }
 
-        int defenseCount =
-            planet.Regiments.Count(IsActive)
-            + planet.Starfighters.Count(IsActive)
-            + planet.Buildings.Count(building =>
-                building.ManufacturingStatus == ManufacturingStatus.Complete
-                && building.DefenseFacilityClass != DefenseFacilityClass.None
+        if (briefing.Mode == StrategyBriefingMapMode.AllDefenses)
+        {
+            int defenseCount =
+                planet.Regiments.Count(IsActive)
+                + planet.Starfighters.Count(IsActive)
+                + planet.Buildings.Count(building =>
+                    building.ManufacturingStatus == ManufacturingStatus.Complete
+                    && building.DefenseFacilityClass != DefenseFacilityClass.None
+                );
+            return new GalacticInformationMarker(
+                Math.Min(3, defenseCount),
+                planet.OwnerInstanceID,
+                false
             );
-        return new GalacticInformationMarker(
-            Math.Min(3, defenseCount),
-            planet.OwnerInstanceID,
-            false
+        }
+
+        throw new ArgumentOutOfRangeException(
+            nameof(briefing),
+            briefing.Mode,
+            "Unsupported briefing map mode."
         );
     }
 
@@ -405,14 +421,16 @@ public sealed class GalaxyMapProjector
     /// <param name="context">The current strategy UI context.</param>
     /// <param name="planet">The visible planet.</param>
     /// <param name="marker">The evaluated marker result.</param>
+    /// <param name="highlightUnexplored">Whether unexplored planets use the briefing highlight.</param>
     /// <returns>The resolved marker texture.</returns>
     private static Texture2D ResolveStarTexture(
         UIContext context,
         Planet planet,
-        GalacticInformationMarker marker
+        GalacticInformationMarker marker,
+        bool highlightUnexplored
     )
     {
-        if (planet.IsUnexploredView)
+        if (planet.IsUnexploredView && !highlightUnexplored)
         {
             return context.GetTexture(
                 context.GetPlayerFactionTheme()?.GalaxyBackground?.UnexploredPlanetIconPath

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapRenderData.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapRenderData.cs
@@ -17,13 +17,15 @@ public sealed class StrategyBriefingMapPresentation
     /// <param name="targetPlanetInstanceID">The spotlighted planet identifier, or null.</param>
     /// <param name="playerFactionInstanceID">The player faction identifier.</param>
     /// <param name="opponentFactionInstanceID">The opposing faction identifier.</param>
+    /// <param name="dimBackground">Whether the galaxy artwork is dimmed behind full-brightness markers.</param>
     public StrategyBriefingMapPresentation(
         StrategyBriefingMapMode mode,
         string label,
         string targetSystemInstanceID,
         string targetPlanetInstanceID,
         string playerFactionInstanceID,
-        string opponentFactionInstanceID
+        string opponentFactionInstanceID,
+        bool dimBackground = false
     )
     {
         Mode = mode;
@@ -32,6 +34,7 @@ public sealed class StrategyBriefingMapPresentation
         TargetPlanetInstanceID = targetPlanetInstanceID;
         PlayerFactionInstanceID = playerFactionInstanceID;
         OpponentFactionInstanceID = opponentFactionInstanceID;
+        DimBackground = dimBackground;
     }
 
     public StrategyBriefingMapMode Mode { get; }
@@ -45,6 +48,8 @@ public sealed class StrategyBriefingMapPresentation
     public string PlayerFactionInstanceID { get; }
 
     public string OpponentFactionInstanceID { get; }
+
+    public bool DimBackground { get; }
 }
 
 /// <summary>
@@ -57,17 +62,20 @@ public sealed class GalaxyMapRenderData
     /// </summary>
     /// <param name="backgroundTexture">The resolved galaxy background texture.</param>
     /// <param name="backgroundBounds">The optional source-space background bounds.</param>
+    /// <param name="backgroundColor">The background-only color multiplier.</param>
     /// <param name="activeFilterLabel">The active galactic-information label.</param>
     /// <param name="clusters">The visible system clusters in render order.</param>
     public GalaxyMapRenderData(
         Texture2D backgroundTexture,
         RectInt? backgroundBounds,
+        Color backgroundColor,
         GalaxyMapActiveFilterLabelRenderData activeFilterLabel,
         IReadOnlyList<GalaxyMapClusterRenderData> clusters
     )
     {
         BackgroundTexture = backgroundTexture;
         BackgroundBounds = backgroundBounds;
+        BackgroundColor = backgroundColor;
         ActiveFilterLabel = activeFilterLabel;
         Clusters = Copy(clusters);
     }
@@ -75,6 +83,8 @@ public sealed class GalaxyMapRenderData
     public Texture2D BackgroundTexture { get; }
 
     public RectInt? BackgroundBounds { get; }
+
+    public Color BackgroundColor { get; }
 
     public GalaxyMapActiveFilterLabelRenderData ActiveFilterLabel { get; }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapRenderData.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapRenderData.cs
@@ -4,6 +4,50 @@ using System.Collections.ObjectModel;
 using UnityEngine;
 
 /// <summary>
+/// Describes the transient map mode and label presented during a faction briefing.
+/// </summary>
+public sealed class StrategyBriefingMapPresentation
+{
+    /// <summary>
+    /// Creates one immutable briefing map cue.
+    /// </summary>
+    /// <param name="mode">The semantic map presentation mode.</param>
+    /// <param name="label">The label shown above the galaxy map.</param>
+    /// <param name="targetSystemInstanceID">The focused system identifier, or null.</param>
+    /// <param name="targetPlanetInstanceID">The spotlighted planet identifier, or null.</param>
+    /// <param name="playerFactionInstanceID">The player faction identifier.</param>
+    /// <param name="opponentFactionInstanceID">The opposing faction identifier.</param>
+    public StrategyBriefingMapPresentation(
+        StrategyBriefingMapMode mode,
+        string label,
+        string targetSystemInstanceID,
+        string targetPlanetInstanceID,
+        string playerFactionInstanceID,
+        string opponentFactionInstanceID
+    )
+    {
+        Mode = mode;
+        Label = label;
+        TargetSystemInstanceID = targetSystemInstanceID;
+        TargetPlanetInstanceID = targetPlanetInstanceID;
+        PlayerFactionInstanceID = playerFactionInstanceID;
+        OpponentFactionInstanceID = opponentFactionInstanceID;
+    }
+
+    public StrategyBriefingMapMode Mode { get; }
+
+    public string Label { get; }
+
+    public string TargetSystemInstanceID { get; }
+
+    public string TargetPlanetInstanceID { get; }
+
+    public string PlayerFactionInstanceID { get; }
+
+    public string OpponentFactionInstanceID { get; }
+}
+
+/// <summary>
 /// Contains a complete immutable galaxy-map presentation snapshot.
 /// </summary>
 public sealed class GalaxyMapRenderData

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapView.cs
@@ -88,7 +88,7 @@ public sealed class GalaxyMapView : MonoBehaviour
             throw new ArgumentNullException(nameof(data));
 
         VerifyReferences();
-        RenderBackground(data.BackgroundTexture, data.BackgroundBounds);
+        RenderBackground(data.BackgroundTexture, data.BackgroundBounds, data.BackgroundColor);
         RenderClusters(data.Clusters);
         RenderActiveFilterLabel(data.ActiveFilterLabel);
     }
@@ -185,9 +185,11 @@ public sealed class GalaxyMapView : MonoBehaviour
     /// </summary>
     /// <param name="texture">The resolved background texture.</param>
     /// <param name="bounds">The optional source-space background bounds.</param>
-    private void RenderBackground(Texture2D texture, RectInt? bounds)
+    /// <param name="color">The background-only color multiplier.</param>
+    private void RenderBackground(Texture2D texture, RectInt? bounds, Color color)
     {
         backgroundImage.texture = texture;
+        backgroundImage.color = color;
         backgroundImage.enabled = texture != null;
         backgroundImage.raycastTarget = false;
         backgroundImage.uvRect = new Rect(0f, 0f, 1f, 1f);

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -23,6 +23,10 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private IStrategyHudActions actions;
     private StrategyAdvisorTheme theme;
     private StrategyAdvisorView view;
+    private Action briefingCompleted;
+    private StrategyBriefingTheme activeBriefing;
+    private int briefingSegmentIndex;
+    private Action<StrategyAdvisorAnimationTheme> briefingSegmentStarted;
 
     /// <summary>
     /// Creates an advisor controller with faction, texture, and audio dependencies.
@@ -70,6 +74,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         view.DroidClicked += HandleDroidClicked;
         view.DroidContextRequested += HandleDroidContextRequested;
         view.PlaybackStarted += HandlePlaybackStarted;
+        view.PlaybackCompleted += HandlePlaybackCompleted;
         view.ProtocolContextRequested += HandleProtocolContextRequested;
         view.Render(CreateViewData(theme));
     }
@@ -200,6 +205,113 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
             targetView.EnqueuePlaybacks(playbackBatch);
             break;
         }
+    }
+
+    /// <summary>
+    /// Plays an ordered faction briefing through the protocol advisor.
+    /// </summary>
+    /// <param name="briefing">The faction-configured briefing.</param>
+    /// <param name="segmentStarted">Invoked when each delayed segment actually begins.</param>
+    /// <param name="completed">Invoked after the complete briefing or skip response finishes.</param>
+    public void PlayBriefing(
+        StrategyBriefingTheme briefing,
+        Action<StrategyAdvisorAnimationTheme> segmentStarted,
+        Action completed
+    )
+    {
+        if (briefing == null || briefing.Segments.Count == 0)
+        {
+            completed?.Invoke();
+            return;
+        }
+
+        activeBriefing = briefing;
+        briefingSegmentIndex = 0;
+        briefingSegmentStarted = segmentStarted;
+        briefingCompleted = completed;
+        PlayCurrentBriefingSegment();
+    }
+
+    /// <summary>
+    /// Skips the active briefing and optionally plays its configured acknowledgement.
+    /// </summary>
+    /// <param name="briefing">The faction briefing containing the skip response.</param>
+    public void SkipBriefing(StrategyBriefingTheme briefing)
+    {
+        StrategyBriefingTheme currentBriefing = activeBriefing;
+        activeBriefing = null;
+        GetRequiredView().CancelPlayback();
+        activeBriefing = currentBriefing;
+        briefingSegmentIndex = currentBriefing?.Segments.Count ?? 0;
+        if (briefing?.Skip == null)
+        {
+            CompleteBriefing();
+            return;
+        }
+
+        GetRequiredView()
+            .EnqueuePlaybacks(new[] { CreateBriefingPlayback(briefing, briefing.Skip) });
+    }
+
+    /// <summary>
+    /// Resolves one configured briefing segment into resident animation playback data.
+    /// </summary>
+    /// <param name="briefing">The briefing content-address configuration.</param>
+    /// <param name="segment">The animation segment to resolve.</param>
+    /// <returns>The resolved playback frames, voice address, and initial delay.</returns>
+    private StrategyAdvisorAnimationViewData CreateBriefingPlayback(
+        StrategyBriefingTheme briefing,
+        StrategyAdvisorAnimationTheme segment
+    )
+    {
+        if (segment == null || segment.FrameCount <= 0)
+            throw new InvalidOperationException("Briefing contains an empty animation segment.");
+
+        Texture2D[] frames = new Texture2D[segment.FrameCount];
+        for (int frameIndex = 0; frameIndex < segment.FrameCount; frameIndex++)
+        {
+            string path = briefing.GetFramePath(segment.BitmapID, frameIndex);
+            frames[frameIndex] = getTexture(path);
+            if (frames[frameIndex] == null)
+                throw new InvalidOperationException($"Briefing frame is missing: {path}");
+        }
+
+        string audioPath = segment.WaveID == 0 ? null : briefing.GetAudioPath(segment.WaveID);
+        return new StrategyAdvisorAnimationViewData(
+            frames,
+            false,
+            audioPath,
+            segment.DelayBeforeSeconds
+        );
+    }
+
+    private void HandlePlaybackCompleted()
+    {
+        if (activeBriefing == null)
+            return;
+
+        briefingSegmentIndex++;
+        if (briefingSegmentIndex < activeBriefing.Segments.Count)
+            PlayCurrentBriefingSegment();
+        else
+            CompleteBriefing();
+    }
+
+    private void PlayCurrentBriefingSegment()
+    {
+        StrategyAdvisorAnimationTheme segment = activeBriefing.Segments[briefingSegmentIndex];
+        GetRequiredView()
+            .EnqueuePlaybacks(new[] { CreateBriefingPlayback(activeBriefing, segment) });
+    }
+
+    private void CompleteBriefing()
+    {
+        activeBriefing = null;
+        briefingSegmentIndex = 0;
+        briefingSegmentStarted = null;
+        Action completed = briefingCompleted;
+        briefingCompleted = null;
+        completed?.Invoke();
     }
 
     /// <summary>
@@ -548,6 +660,9 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <param name="animation">The animation that began playback.</param>
     private void HandlePlaybackStarted(StrategyAdvisorAnimationViewData animation)
     {
+        if (activeBriefing != null && briefingSegmentIndex < activeBriefing.Segments.Count)
+            briefingSegmentStarted?.Invoke(activeBriefing.Segments[briefingSegmentIndex]);
+
         if (!string.IsNullOrEmpty(animation?.AudioPath))
             playSfx(animation.AudioPath);
     }
@@ -731,6 +846,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         view.Destroyed -= HandleViewDestroyed;
         view.DroidClicked -= HandleDroidClicked;
         view.DroidContextRequested -= HandleDroidContextRequested;
+        view.PlaybackCompleted -= HandlePlaybackCompleted;
         view.PlaybackStarted -= HandlePlaybackStarted;
         view.ProtocolContextRequested -= HandleProtocolContextRequested;
         view = null;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -12,7 +12,6 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
 {
     private readonly Func<Faction> getPlayerFaction;
     private readonly Func<string, Texture2D> getTexture;
-    private readonly Func<string, float> getAudioDuration;
     private readonly Action<string> playSfx;
     private readonly Dictionary<int, StrategyAdvisorNotificationTheme> pendingNotifications =
         new Dictionary<int, StrategyAdvisorNotificationTheme>();
@@ -24,10 +23,8 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private IStrategyHudActions actions;
     private StrategyAdvisorTheme theme;
     private StrategyAdvisorView view;
-    private Action briefingCompleted;
-    private StrategyBriefingTheme activeBriefing;
-    private int briefingSegmentIndex;
-    private Action<StrategyAdvisorAnimationTheme> briefingSegmentStarted;
+    private Action playbackCompleted;
+    private Action playbackStarted;
 
     /// <summary>
     /// Creates an advisor controller with faction, texture, and audio dependencies.
@@ -35,20 +32,16 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <param name="getPlayerFaction">Resolves the current player faction.</param>
     /// <param name="getTexture">Resolves a texture from a configured resource path.</param>
     /// <param name="playSfx">Plays a strategy sound-effect path.</param>
-    /// <param name="getAudioDuration">Resolves the duration of a preloaded audio cue.</param>
     public StrategyAdvisorController(
         Func<Faction> getPlayerFaction,
         Func<string, Texture2D> getTexture,
-        Action<string> playSfx,
-        Func<string, float> getAudioDuration
+        Action<string> playSfx
     )
     {
         this.getPlayerFaction =
             getPlayerFaction ?? throw new ArgumentNullException(nameof(getPlayerFaction));
         this.getTexture = getTexture ?? throw new ArgumentNullException(nameof(getTexture));
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
-        this.getAudioDuration =
-            getAudioDuration ?? throw new ArgumentNullException(nameof(getAudioDuration));
     }
 
     /// <summary>
@@ -213,128 +206,66 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     }
 
     /// <summary>
-    /// Plays an ordered faction briefing through the protocol advisor.
+    /// Plays one resolved animation through the protocol advisor.
     /// </summary>
-    /// <param name="briefing">The faction-configured briefing.</param>
-    /// <param name="segmentStarted">Invoked when each delayed segment actually begins.</param>
-    /// <param name="completed">Invoked after the complete briefing or skip response finishes.</param>
-    public void PlayBriefing(
-        StrategyBriefingTheme briefing,
-        Action<StrategyAdvisorAnimationTheme> segmentStarted,
+    /// <param name="animation">The resolved animation presentation.</param>
+    /// <param name="started">Invoked when playback starts after its configured delay.</param>
+    /// <param name="completed">Invoked after playback completes.</param>
+    public void ReplaceAnimation(
+        StrategyAdvisorAnimationViewData animation,
+        Action started,
         Action completed
     )
     {
-        if (briefing == null || briefing.Segments.Count == 0)
+        if (animation?.Frames.Count <= 0)
         {
             completed?.Invoke();
             return;
         }
 
-        activeBriefing = briefing;
-        briefingSegmentIndex = 0;
-        briefingSegmentStarted = segmentStarted;
-        briefingCompleted = completed;
-        PlayCurrentBriefingSegment();
+        StrategyAdvisorView targetView = GetRequiredView();
+        playbackStarted = null;
+        playbackCompleted = null;
+        targetView.CancelPlayback();
+        playbackStarted = started;
+        playbackCompleted = completed;
+        targetView.EnqueuePlaybacks(new[] { animation });
     }
 
     /// <summary>
-    /// Skips the active briefing and optionally plays its configured acknowledgement.
+    /// Cancels the active advisor animation without invoking its completion callback.
     /// </summary>
-    /// <param name="briefing">The faction briefing containing the skip response.</param>
-    public void SkipBriefing(StrategyBriefingTheme briefing)
+    public void CancelAnimation()
     {
-        StrategyBriefingTheme currentBriefing = activeBriefing;
-        activeBriefing = null;
+        playbackStarted = null;
+        playbackCompleted = null;
         GetRequiredView().CancelPlayback();
-        activeBriefing = currentBriefing;
-        briefingSegmentIndex = currentBriefing?.Segments.Count ?? 0;
-        if (briefing?.Skip == null)
-        {
-            CompleteBriefing();
-            return;
-        }
-
-        GetRequiredView()
-            .EnqueuePlaybacks(new[] { CreateBriefingPlayback(briefing, briefing.Skip) });
     }
 
     /// <summary>
-    /// Pauses the active briefing animation without discarding its position.
+    /// Pauses the active advisor animation without discarding its position.
     /// </summary>
-    public void PauseBriefing()
+    public void PauseAnimation()
     {
         GetRequiredView().PausePlayback();
     }
 
     /// <summary>
-    /// Resumes the active briefing animation from its paused position.
+    /// Resumes the active advisor animation from its paused position.
     /// </summary>
-    public void ResumeBriefing()
+    public void ResumeAnimation()
     {
         GetRequiredView().ResumePlayback();
     }
 
     /// <summary>
-    /// Resolves one configured briefing segment into resident animation playback data.
+    /// Invokes and clears the callback associated with completed generic playback.
     /// </summary>
-    /// <param name="briefing">The briefing content-address configuration.</param>
-    /// <param name="segment">The animation segment to resolve.</param>
-    /// <returns>The resolved playback frames, voice address, and initial delay.</returns>
-    private StrategyAdvisorAnimationViewData CreateBriefingPlayback(
-        StrategyBriefingTheme briefing,
-        StrategyAdvisorAnimationTheme segment
-    )
-    {
-        if (segment == null || segment.FrameCount <= 0)
-            throw new InvalidOperationException("Briefing contains an empty animation segment.");
-
-        Texture2D[] frames = new Texture2D[segment.FrameCount];
-        for (int frameIndex = 0; frameIndex < segment.FrameCount; frameIndex++)
-        {
-            string path = briefing.GetFramePath(segment.Animation, frameIndex);
-            frames[frameIndex] = getTexture(path);
-            if (frames[frameIndex] == null)
-                throw new InvalidOperationException($"Briefing frame is missing: {path}");
-        }
-
-        string audioPath = string.IsNullOrWhiteSpace(segment.Audio)
-            ? null
-            : briefing.GetAudioPath(segment.Audio);
-        return new StrategyAdvisorAnimationViewData(
-            frames,
-            false,
-            audioPath,
-            segment.DelayBeforeSeconds,
-            string.IsNullOrEmpty(audioPath) ? 0f : getAudioDuration(audioPath)
-        );
-    }
-
     private void HandlePlaybackCompleted()
     {
-        if (activeBriefing == null)
-            return;
-
-        briefingSegmentIndex++;
-        if (briefingSegmentIndex < activeBriefing.Segments.Count)
-            PlayCurrentBriefingSegment();
-        else
-            CompleteBriefing();
-    }
-
-    private void PlayCurrentBriefingSegment()
-    {
-        StrategyAdvisorAnimationTheme segment = activeBriefing.Segments[briefingSegmentIndex];
-        GetRequiredView()
-            .EnqueuePlaybacks(new[] { CreateBriefingPlayback(activeBriefing, segment) });
-    }
-
-    private void CompleteBriefing()
-    {
-        activeBriefing = null;
-        briefingSegmentIndex = 0;
-        briefingSegmentStarted = null;
-        Action completed = briefingCompleted;
-        briefingCompleted = null;
+        playbackStarted = null;
+        Action completed = playbackCompleted;
+        playbackCompleted = null;
         completed?.Invoke();
     }
 
@@ -686,8 +617,9 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <param name="animation">The animation that began playback.</param>
     private void HandlePlaybackStarted(StrategyAdvisorAnimationViewData animation)
     {
-        if (activeBriefing != null && briefingSegmentIndex < activeBriefing.Segments.Count)
-            briefingSegmentStarted?.Invoke(activeBriefing.Segments[briefingSegmentIndex]);
+        Action started = playbackStarted;
+        playbackStarted = null;
+        started?.Invoke();
 
         if (!string.IsNullOrEmpty(animation?.AudioPath))
             playSfx(animation.AudioPath);

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -12,6 +12,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
 {
     private readonly Func<Faction> getPlayerFaction;
     private readonly Func<string, Texture2D> getTexture;
+    private readonly Func<string, float> getAudioDuration;
     private readonly Action<string> playSfx;
     private readonly Dictionary<int, StrategyAdvisorNotificationTheme> pendingNotifications =
         new Dictionary<int, StrategyAdvisorNotificationTheme>();
@@ -34,16 +35,20 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <param name="getPlayerFaction">Resolves the current player faction.</param>
     /// <param name="getTexture">Resolves a texture from a configured resource path.</param>
     /// <param name="playSfx">Plays a strategy sound-effect path.</param>
+    /// <param name="getAudioDuration">Resolves the duration of a preloaded audio cue.</param>
     public StrategyAdvisorController(
         Func<Faction> getPlayerFaction,
         Func<string, Texture2D> getTexture,
-        Action<string> playSfx
+        Action<string> playSfx,
+        Func<string, float> getAudioDuration
     )
     {
         this.getPlayerFaction =
             getPlayerFaction ?? throw new ArgumentNullException(nameof(getPlayerFaction));
         this.getTexture = getTexture ?? throw new ArgumentNullException(nameof(getTexture));
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
+        this.getAudioDuration =
+            getAudioDuration ?? throw new ArgumentNullException(nameof(getAudioDuration));
     }
 
     /// <summary>
@@ -254,6 +259,22 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     }
 
     /// <summary>
+    /// Pauses the active briefing animation without discarding its position.
+    /// </summary>
+    public void PauseBriefing()
+    {
+        GetRequiredView().PausePlayback();
+    }
+
+    /// <summary>
+    /// Resumes the active briefing animation from its paused position.
+    /// </summary>
+    public void ResumeBriefing()
+    {
+        GetRequiredView().ResumePlayback();
+    }
+
+    /// <summary>
     /// Resolves one configured briefing segment into resident animation playback data.
     /// </summary>
     /// <param name="briefing">The briefing content-address configuration.</param>
@@ -281,7 +302,8 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
             frames,
             false,
             audioPath,
-            segment.DelayBeforeSeconds
+            segment.DelayBeforeSeconds,
+            string.IsNullOrEmpty(audioPath) ? 0f : getAudioDuration(audioPath)
         );
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -291,13 +291,15 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         Texture2D[] frames = new Texture2D[segment.FrameCount];
         for (int frameIndex = 0; frameIndex < segment.FrameCount; frameIndex++)
         {
-            string path = briefing.GetFramePath(segment.BitmapID, frameIndex);
+            string path = briefing.GetFramePath(segment.Animation, frameIndex);
             frames[frameIndex] = getTexture(path);
             if (frames[frameIndex] == null)
                 throw new InvalidOperationException($"Briefing frame is missing: {path}");
         }
 
-        string audioPath = segment.WaveID == 0 ? null : briefing.GetAudioPath(segment.WaveID);
+        string audioPath = string.IsNullOrWhiteSpace(segment.Audio)
+            ? null
+            : briefing.GetAudioPath(segment.Audio);
         return new StrategyAdvisorAnimationViewData(
             frames,
             false,
@@ -582,8 +584,8 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
 
         return new StrategyAdvisorViewData(
             true,
-            ResolveTexture(advisorTheme.GetFramePath(advisorTheme.ProtocolIdleBitmapID, 0, false)),
-            ResolveTexture(advisorTheme.GetFramePath(advisorTheme.DroidIdleBitmapID, 0, true)),
+            ResolveTexture(advisorTheme.GetFramePath(advisorTheme.ProtocolIdleAnimation, 0, false)),
+            ResolveTexture(advisorTheme.GetFramePath(advisorTheme.DroidIdleAnimation, 0, true)),
             ToRect(advisorTheme.ProtocolSourceLayout),
             ToRect(advisorTheme.DroidSourceLayout),
             advisorTheme.FrameIntervalSeconds
@@ -635,7 +637,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         for (int frameIndex = 0; frameIndex < animation.FrameCount; frameIndex++)
         {
             frames[frameIndex] = ResolveTexture(
-                theme.GetFramePath(animation.BitmapID, frameIndex, usesDroid)
+                theme.GetFramePath(animation.Animation, frameIndex, usesDroid)
             );
             ready &= frames[frameIndex] != null;
         }
@@ -647,7 +649,9 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
             new StrategyAdvisorAnimationViewData(
                 frames,
                 usesDroid,
-                animation.WaveID == 0 ? null : theme.GetAudioPath(animation.WaveID)
+                string.IsNullOrWhiteSpace(animation.Audio)
+                    ? null
+                    : theme.GetAudioPath(animation.Audio)
             )
         );
         return true;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -206,7 +206,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     }
 
     /// <summary>
-    /// Plays one resolved animation through the protocol advisor.
+    /// Cancels current protocol-advisor playback and replaces it with one resolved animation.
     /// </summary>
     /// <param name="animation">The resolved animation presentation.</param>
     /// <param name="started">Invoked when playback starts after its configured delay.</param>
@@ -217,16 +217,17 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         Action completed
     )
     {
-        if (animation?.Frames.Count <= 0)
+        StrategyAdvisorView targetView = GetRequiredView();
+        playbackStarted = null;
+        playbackCompleted = null;
+        targetView.CancelPlayback();
+
+        if (animation == null || animation.Frames.Count == 0)
         {
             completed?.Invoke();
             return;
         }
 
-        StrategyAdvisorView targetView = GetRequiredView();
-        playbackStarted = null;
-        playbackCompleted = null;
-        targetView.CancelPlayback();
         playbackStarted = started;
         playbackCompleted = completed;
         targetView.EnqueuePlaybacks(new[] { animation });

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorView.cs
@@ -61,8 +61,11 @@ public sealed class StrategyAdvisorView : MonoBehaviour
     private int activeFrameIndex;
     private float delayRemainingSeconds;
     private float frameElapsedSeconds;
+    private float playbackElapsedSeconds;
     private bool animationStarted;
+    private bool framesCompleted;
     private bool eventsBound;
+    private bool playbackPaused;
 
     /// <summary>
     /// Validates authored references and subscribes advisor inputs when Unity creates the view.
@@ -179,12 +182,33 @@ public sealed class StrategyAdvisorView : MonoBehaviour
     }
 
     /// <summary>
+    /// Pauses animation and delay advancement without discarding playback state.
+    /// </summary>
+    public void PausePlayback()
+    {
+        playbackPaused = true;
+    }
+
+    /// <summary>
+    /// Resumes animation and delay advancement from the paused position.
+    /// </summary>
+    public void ResumePlayback()
+    {
+        playbackPaused = false;
+    }
+
+    /// <summary>
     /// Advances playback by an explicit unscaled duration for runtime and deterministic tests.
     /// </summary>
     /// <param name="elapsedSeconds">The unscaled elapsed duration.</param>
     internal void AdvanceAnimation(float elapsedSeconds)
     {
-        if (activeAnimation == null || presentation == null || elapsedSeconds <= 0f)
+        if (
+            playbackPaused
+            || activeAnimation == null
+            || presentation == null
+            || elapsedSeconds <= 0f
+        )
             return;
 
         if (!animationStarted)
@@ -200,6 +224,14 @@ public sealed class StrategyAdvisorView : MonoBehaviour
         if (presentation.FrameIntervalSeconds <= 0f)
             return;
 
+        playbackElapsedSeconds += elapsedSeconds;
+        if (framesCompleted)
+        {
+            if (playbackElapsedSeconds >= activeAnimation.MinimumPlaybackSeconds)
+                FinishAnimation();
+            return;
+        }
+
         frameElapsedSeconds += elapsedSeconds;
         while (activeAnimation != null && frameElapsedSeconds >= presentation.FrameIntervalSeconds)
         {
@@ -207,8 +239,11 @@ public sealed class StrategyAdvisorView : MonoBehaviour
             activeFrameIndex++;
             if (activeFrameIndex >= activeAnimation.Frames.Count)
             {
-                FinishAnimation();
-                continue;
+                framesCompleted = true;
+                activeFrameIndex = activeAnimation.Frames.Count - 1;
+                if (playbackElapsedSeconds >= activeAnimation.MinimumPlaybackSeconds)
+                    FinishAnimation();
+                return;
             }
 
             SetActiveFrame();
@@ -255,7 +290,9 @@ public sealed class StrategyAdvisorView : MonoBehaviour
         activeFrameIndex = 0;
         delayRemainingSeconds = activeAnimation.DelayBeforeSeconds;
         frameElapsedSeconds = 0f;
+        playbackElapsedSeconds = 0f;
         animationStarted = false;
+        framesCompleted = false;
         if (delayRemainingSeconds <= 0f)
             BeginAnimation();
     }
@@ -293,7 +330,9 @@ public sealed class StrategyAdvisorView : MonoBehaviour
         activeFrameIndex = 0;
         delayRemainingSeconds = 0f;
         frameElapsedSeconds = 0f;
+        playbackElapsedSeconds = 0f;
         animationStarted = false;
+        framesCompleted = false;
         StartNextAnimation();
         if (activeAnimation == null && playbackQueue.Count == 0)
             PlaybackCompleted?.Invoke();
@@ -324,7 +363,9 @@ public sealed class StrategyAdvisorView : MonoBehaviour
         activeFrameIndex = 0;
         delayRemainingSeconds = 0f;
         frameElapsedSeconds = 0f;
+        playbackElapsedSeconds = 0f;
         animationStarted = false;
+        framesCompleted = false;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorView.cs
@@ -366,6 +366,7 @@ public sealed class StrategyAdvisorView : MonoBehaviour
         playbackElapsedSeconds = 0f;
         animationStarted = false;
         framesCompleted = false;
+        playbackPaused = false;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorView.cs
@@ -9,6 +9,8 @@ using UnityEngine.UI;
 /// </summary>
 public sealed class StrategyAdvisorView : MonoBehaviour
 {
+    private const float _delayToleranceSeconds = 0.0001f;
+
     [SerializeField]
     private RawImage protocolImage;
 
@@ -42,6 +44,11 @@ public sealed class StrategyAdvisorView : MonoBehaviour
     public event Action<StrategyAdvisorAnimationViewData> PlaybackStarted;
 
     /// <summary>
+    /// Occurs after the active playback queue finishes.
+    /// </summary>
+    public event Action PlaybackCompleted;
+
+    /// <summary>
     /// Occurs when a protocol context request is raised.
     /// </summary>
     public event Action<int, int> ProtocolContextRequested;
@@ -52,7 +59,9 @@ public sealed class StrategyAdvisorView : MonoBehaviour
     private StrategyAdvisorViewData presentation;
     private StrategyAdvisorAnimationViewData activeAnimation;
     private int activeFrameIndex;
+    private float delayRemainingSeconds;
     private float frameElapsedSeconds;
+    private bool animationStarted;
     private bool eventsBound;
 
     /// <summary>
@@ -157,17 +166,38 @@ public sealed class StrategyAdvisorView : MonoBehaviour
     }
 
     /// <summary>
+    /// Cancels active and queued advisor animation and restores the idle presentation.
+    /// </summary>
+    public void CancelPlayback()
+    {
+        bool hadPlayback = activeAnimation != null || playbackQueue.Count > 0;
+        ClearPlayback();
+        SetIdleFrame(false);
+        SetIdleFrame(true);
+        if (hadPlayback)
+            PlaybackCompleted?.Invoke();
+    }
+
+    /// <summary>
     /// Advances playback by an explicit unscaled duration for runtime and deterministic tests.
     /// </summary>
     /// <param name="elapsedSeconds">The unscaled elapsed duration.</param>
     internal void AdvanceAnimation(float elapsedSeconds)
     {
-        if (
-            activeAnimation == null
-            || presentation == null
-            || presentation.FrameIntervalSeconds <= 0f
-            || elapsedSeconds <= 0f
-        )
+        if (activeAnimation == null || presentation == null || elapsedSeconds <= 0f)
+            return;
+
+        if (!animationStarted)
+        {
+            delayRemainingSeconds -= elapsedSeconds;
+            if (delayRemainingSeconds > _delayToleranceSeconds)
+                return;
+
+            elapsedSeconds = Mathf.Max(0f, -delayRemainingSeconds);
+            BeginAnimation();
+        }
+
+        if (presentation.FrameIntervalSeconds <= 0f)
             return;
 
         frameElapsedSeconds += elapsedSeconds;
@@ -223,7 +253,20 @@ public sealed class StrategyAdvisorView : MonoBehaviour
 
         activeAnimation = playbackQueue.Dequeue();
         activeFrameIndex = 0;
+        delayRemainingSeconds = activeAnimation.DelayBeforeSeconds;
         frameElapsedSeconds = 0f;
+        animationStarted = false;
+        if (delayRemainingSeconds <= 0f)
+            BeginAnimation();
+    }
+
+    /// <summary>
+    /// Presents the first frame and emits playback only after the configured delay elapses.
+    /// </summary>
+    private void BeginAnimation()
+    {
+        animationStarted = true;
+        delayRemainingSeconds = 0f;
         if (activeAnimation.UsesDroid)
             SetIdleFrame(false);
         SetActiveFrame();
@@ -244,11 +287,16 @@ public sealed class StrategyAdvisorView : MonoBehaviour
     /// </summary>
     private void FinishAnimation()
     {
-        SetIdleFrame(activeAnimation.UsesDroid);
+        bool usedDroid = activeAnimation.UsesDroid;
+        SetIdleFrame(usedDroid);
         activeAnimation = null;
         activeFrameIndex = 0;
+        delayRemainingSeconds = 0f;
         frameElapsedSeconds = 0f;
+        animationStarted = false;
         StartNextAnimation();
+        if (activeAnimation == null && playbackQueue.Count == 0)
+            PlaybackCompleted?.Invoke();
     }
 
     /// <summary>
@@ -274,7 +322,9 @@ public sealed class StrategyAdvisorView : MonoBehaviour
         playbackQueue.Clear();
         activeAnimation = null;
         activeFrameIndex = 0;
+        delayRemainingSeconds = 0f;
         frameElapsedSeconds = 0f;
+        animationStarted = false;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewData.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewData.cs
@@ -59,15 +59,18 @@ public sealed class StrategyAdvisorAnimationViewData
     /// <param name="frames">The animation frames in playback order.</param>
     /// <param name="usesDroid">Whether the droid image presents the animation.</param>
     /// <param name="audioPath">The audio cue requested when playback starts.</param>
+    /// <param name="delayBeforeSeconds">The unscaled delay before playback starts.</param>
     public StrategyAdvisorAnimationViewData(
         IReadOnlyList<Texture2D> frames,
         bool usesDroid,
-        string audioPath
+        string audioPath,
+        float delayBeforeSeconds = 0f
     )
     {
         this.frames = Copy(frames);
         UsesDroid = usesDroid;
         AudioPath = audioPath;
+        DelayBeforeSeconds = Math.Max(0f, delayBeforeSeconds);
     }
 
     public IReadOnlyList<Texture2D> Frames => frames;
@@ -75,6 +78,8 @@ public sealed class StrategyAdvisorAnimationViewData
     public bool UsesDroid { get; }
 
     public string AudioPath { get; }
+
+    public float DelayBeforeSeconds { get; }
 
     /// <summary>
     /// Copies animation frames into an isolated read-only snapshot.

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewData.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewData.cs
@@ -60,17 +60,20 @@ public sealed class StrategyAdvisorAnimationViewData
     /// <param name="usesDroid">Whether the droid image presents the animation.</param>
     /// <param name="audioPath">The audio cue requested when playback starts.</param>
     /// <param name="delayBeforeSeconds">The unscaled delay before playback starts.</param>
+    /// <param name="minimumPlaybackSeconds">The minimum time the playback remains active.</param>
     public StrategyAdvisorAnimationViewData(
         IReadOnlyList<Texture2D> frames,
         bool usesDroid,
         string audioPath,
-        float delayBeforeSeconds = 0f
+        float delayBeforeSeconds = 0f,
+        float minimumPlaybackSeconds = 0f
     )
     {
         this.frames = Copy(frames);
         UsesDroid = usesDroid;
         AudioPath = audioPath;
         DelayBeforeSeconds = Math.Max(0f, delayBeforeSeconds);
+        MinimumPlaybackSeconds = Math.Max(0f, minimumPlaybackSeconds);
     }
 
     public IReadOnlyList<Texture2D> Frames => frames;
@@ -80,6 +83,8 @@ public sealed class StrategyAdvisorAnimationViewData
     public string AudioPath { get; }
 
     public float DelayBeforeSeconds { get; }
+
+    public float MinimumPlaybackSeconds { get; }
 
     /// <summary>
     /// Copies animation frames into an isolated read-only snapshot.

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
@@ -25,11 +25,13 @@ public sealed class StrategyHudController : IContextMenuReceiver
     /// <param name="getPlayerTheme">Returns the current player faction theme.</param>
     /// <param name="getTexture">Resolves a texture from a configured resource path.</param>
     /// <param name="playSfx">Plays a strategy sound-effect path.</param>
+    /// <param name="getAudioDuration">Resolves the duration of a preloaded audio cue.</param>
     public StrategyHudController(
         Func<Faction> getPlayerFaction,
         Func<FactionTheme> getPlayerTheme,
         Func<string, Texture2D> getTexture,
-        Action<string> playSfx
+        Action<string> playSfx,
+        Func<string, float> getAudioDuration
     )
     {
         if (getPlayerFaction == null)
@@ -39,7 +41,12 @@ public sealed class StrategyHudController : IContextMenuReceiver
             getPlayerTheme ?? throw new ArgumentNullException(nameof(getPlayerTheme));
         this.getTexture = getTexture ?? throw new ArgumentNullException(nameof(getTexture));
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
-        advisorController = new StrategyAdvisorController(getPlayerFaction, getTexture, playSfx);
+        advisorController = new StrategyAdvisorController(
+            getPlayerFaction,
+            getTexture,
+            playSfx,
+            getAudioDuration
+        );
     }
 
     /// <summary>
@@ -134,6 +141,22 @@ public sealed class StrategyHudController : IContextMenuReceiver
     public void SkipBriefing(StrategyBriefingTheme briefing)
     {
         advisorController.SkipBriefing(briefing);
+    }
+
+    /// <summary>
+    /// Pauses the active faction briefing animation.
+    /// </summary>
+    public void PauseBriefing()
+    {
+        advisorController.PauseBriefing();
+    }
+
+    /// <summary>
+    /// Resumes the active faction briefing animation.
+    /// </summary>
+    public void ResumeBriefing()
+    {
+        advisorController.ResumeBriefing();
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
@@ -113,7 +113,7 @@ public sealed class StrategyHudController : IContextMenuReceiver
     }
 
     /// <summary>
-    /// Plays one resolved protocol-advisor animation.
+    /// Cancels current protocol-advisor playback and replaces it with one resolved animation.
     /// </summary>
     /// <param name="animation">The resolved animation presentation.</param>
     /// <param name="started">Invoked when playback starts after its configured delay.</param>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
@@ -25,13 +25,11 @@ public sealed class StrategyHudController : IContextMenuReceiver
     /// <param name="getPlayerTheme">Returns the current player faction theme.</param>
     /// <param name="getTexture">Resolves a texture from a configured resource path.</param>
     /// <param name="playSfx">Plays a strategy sound-effect path.</param>
-    /// <param name="getAudioDuration">Resolves the duration of a preloaded audio cue.</param>
     public StrategyHudController(
         Func<Faction> getPlayerFaction,
         Func<FactionTheme> getPlayerTheme,
         Func<string, Texture2D> getTexture,
-        Action<string> playSfx,
-        Func<string, float> getAudioDuration
+        Action<string> playSfx
     )
     {
         if (getPlayerFaction == null)
@@ -41,12 +39,7 @@ public sealed class StrategyHudController : IContextMenuReceiver
             getPlayerTheme ?? throw new ArgumentNullException(nameof(getPlayerTheme));
         this.getTexture = getTexture ?? throw new ArgumentNullException(nameof(getTexture));
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
-        advisorController = new StrategyAdvisorController(
-            getPlayerFaction,
-            getTexture,
-            playSfx,
-            getAudioDuration
-        );
+        advisorController = new StrategyAdvisorController(getPlayerFaction, getTexture, playSfx);
     }
 
     /// <summary>
@@ -120,43 +113,42 @@ public sealed class StrategyHudController : IContextMenuReceiver
     }
 
     /// <summary>
-    /// Plays the active faction's configured new-game briefing.
+    /// Plays one resolved protocol-advisor animation.
     /// </summary>
-    /// <param name="briefing">The active faction briefing.</param>
-    /// <param name="segmentStarted">Invoked when each segment starts.</param>
-    /// <param name="completed">Invoked after playback or the skip response completes.</param>
-    public void PlayBriefing(
-        StrategyBriefingTheme briefing,
-        Action<StrategyAdvisorAnimationTheme> segmentStarted,
+    /// <param name="animation">The resolved animation presentation.</param>
+    /// <param name="started">Invoked when playback starts after its configured delay.</param>
+    /// <param name="completed">Invoked after playback completes.</param>
+    public void ReplaceAdvisorAnimation(
+        StrategyAdvisorAnimationViewData animation,
+        Action started,
         Action completed
     )
     {
-        advisorController.PlayBriefing(briefing, segmentStarted, completed);
+        advisorController.ReplaceAnimation(animation, started, completed);
     }
 
     /// <summary>
-    /// Skips the active faction briefing using its configured acknowledgement.
+    /// Cancels active advisor animation without invoking its completion callback.
     /// </summary>
-    /// <param name="briefing">The active faction briefing.</param>
-    public void SkipBriefing(StrategyBriefingTheme briefing)
+    public void CancelAdvisorAnimation()
     {
-        advisorController.SkipBriefing(briefing);
+        advisorController.CancelAnimation();
     }
 
     /// <summary>
-    /// Pauses the active faction briefing animation.
+    /// Pauses the active advisor animation.
     /// </summary>
-    public void PauseBriefing()
+    public void PauseAdvisorAnimation()
     {
-        advisorController.PauseBriefing();
+        advisorController.PauseAnimation();
     }
 
     /// <summary>
-    /// Resumes the active faction briefing animation.
+    /// Resumes the active advisor animation.
     /// </summary>
-    public void ResumeBriefing()
+    public void ResumeAdvisorAnimation()
     {
-        advisorController.ResumeBriefing();
+        advisorController.ResumeAnimation();
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
@@ -113,6 +113,30 @@ public sealed class StrategyHudController : IContextMenuReceiver
     }
 
     /// <summary>
+    /// Plays the active faction's configured new-game briefing.
+    /// </summary>
+    /// <param name="briefing">The active faction briefing.</param>
+    /// <param name="segmentStarted">Invoked when each segment starts.</param>
+    /// <param name="completed">Invoked after playback or the skip response completes.</param>
+    public void PlayBriefing(
+        StrategyBriefingTheme briefing,
+        Action<StrategyAdvisorAnimationTheme> segmentStarted,
+        Action completed
+    )
+    {
+        advisorController.PlayBriefing(briefing, segmentStarted, completed);
+    }
+
+    /// <summary>
+    /// Skips the active faction briefing using its configured acknowledgement.
+    /// </summary>
+    /// <param name="briefing">The active faction briefing.</param>
+    public void SkipBriefing(StrategyBriefingTheme briefing)
+    {
+        advisorController.SkipBriefing(briefing);
+    }
+
+    /// <summary>
     /// Applies one selected command from a HUD-owned context-menu request.
     /// </summary>
     /// <param name="request">The completed HUD request.</param>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/GameFlowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/GameFlowController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Rebellion.Game;
 using Rebellion.Game.Encyclopedia;
 using Rebellion.Game.Factions;
@@ -15,6 +16,7 @@ public sealed class GameFlowController : MonoBehaviour
     private StrategyController strategyController;
 
     private GameManager activeGameManager;
+    private Task briefingContentTask = Task.CompletedTask;
     private GameRoot game;
     private FactionThemeLibrary themeLibrary;
     private UIContext uiContext;
@@ -129,6 +131,7 @@ public sealed class GameFlowController : MonoBehaviour
         }
 
         FactionTheme theme = themeLibrary.GetTheme(faction.InstanceID);
+        briefingContentTask = PreloadBriefingContentAsync(theme.StrategyBriefing);
         if (string.IsNullOrEmpty(theme.IntroCutscenePath))
         {
             EnterGameplay();
@@ -155,10 +158,11 @@ public sealed class GameFlowController : MonoBehaviour
     /// Initializes strategy UI for an active game manager.
     /// </summary>
     /// <param name="gameManager">The active game manager.</param>
-    private void EnterGameplay(GameManager gameManager)
+    private async void EnterGameplay(GameManager gameManager)
     {
         try
         {
+            await briefingContentTask;
             AppBootstrap bootstrap = AppBootstrap.Instance;
             ContentPack contentPack = bootstrap.GetContentPack();
             EncyclopediaCatalog encyclopediaCatalog = new EncyclopediaCatalogBuilder().Build(
@@ -172,11 +176,28 @@ public sealed class GameFlowController : MonoBehaviour
             );
 
             strategyController.Initialize(gameManager, uiContext);
-            activeGameManager = gameManager;
+            if (GameLaunchContext.PlayIntroCutscene)
+                strategyController.PlayBriefing(() => activeGameManager = gameManager);
+            else
+                activeGameManager = gameManager;
         }
         catch (Exception exception)
         {
             Debug.LogException(exception);
         }
+    }
+
+    /// <summary>
+    /// Preloads only the active faction's briefing media while its introduction video plays.
+    /// </summary>
+    /// <param name="briefing">The active faction briefing, or null.</param>
+    /// <returns>A task that completes when the briefing media is resident.</returns>
+    private static Task PreloadBriefingContentAsync(StrategyBriefingTheme briefing)
+    {
+        return briefing == null
+            ? Task.CompletedTask
+            : AppBootstrap
+                .Instance.GetContentAssets()
+                .PreloadAsync(briefing.CreatePreloadManifest());
     }
 }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyBriefingController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyBriefingController.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Linq;
+using Rebellion.Game;
+using Rebellion.Game.Galaxy;
+using Rebellion.SceneGraph;
+using UnityEngine;
+using Faction = Rebellion.Game.Factions.Faction;
+
+/// <summary>
+/// Sequences faction briefings and projects each segment onto the strategy map.
+/// </summary>
+public sealed class StrategyBriefingController
+{
+    private readonly Func<string, float> getAudioDuration;
+    private readonly Func<string, Texture2D> getTexture;
+    private readonly GameRoot game;
+    private readonly GalaxyMapController galaxyMapController;
+    private readonly Action playPresentationSfx;
+    private readonly StrategyHudController strategyHudController;
+
+    private StrategyBriefingTheme activeBriefing;
+    private Action completed;
+    private int segmentIndex;
+
+    /// <summary>
+    /// Creates a briefing coordinator from its direct playback and map dependencies.
+    /// </summary>
+    /// <param name="game">The active game.</param>
+    /// <param name="getTexture">Resolves a preloaded briefing frame.</param>
+    /// <param name="getAudioDuration">Resolves the duration of a preloaded voice clip.</param>
+    /// <param name="strategyHudController">Presents advisor animation playback.</param>
+    /// <param name="galaxyMapController">Presents briefing map cues.</param>
+    /// <param name="playPresentationSfx">Plays the map-presentation transition sound.</param>
+    public StrategyBriefingController(
+        GameRoot game,
+        Func<string, Texture2D> getTexture,
+        Func<string, float> getAudioDuration,
+        StrategyHudController strategyHudController,
+        GalaxyMapController galaxyMapController,
+        Action playPresentationSfx
+    )
+    {
+        this.game = game ?? throw new ArgumentNullException(nameof(game));
+        this.getTexture = getTexture ?? throw new ArgumentNullException(nameof(getTexture));
+        this.getAudioDuration =
+            getAudioDuration ?? throw new ArgumentNullException(nameof(getAudioDuration));
+        this.strategyHudController =
+            strategyHudController ?? throw new ArgumentNullException(nameof(strategyHudController));
+        this.galaxyMapController =
+            galaxyMapController ?? throw new ArgumentNullException(nameof(galaxyMapController));
+        this.playPresentationSfx =
+            playPresentationSfx ?? throw new ArgumentNullException(nameof(playPresentationSfx));
+    }
+
+    /// <summary>
+    /// Plays every configured segment in order.
+    /// </summary>
+    /// <param name="briefing">The active faction briefing.</param>
+    /// <param name="onCompleted">Invoked after playback completes or is skipped.</param>
+    public void Play(StrategyBriefingTheme briefing, Action onCompleted)
+    {
+        if (briefing == null || briefing.Segments.Count == 0)
+        {
+            onCompleted?.Invoke();
+            return;
+        }
+
+        activeBriefing = briefing;
+        completed = onCompleted;
+        segmentIndex = 0;
+        PlayCurrentSegment();
+    }
+
+    /// <summary>
+    /// Cancels the remaining segments and plays the configured skip response when available.
+    /// </summary>
+    public void Skip()
+    {
+        if (activeBriefing == null)
+            return;
+
+        StrategyBriefingSegmentTheme skip = activeBriefing.Skip;
+        strategyHudController.CancelAdvisorAnimation();
+        segmentIndex = activeBriefing.Segments.Count;
+        if (skip == null)
+        {
+            Complete();
+            return;
+        }
+
+        strategyHudController.ReplaceAdvisorAnimation(CreatePlayback(skip), null, Complete);
+    }
+
+    /// <summary>
+    /// Pauses the active advisor animation without discarding briefing state.
+    /// </summary>
+    public void Pause()
+    {
+        strategyHudController.PauseAdvisorAnimation();
+    }
+
+    /// <summary>
+    /// Resumes the active advisor animation from its paused position.
+    /// </summary>
+    public void Resume()
+    {
+        strategyHudController.ResumeAdvisorAnimation();
+    }
+
+    /// <summary>
+    /// Resolves one segment into resident advisor playback data.
+    /// </summary>
+    /// <param name="segment">The configured briefing segment.</param>
+    /// <returns>The resolved animation presentation.</returns>
+    private StrategyAdvisorAnimationViewData CreatePlayback(StrategyBriefingSegmentTheme segment)
+    {
+        if (segment == null || segment.FrameCount <= 0)
+            throw new InvalidOperationException("Briefing contains an empty animation segment.");
+
+        Texture2D[] frames = new Texture2D[segment.FrameCount];
+        for (int frameIndex = 0; frameIndex < segment.FrameCount; frameIndex++)
+        {
+            string path = activeBriefing.GetFramePath(segment.Animation, frameIndex);
+            frames[frameIndex] = getTexture(path);
+            if (frames[frameIndex] == null)
+                throw new InvalidOperationException($"Briefing frame is missing: {path}");
+        }
+
+        string audioPath = string.IsNullOrWhiteSpace(segment.Audio)
+            ? null
+            : activeBriefing.GetAudioPath(segment.Audio);
+        return new StrategyAdvisorAnimationViewData(
+            frames,
+            false,
+            audioPath,
+            segment.DelayBeforeSeconds,
+            string.IsNullOrEmpty(audioPath) ? 0f : getAudioDuration(audioPath)
+        );
+    }
+
+    /// <summary>
+    /// Advances to the next configured segment or completes the briefing.
+    /// </summary>
+    private void HandleSegmentCompleted()
+    {
+        segmentIndex++;
+        if (segmentIndex < activeBriefing.Segments.Count)
+            PlayCurrentSegment();
+        else
+            Complete();
+    }
+
+    /// <summary>
+    /// Resolves and begins the current segment.
+    /// </summary>
+    private void PlayCurrentSegment()
+    {
+        StrategyBriefingSegmentTheme segment = activeBriefing.Segments[segmentIndex];
+        strategyHudController.ReplaceAdvisorAnimation(
+            CreatePlayback(segment),
+            () => PresentSegment(segment),
+            HandleSegmentCompleted
+        );
+    }
+
+    /// <summary>
+    /// Resolves one semantic focus into a transient galaxy-map presentation.
+    /// </summary>
+    /// <param name="segment">The segment whose playback is starting.</param>
+    private void PresentSegment(StrategyBriefingSegmentTheme segment)
+    {
+        StrategyBriefingMapPresentation presentation = CreateMapPresentation(game, segment);
+        if (presentation.DimBackground)
+            playPresentationSfx();
+
+        galaxyMapController.SetBriefingPresentation(presentation);
+    }
+
+    /// <summary>
+    /// Resolves one semantic focus into a transient galaxy-map presentation.
+    /// </summary>
+    /// <param name="game">The active game.</param>
+    /// <param name="segment">The segment whose playback is starting.</param>
+    /// <returns>The resolved map presentation.</returns>
+    internal static StrategyBriefingMapPresentation CreateMapPresentation(
+        GameRoot game,
+        StrategyBriefingSegmentTheme segment
+    )
+    {
+        if (game == null)
+            throw new ArgumentNullException(nameof(game));
+        if (segment == null)
+            throw new ArgumentNullException(nameof(segment));
+
+        string targetID = segment.TargetInstanceID;
+        Faction playerFaction = game.GetPlayerFaction();
+        Faction opponentFaction = game.GetFactions()
+            .FirstOrDefault(faction => faction != playerFaction);
+        if (segment.Focus == StrategyBriefingFocus.PlayerHeadquarters)
+            targetID = playerFaction?.HQInstanceID;
+        else if (segment.Focus == StrategyBriefingFocus.OpponentHeadquarters)
+            targetID = opponentFaction?.HQInstanceID;
+
+        bool requiresTarget =
+            segment.Focus == StrategyBriefingFocus.Target
+            || segment.Focus == StrategyBriefingFocus.PlayerHeadquarters
+            || segment.Focus == StrategyBriefingFocus.OpponentHeadquarters;
+        if (requiresTarget && string.IsNullOrEmpty(targetID))
+        {
+            throw new InvalidOperationException(
+                $"Briefing focus {segment.Focus} requires a target instance ID."
+            );
+        }
+
+        ISceneNode target = game.GetSceneNodeByInstanceID<ISceneNode>(targetID);
+        if (requiresTarget && target == null)
+            throw new InvalidOperationException($"Briefing target '{targetID}' was not found.");
+
+        Planet targetPlanet = target as Planet ?? target?.GetParentOfType<Planet>();
+        PlanetSystem targetSystem =
+            target as PlanetSystem ?? target?.GetParentOfType<PlanetSystem>();
+        if (requiresTarget && targetSystem == null)
+        {
+            throw new InvalidOperationException(
+                $"Briefing target '{targetID}' cannot be presented on the galaxy map."
+            );
+        }
+
+        string label = segment.Label;
+        if (string.IsNullOrEmpty(label) && segment.Focus != StrategyBriefingFocus.None)
+            label = target?.DisplayName;
+        StrategyBriefingMapMode mapMode = segment.MapMode;
+        if (mapMode == StrategyBriefingMapMode.Default && targetPlanet != null)
+            mapMode = StrategyBriefingMapMode.Spotlight;
+
+        bool presentsMap =
+            mapMode != StrategyBriefingMapMode.Default
+            || segment.Focus != StrategyBriefingFocus.None;
+        return new StrategyBriefingMapPresentation(
+            mapMode,
+            label,
+            targetSystem?.InstanceID,
+            targetPlanet?.InstanceID,
+            playerFaction?.InstanceID,
+            opponentFaction?.InstanceID,
+            presentsMap
+        );
+    }
+
+    /// <summary>
+    /// Restores normal map presentation and reports final completion once.
+    /// </summary>
+    private void Complete()
+    {
+        activeBriefing = null;
+        segmentIndex = 0;
+        galaxyMapController.SetBriefingPresentation(null);
+        Action onCompleted = completed;
+        completed = null;
+        onCompleted?.Invoke();
+    }
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyBriefingController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyBriefingController.cs
@@ -194,8 +194,7 @@ public sealed class StrategyBriefingController
 
         string targetID = segment.TargetInstanceID;
         Faction playerFaction = game.GetPlayerFaction();
-        Faction opponentFaction = game.GetFactions()
-            .FirstOrDefault(faction => faction != playerFaction);
+        Faction opponentFaction = game.GetFactions().Single(faction => faction != playerFaction);
         if (segment.Focus == StrategyBriefingFocus.PlayerHeadquarters)
             targetID = playerFaction?.HQInstanceID;
         else if (segment.Focus == StrategyBriefingFocus.OpponentHeadquarters)

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -75,11 +75,16 @@ public sealed class StrategyController
     [SerializeField]
     private BookmarkBarView bookmarkBar;
 
+    [SerializeField]
+    private SaveMenuConfirmDialogView briefingSkipConfirmation;
+
     private CancelStack cancelStack;
     private GameManager gameManager;
     private MessageSystem messageSystem;
     private StrategyBriefingTheme activeBriefing;
     private bool briefingActive;
+    private EventSystem briefingEventSystem;
+    private bool briefingSkipConfirmationOpen;
     private UIContext uiContext;
 
     private bool dirty = true;
@@ -193,7 +198,8 @@ public sealed class StrategyController
             () => gameManager?.GetPlayerFaction(),
             () => uiContext?.GetPlayerFactionTheme(),
             path => uiContext?.GetTexture(path),
-            PlaySfx
+            PlaySfx,
+            path => AppBootstrap.Instance.GetContentAssets().GetPreloadedAudio(path).length
         );
         strategyHudController.Initialize(this);
         strategyHudController.BindView(strategyHud);
@@ -241,7 +247,8 @@ public sealed class StrategyController
             strategyWindowLayerView,
             strategyWindowManager
         );
-        strategyWindowLayerView.RenderModalState(strategyWindowManager.HasModalWindow());
+        bool hasModalWindow = strategyWindowManager.HasModalWindow();
+        strategyWindowLayerView.RenderModalState(hasModalWindow, hasModalWindow);
     }
 
     /// <summary>
@@ -479,6 +486,8 @@ public sealed class StrategyController
         strategyContextMenu.DismissRequested += HandleContextMenuDismissRequested;
         strategyOverlay.TargetingCancelRequested += HandleTargetingCancelRequested;
         bookmarkBar.BookmarkRequested += HandleBookmarkRequested;
+        briefingSkipConfirmation.Confirmed += ConfirmBriefingSkip;
+        briefingSkipConfirmation.Canceled += CancelBriefingSkip;
     }
 
     /// <summary>
@@ -509,6 +518,11 @@ public sealed class StrategyController
             strategyOverlay.TargetingCancelRequested -= HandleTargetingCancelRequested;
         if (bookmarkBar != null)
             bookmarkBar.BookmarkRequested -= HandleBookmarkRequested;
+        if (briefingSkipConfirmation != null)
+        {
+            briefingSkipConfirmation.Confirmed -= ConfirmBriefingSkip;
+            briefingSkipConfirmation.Canceled -= CancelBriefingSkip;
+        }
     }
 
     /// <summary>
@@ -638,6 +652,7 @@ public sealed class StrategyController
     /// </summary>
     private void OnDestroy()
     {
+        SetBriefingInteractionEnabled(true);
         UnregisterCancelHandlers();
         UnsubscribeViewEvents();
         if (gameManager != null)
@@ -659,12 +674,21 @@ public sealed class StrategyController
 
         if (briefingActive)
         {
-            if (Input.anyKeyDown || Input.GetMouseButtonDown(0) || Input.GetMouseButtonDown(1))
+            if (Input.GetKeyDown(KeyCode.Escape))
             {
-                briefingActive = false;
-                AudioManager.EnsureExists().StopSfx();
-                strategyHudController.SkipBriefing(activeBriefing);
+                if (briefingSkipConfirmationOpen)
+                {
+                    briefingSkipConfirmation.Hide();
+                    CancelBriefingSkip();
+                }
+                else
+                {
+                    OpenBriefingSkipConfirmation();
+                }
             }
+
+            if (dirty)
+                Render();
             return;
         }
 
@@ -694,7 +718,16 @@ public sealed class StrategyController
             return;
         }
 
+        AudioManager
+            .EnsureExists()
+            .PreloadSfx(
+                StrategyUISoundPaths.GetBriefingPreloadPaths(uiContext.GetPlayerFactionTheme())
+            );
         briefingActive = true;
+        briefingSkipConfirmationOpen = false;
+        briefingEventSystem = EventSystem.current;
+        SetBriefingInteractionEnabled(false);
+        dirty = true;
         StopMusic();
         strategyHudController.PlayBriefing(
             activeBriefing,
@@ -702,9 +735,13 @@ public sealed class StrategyController
             () =>
             {
                 briefingActive = false;
+                briefingSkipConfirmationOpen = false;
+                SetBriefingInteractionEnabled(true);
+                briefingEventSystem = null;
                 activeBriefing = null;
                 galaxyMapController.SetBriefingPresentation(null);
                 strategyMusicController.Resume();
+                messagesWindowController.Open(MessagesTab.Advice);
                 completed?.Invoke();
                 dirty = true;
             }
@@ -728,16 +765,42 @@ public sealed class StrategyController
         else if (segment.BriefingFocus == StrategyBriefingFocus.OpponentHeadquarters)
             targetID = opponentFaction?.HQInstanceID;
 
+        bool requiresTarget =
+            segment.BriefingFocus == StrategyBriefingFocus.Target
+            || segment.BriefingFocus == StrategyBriefingFocus.PlayerHeadquarters
+            || segment.BriefingFocus == StrategyBriefingFocus.OpponentHeadquarters;
+        if (requiresTarget && string.IsNullOrEmpty(targetID))
+        {
+            throw new InvalidOperationException(
+                $"Briefing focus {segment.BriefingFocus} requires a target instance ID."
+            );
+        }
+
         ISceneNode target = gameManager.GetGame().GetSceneNodeByInstanceID<ISceneNode>(targetID);
+        if (requiresTarget && target == null)
+            throw new InvalidOperationException($"Briefing target '{targetID}' was not found.");
+
         Planet targetPlanet = target as Planet ?? target?.GetParentOfType<Planet>();
         PlanetSystem targetSystem =
             target as PlanetSystem ?? target?.GetParentOfType<PlanetSystem>();
+        if (requiresTarget && targetSystem == null)
+        {
+            throw new InvalidOperationException(
+                $"Briefing target '{targetID}' cannot be presented on the galaxy map."
+            );
+        }
         string label = segment.BriefingLabel;
         if (string.IsNullOrEmpty(label) && segment.BriefingFocus != StrategyBriefingFocus.None)
             label = target?.DisplayName;
         StrategyBriefingMapMode mapMode = segment.BriefingMapMode;
         if (mapMode == StrategyBriefingMapMode.Default && targetPlanet != null)
             mapMode = StrategyBriefingMapMode.Spotlight;
+
+        if (
+            mapMode != StrategyBriefingMapMode.Default
+            || segment.BriefingFocus != StrategyBriefingFocus.None
+        )
+            PlaySfx(StrategyUISoundPaths.GalacticInformationControl);
 
         galaxyMapController.SetBriefingPresentation(
             new StrategyBriefingMapPresentation(
@@ -746,10 +809,59 @@ public sealed class StrategyController
                 targetSystem?.InstanceID,
                 targetPlanet?.InstanceID,
                 playerFaction?.InstanceID,
-                opponentFaction?.InstanceID
+                opponentFaction?.InstanceID,
+                mapMode != StrategyBriefingMapMode.Default
+                    || segment.BriefingFocus != StrategyBriefingFocus.None
             )
         );
         dirty = true;
+    }
+
+    /// <summary>
+    /// Pauses briefing playback and asks whether the player wants to skip it.
+    /// </summary>
+    private void OpenBriefingSkipConfirmation()
+    {
+        briefingSkipConfirmationOpen = true;
+        strategyHudController.PauseBriefing();
+        AudioManager.EnsureExists().PauseSfx();
+        SetBriefingInteractionEnabled(true);
+        briefingSkipConfirmation.Show("Do you wish to skip the tutorial?");
+    }
+
+    /// <summary>
+    /// Cancels active narration and begins the configured skip response.
+    /// </summary>
+    private void ConfirmBriefingSkip()
+    {
+        briefingSkipConfirmationOpen = false;
+        SetBriefingInteractionEnabled(false);
+        AudioManager.EnsureExists().StopSfx();
+        strategyHudController.ResumeBriefing();
+        strategyHudController.SkipBriefing(activeBriefing);
+        dirty = true;
+    }
+
+    /// <summary>
+    /// Resumes tutorial narration after the player rejects the skip request.
+    /// </summary>
+    private void CancelBriefingSkip()
+    {
+        briefingSkipConfirmationOpen = false;
+        SetBriefingInteractionEnabled(false);
+        strategyHudController.ResumeBriefing();
+        AudioManager.EnsureExists().ResumeSfx();
+        dirty = true;
+    }
+
+    /// <summary>
+    /// Enables UI event routing only while the briefing skip confirmation needs it.
+    /// </summary>
+    /// <param name="enabled">Whether Unity UI controls may receive input.</param>
+    private void SetBriefingInteractionEnabled(bool enabled)
+    {
+        if (briefingEventSystem != null)
+            briefingEventSystem.enabled = enabled;
     }
 
     /// <summary>
@@ -834,6 +946,9 @@ public sealed class StrategyController
         ValidateGalacticInformationLayer();
         ValidateBookmarkLayer();
         ValidateContextMenuLayer();
+
+        if (briefingSkipConfirmation == null)
+            throw new MissingReferenceException("Briefing skip confirmation dialog is missing.");
     }
 
     /// <summary>
@@ -1044,7 +1159,8 @@ public sealed class StrategyController
     /// </summary>
     private void RenderWindowContent()
     {
-        strategyWindowLayerView.RenderModalState(strategyWindowManager.HasModalWindow());
+        bool hasModalWindow = strategyWindowManager.HasModalWindow();
+        strategyWindowLayerView.RenderModalState(briefingActive || hasModalWindow, hasModalWindow);
         advisorReportWindowController.RenderWindows();
         statusWindowController.RenderWindows();
         encyclopediaWindowController.RenderWindows();
@@ -1317,7 +1433,8 @@ public sealed class StrategyController
         if (window == null)
             return;
 
-        strategyWindowLayerView.RenderModalState(strategyWindowManager.HasModalWindow());
+        bool hasModalWindow = strategyWindowManager.HasModalWindow();
+        strategyWindowLayerView.RenderModalState(hasModalWindow, hasModalWindow);
         galacticInformationDisplayController?.Hide();
         targetingController?.Cancel();
         contextMenuController?.Cancel();
@@ -1334,7 +1451,8 @@ public sealed class StrategyController
         if (window == null)
             return;
 
-        strategyWindowLayerView.RenderModalState(strategyWindowManager.HasModalWindow());
+        bool hasModalWindow = strategyWindowManager.HasModalWindow();
+        strategyWindowLayerView.RenderModalState(hasModalWindow, hasModalWindow);
         targetingController?.Cancel();
         ClearWindowMovePreview();
         dirty = true;
@@ -1377,13 +1495,7 @@ public sealed class StrategyController
     private void PreloadStrategySfx()
     {
         FactionTheme playerTheme = uiContext?.GetPlayerFactionTheme();
-        AudioManager
-            .EnsureExists()
-            .PreloadSfx(
-                StrategyUISoundPaths
-                    .GetPreloadPaths(playerTheme)
-                    .Concat(StrategyUISoundPaths.GetBriefingPreloadPaths(playerTheme))
-            );
+        AudioManager.EnsureExists().PreloadSfx(StrategyUISoundPaths.GetPreloadPaths(playerTheme));
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -772,7 +772,6 @@ public sealed class StrategyController
         briefingSkipConfirmationOpen = false;
         SetBriefingInteractionEnabled(false);
         AudioManager.EnsureExists().StopSfx();
-        briefingController.Resume();
         briefingController.Skip();
         dirty = true;
     }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -1456,7 +1456,7 @@ public sealed class StrategyController
             strategyWindowManager.DestroyWindow(window);
         }
 
-        strategyWindowLayerView.RenderModalState(false);
+        strategyWindowLayerView.RenderModalState(false, false);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -81,7 +81,7 @@ public sealed class StrategyController
     private CancelStack cancelStack;
     private GameManager gameManager;
     private MessageSystem messageSystem;
-    private StrategyBriefingTheme activeBriefing;
+    private StrategyBriefingController briefingController;
     private bool briefingActive;
     private EventSystem briefingEventSystem;
     private bool briefingSkipConfirmationOpen;
@@ -198,8 +198,7 @@ public sealed class StrategyController
             () => gameManager?.GetPlayerFaction(),
             () => uiContext?.GetPlayerFactionTheme(),
             path => uiContext?.GetTexture(path),
-            PlaySfx,
-            path => AppBootstrap.Instance.GetContentAssets().GetPreloadedAudio(path).length
+            PlaySfx
         );
         strategyHudController.Initialize(this);
         strategyHudController.BindView(strategyHud);
@@ -207,6 +206,14 @@ public sealed class StrategyController
         galaxyMapController = new GalaxyMapController(() => uiContext);
         galaxyMapController.Initialize(this);
         galaxyMapController.BindView(galaxyMap);
+        briefingController = new StrategyBriefingController(
+            gameManager.GetGame(),
+            path => uiContext?.GetTexture(path),
+            path => AppBootstrap.Instance.GetContentAssets().GetPreloadedAudio(path).length,
+            strategyHudController,
+            galaxyMapController,
+            () => PlaySfx(StrategyUISoundPaths.GalacticInformationControl)
+        );
         galacticInformationDisplayController = new GalacticInformationDisplayController(
             () => uiContext,
             PlaySfx
@@ -711,8 +718,8 @@ public sealed class StrategyController
     /// <param name="completed">Invoked after playback completes or is skipped.</param>
     public void PlayBriefing(Action completed)
     {
-        activeBriefing = uiContext?.GetPlayerFactionTheme()?.StrategyBriefing;
-        if (activeBriefing == null || activeBriefing.Segments.Count == 0)
+        StrategyBriefingTheme briefing = uiContext?.GetPlayerFactionTheme()?.StrategyBriefing;
+        if (briefing == null || briefing.Segments.Count == 0)
         {
             completed?.Invoke();
             return;
@@ -729,17 +736,14 @@ public sealed class StrategyController
         SetBriefingInteractionEnabled(false);
         dirty = true;
         StopMusic();
-        strategyHudController.PlayBriefing(
-            activeBriefing,
-            FocusBriefingSegment,
+        briefingController.Play(
+            briefing,
             () =>
             {
                 briefingActive = false;
                 briefingSkipConfirmationOpen = false;
                 SetBriefingInteractionEnabled(true);
                 briefingEventSystem = null;
-                activeBriefing = null;
-                galaxyMapController.SetBriefingPresentation(null);
                 strategyMusicController.Resume();
                 messagesWindowController.Open(MessagesTab.Advice);
                 completed?.Invoke();
@@ -749,81 +753,12 @@ public sealed class StrategyController
     }
 
     /// <summary>
-    /// Applies one semantic briefing focus without encoding faction-specific behavior in code.
-    /// </summary>
-    /// <param name="segment">The briefing segment whose focus is starting.</param>
-    private void FocusBriefingSegment(StrategyAdvisorAnimationTheme segment)
-    {
-        string targetID = segment.BriefingTargetInstanceID;
-        Faction playerFaction = gameManager.GetPlayerFaction();
-        Faction opponentFaction = gameManager
-            .GetGame()
-            .GetFactions()
-            .FirstOrDefault(faction => faction != playerFaction);
-        if (segment.BriefingFocus == StrategyBriefingFocus.PlayerHeadquarters)
-            targetID = playerFaction?.HQInstanceID;
-        else if (segment.BriefingFocus == StrategyBriefingFocus.OpponentHeadquarters)
-            targetID = opponentFaction?.HQInstanceID;
-
-        bool requiresTarget =
-            segment.BriefingFocus == StrategyBriefingFocus.Target
-            || segment.BriefingFocus == StrategyBriefingFocus.PlayerHeadquarters
-            || segment.BriefingFocus == StrategyBriefingFocus.OpponentHeadquarters;
-        if (requiresTarget && string.IsNullOrEmpty(targetID))
-        {
-            throw new InvalidOperationException(
-                $"Briefing focus {segment.BriefingFocus} requires a target instance ID."
-            );
-        }
-
-        ISceneNode target = gameManager.GetGame().GetSceneNodeByInstanceID<ISceneNode>(targetID);
-        if (requiresTarget && target == null)
-            throw new InvalidOperationException($"Briefing target '{targetID}' was not found.");
-
-        Planet targetPlanet = target as Planet ?? target?.GetParentOfType<Planet>();
-        PlanetSystem targetSystem =
-            target as PlanetSystem ?? target?.GetParentOfType<PlanetSystem>();
-        if (requiresTarget && targetSystem == null)
-        {
-            throw new InvalidOperationException(
-                $"Briefing target '{targetID}' cannot be presented on the galaxy map."
-            );
-        }
-        string label = segment.BriefingLabel;
-        if (string.IsNullOrEmpty(label) && segment.BriefingFocus != StrategyBriefingFocus.None)
-            label = target?.DisplayName;
-        StrategyBriefingMapMode mapMode = segment.BriefingMapMode;
-        if (mapMode == StrategyBriefingMapMode.Default && targetPlanet != null)
-            mapMode = StrategyBriefingMapMode.Spotlight;
-
-        if (
-            mapMode != StrategyBriefingMapMode.Default
-            || segment.BriefingFocus != StrategyBriefingFocus.None
-        )
-            PlaySfx(StrategyUISoundPaths.GalacticInformationControl);
-
-        galaxyMapController.SetBriefingPresentation(
-            new StrategyBriefingMapPresentation(
-                mapMode,
-                label,
-                targetSystem?.InstanceID,
-                targetPlanet?.InstanceID,
-                playerFaction?.InstanceID,
-                opponentFaction?.InstanceID,
-                mapMode != StrategyBriefingMapMode.Default
-                    || segment.BriefingFocus != StrategyBriefingFocus.None
-            )
-        );
-        dirty = true;
-    }
-
-    /// <summary>
     /// Pauses briefing playback and asks whether the player wants to skip it.
     /// </summary>
     private void OpenBriefingSkipConfirmation()
     {
         briefingSkipConfirmationOpen = true;
-        strategyHudController.PauseBriefing();
+        briefingController.Pause();
         AudioManager.EnsureExists().PauseSfx();
         SetBriefingInteractionEnabled(true);
         briefingSkipConfirmation.Show("Do you wish to skip the tutorial?");
@@ -837,8 +772,8 @@ public sealed class StrategyController
         briefingSkipConfirmationOpen = false;
         SetBriefingInteractionEnabled(false);
         AudioManager.EnsureExists().StopSfx();
-        strategyHudController.ResumeBriefing();
-        strategyHudController.SkipBriefing(activeBriefing);
+        briefingController.Resume();
+        briefingController.Skip();
         dirty = true;
     }
 
@@ -849,7 +784,7 @@ public sealed class StrategyController
     {
         briefingSkipConfirmationOpen = false;
         SetBriefingInteractionEnabled(false);
-        strategyHudController.ResumeBriefing();
+        briefingController.Resume();
         AudioManager.EnsureExists().ResumeSfx();
         dirty = true;
     }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -78,6 +78,8 @@ public sealed class StrategyController
     private CancelStack cancelStack;
     private GameManager gameManager;
     private MessageSystem messageSystem;
+    private StrategyBriefingTheme activeBriefing;
+    private bool briefingActive;
     private UIContext uiContext;
 
     private bool dirty = true;
@@ -655,6 +657,17 @@ public sealed class StrategyController
         if (gameManager == null || !contentReady)
             return;
 
+        if (briefingActive)
+        {
+            if (Input.anyKeyDown || Input.GetMouseButtonDown(0) || Input.GetMouseButtonDown(1))
+            {
+                briefingActive = false;
+                AudioManager.EnsureExists().StopSfx();
+                strategyHudController.SkipBriefing(activeBriefing);
+            }
+            return;
+        }
+
         if (battleAlertWindowController.SyncPendingCombatWindow())
             dirty = true;
 
@@ -666,6 +679,77 @@ public sealed class StrategyController
         );
         if (dirty)
             Render();
+    }
+
+    /// <summary>
+    /// Plays the faction-configured new-game briefing over the initialized strategy screen.
+    /// </summary>
+    /// <param name="completed">Invoked after playback completes or is skipped.</param>
+    public void PlayBriefing(Action completed)
+    {
+        activeBriefing = uiContext?.GetPlayerFactionTheme()?.StrategyBriefing;
+        if (activeBriefing == null || activeBriefing.Segments.Count == 0)
+        {
+            completed?.Invoke();
+            return;
+        }
+
+        briefingActive = true;
+        StopMusic();
+        strategyHudController.PlayBriefing(
+            activeBriefing,
+            FocusBriefingSegment,
+            () =>
+            {
+                briefingActive = false;
+                activeBriefing = null;
+                galaxyMapController.SetBriefingPresentation(null);
+                strategyMusicController.Resume();
+                completed?.Invoke();
+                dirty = true;
+            }
+        );
+    }
+
+    /// <summary>
+    /// Applies one semantic briefing focus without encoding faction-specific behavior in code.
+    /// </summary>
+    /// <param name="segment">The briefing segment whose focus is starting.</param>
+    private void FocusBriefingSegment(StrategyAdvisorAnimationTheme segment)
+    {
+        string targetID = segment.BriefingTargetInstanceID;
+        Faction playerFaction = gameManager.GetPlayerFaction();
+        Faction opponentFaction = gameManager
+            .GetGame()
+            .GetFactions()
+            .FirstOrDefault(faction => faction != playerFaction);
+        if (segment.BriefingFocus == StrategyBriefingFocus.PlayerHeadquarters)
+            targetID = playerFaction?.HQInstanceID;
+        else if (segment.BriefingFocus == StrategyBriefingFocus.OpponentHeadquarters)
+            targetID = opponentFaction?.HQInstanceID;
+
+        ISceneNode target = gameManager.GetGame().GetSceneNodeByInstanceID<ISceneNode>(targetID);
+        Planet targetPlanet = target as Planet ?? target?.GetParentOfType<Planet>();
+        PlanetSystem targetSystem =
+            target as PlanetSystem ?? target?.GetParentOfType<PlanetSystem>();
+        string label = segment.BriefingLabel;
+        if (string.IsNullOrEmpty(label) && segment.BriefingFocus != StrategyBriefingFocus.None)
+            label = target?.DisplayName;
+        StrategyBriefingMapMode mapMode = segment.BriefingMapMode;
+        if (mapMode == StrategyBriefingMapMode.Default && targetPlanet != null)
+            mapMode = StrategyBriefingMapMode.Spotlight;
+
+        galaxyMapController.SetBriefingPresentation(
+            new StrategyBriefingMapPresentation(
+                mapMode,
+                label,
+                targetSystem?.InstanceID,
+                targetPlanet?.InstanceID,
+                playerFaction?.InstanceID,
+                opponentFaction?.InstanceID
+            )
+        );
+        dirty = true;
     }
 
     /// <summary>
@@ -1292,9 +1376,14 @@ public sealed class StrategyController
     /// </summary>
     private void PreloadStrategySfx()
     {
+        FactionTheme playerTheme = uiContext?.GetPlayerFactionTheme();
         AudioManager
             .EnsureExists()
-            .PreloadSfx(StrategyUISoundPaths.GetPreloadPaths(uiContext?.GetPlayerFactionTheme()));
+            .PreloadSfx(
+                StrategyUISoundPaths
+                    .GetPreloadPaths(playerTheme)
+                    .Concat(StrategyUISoundPaths.GetBriefingPreloadPaths(playerTheme))
+            );
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -52,4 +52,26 @@ internal static class StrategyUISoundPaths
                 yield return path.Trim();
         }
     }
+
+    /// <summary>
+    /// Enumerates the active faction's dynamically preloaded briefing voice clips.
+    /// </summary>
+    /// <param name="theme">The active faction theme, or null.</param>
+    /// <returns>The configured briefing audio addresses.</returns>
+    internal static IEnumerable<string> GetBriefingPreloadPaths(FactionTheme theme)
+    {
+        StrategyBriefingTheme briefing = theme?.StrategyBriefing;
+        if (briefing == null)
+            yield break;
+
+        for (int i = 0; i < briefing.Segments.Count; i++)
+        {
+            int waveID = briefing.Segments[i]?.WaveID ?? 0;
+            if (waveID > 0)
+                yield return briefing.GetAudioPath(waveID);
+        }
+
+        if (briefing.Skip?.WaveID > 0)
+            yield return briefing.GetAudioPath(briefing.Skip.WaveID);
+    }
 }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -19,7 +19,7 @@ internal static class StrategyUISoundPaths
     public const string GalacticInformationControl = "Application/Strategy/Audio/Controls/open";
 
     public const string PlanetaryAssault =
-        "Application/Strategy/Audio/Messages/message-planetary-assault";
+        "Application/Strategy/Messages/Audio/message-planetary-assault";
 
     /// <summary>
     /// Enumerates shared and themed sound-effect paths used by the strategy interface.

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -66,12 +66,12 @@ internal static class StrategyUISoundPaths
 
         for (int i = 0; i < briefing.Segments.Count; i++)
         {
-            int waveID = briefing.Segments[i]?.WaveID ?? 0;
-            if (waveID > 0)
-                yield return briefing.GetAudioPath(waveID);
+            string audio = briefing.Segments[i]?.Audio;
+            if (!string.IsNullOrWhiteSpace(audio))
+                yield return briefing.GetAudioPath(audio);
         }
 
-        if (briefing.Skip?.WaveID > 0)
-            yield return briefing.GetAudioPath(briefing.Skip.WaveID);
+        if (!string.IsNullOrWhiteSpace(briefing.Skip?.Audio))
+            yield return briefing.GetAudioPath(briefing.Skip.Audio);
     }
 }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowLayerView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowLayerView.cs
@@ -157,18 +157,19 @@ public sealed class StrategyWindowLayerView : MonoBehaviour
     /// <summary>
     /// Renders the modal input blocker and background dimmer for the current registry state.
     /// </summary>
-    /// <param name="active">Whether a modal window currently owns interaction.</param>
-    internal void RenderModalState(bool active)
+    /// <param name="blockInput">Whether the modal layer owns interaction.</param>
+    /// <param name="dimBackground">Whether the underlying strategy screen is dimmed.</param>
+    internal void RenderModalState(bool blockInput, bool dimBackground)
     {
         if (modalInputBlockerImage == null)
             return;
 
-        SetModalImageActive(modalInputBlockerImage, active);
-        SetModalImageActive(modalBackgroundDimImage, active);
+        SetModalImageActive(modalInputBlockerImage, blockInput);
+        SetModalImageActive(modalBackgroundDimImage, dimBackground);
 
-        if (active)
+        if (blockInput)
             modalInputBlockerImage.transform.SetAsFirstSibling();
-        if (active && modalBackgroundDimImage != null)
+        if (dimBackground && modalBackgroundDimImage != null)
             modalBackgroundDimImage.transform.SetSiblingIndex(1);
     }
 

--- a/Assets/Scripts/UserSettings/UserAudioSettings.cs
+++ b/Assets/Scripts/UserSettings/UserAudioSettings.cs
@@ -10,6 +10,7 @@ public sealed class UserAudioSettings
     public float MusicVolume = 1f;
     public float SfxVolume = 1f;
     public float AmbienceVolume = 1f;
+    public float VideoVolume = 1f;
 
     /// <summary>
     /// Clamps volume settings to valid values.
@@ -20,6 +21,7 @@ public sealed class UserAudioSettings
         MusicVolume = Clamp01(MusicVolume);
         SfxVolume = Clamp01(SfxVolume);
         AmbienceVolume = Clamp01(AmbienceVolume);
+        VideoVolume = Clamp01(VideoVolume);
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/Managers/AudioManagerTests.cs
+++ b/Assets/Tests/EditMode/Managers/AudioManagerTests.cs
@@ -30,10 +30,12 @@ public sealed class AudioManagerTests
         Assert.AreEqual(1f, manager.MusicVolume);
         Assert.AreEqual(1f, manager.SfxVolume);
         Assert.AreEqual(1f, manager.AmbienceVolume);
+        Assert.AreEqual(1f, manager.VideoVolume);
         Assert.DoesNotThrow(() => manager.SetMasterVolume(0.75f));
         Assert.DoesNotThrow(() => manager.SetMusicVolume(0.25f));
         Assert.DoesNotThrow(() => manager.SetSfxVolume(0.5f));
         Assert.DoesNotThrow(() => manager.SetAmbienceVolume(0.625f));
+        Assert.DoesNotThrow(() => manager.SetVideoVolume(0.875f));
     }
 
     [Test]
@@ -46,6 +48,7 @@ public sealed class AudioManagerTests
             MusicVolume = 0.25f,
             SfxVolume = 0.5f,
             AmbienceVolume = 0.625f,
+            VideoVolume = 0.875f,
         };
 
         manager.ApplySettings(settings);
@@ -55,6 +58,8 @@ public sealed class AudioManagerTests
         Assert.AreEqual(0.25f, snapshot.MusicVolume);
         Assert.AreEqual(0.5f, snapshot.SfxVolume);
         Assert.AreEqual(0.625f, snapshot.AmbienceVolume);
+        Assert.AreEqual(0.875f, snapshot.VideoVolume);
+        Assert.AreEqual(0.65625f, manager.EffectiveVideoVolume);
     }
 
     [Test]
@@ -69,6 +74,7 @@ public sealed class AudioManagerTests
         Assert.AreEqual(1f, manager.MusicVolume);
         Assert.AreEqual(1f, manager.SfxVolume);
         Assert.AreEqual(1f, manager.AmbienceVolume);
+        Assert.AreEqual(1f, manager.VideoVolume);
     }
 
     [Test]
@@ -80,12 +86,14 @@ public sealed class AudioManagerTests
         manager.SetMusicVolume(2f);
         manager.SetSfxVolume(-0.5f);
         manager.SetAmbienceVolume(1.5f);
+        manager.SetVideoVolume(2f);
         UserAudioSettings snapshot = manager.CreateSettingsSnapshot();
 
         Assert.AreEqual(0f, snapshot.MasterVolume);
         Assert.AreEqual(1f, snapshot.MusicVolume);
         Assert.AreEqual(0f, snapshot.SfxVolume);
         Assert.AreEqual(1f, snapshot.AmbienceVolume);
+        Assert.AreEqual(1f, snapshot.VideoVolume);
     }
 
     [Test]

--- a/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
+++ b/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
@@ -14,10 +14,10 @@ namespace Rebellion.Tests.UI.Runtime.Themes
                     "Pack/Factions/Example/Strategy/Advisor/Animations/Notifications",
             };
 
-            string path = theme.GetFramePath(3331, 4, true);
+            string path = theme.GetFramePath("Standard", 4, true);
 
             Assert.AreEqual(
-                "Pack/Factions/Example/Strategy/Advisor/Animations/Notifications/Alert/3331/frame-004",
+                "Pack/Factions/Example/Strategy/Advisor/Animations/Notifications/Alert/Standard/frame-004",
                 path
             );
         }
@@ -30,27 +30,26 @@ namespace Rebellion.Tests.UI.Runtime.Themes
                 AnimationImageRoot = "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings",
             };
 
-            string path = theme.GetFramePath(2100, 12);
+            string path = theme.GetFramePath("Introduction", 12);
 
             Assert.AreEqual(
-                "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings/2100/frame-012",
+                "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings/Introduction/frame-012",
                 path
             );
         }
 
         [Test]
-        public void GetAudioPath_ReturnsNormalizedWavePath()
+        public void GetAudioPath_ReturnsNamedAudioPath()
         {
             StrategyAdvisorTheme theme = new StrategyAdvisorTheme
             {
                 AudioRoot = "Pack/Factions/Example/Strategy/Advisor/Audio/Notifications",
-                AudioFilePrefix = "advisor",
             };
 
-            string path = theme.GetAudioPath(42);
+            string path = theme.GetAudioPath("FleetArrived");
 
             Assert.AreEqual(
-                "Pack/Factions/Example/Strategy/Advisor/Audio/Notifications/advisor-0042",
+                "Pack/Factions/Example/Strategy/Advisor/Audio/Notifications/FleetArrived",
                 path
             );
         }
@@ -62,11 +61,22 @@ namespace Rebellion.Tests.UI.Runtime.Themes
             {
                 AnimationImageRoot = "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings",
                 AudioRoot = "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings",
-                AudioFilePrefix = "briefing",
-                Skip = new StrategyAdvisorAnimationTheme { BitmapID = 20, WaveID = 40 },
+                Skip = new StrategyAdvisorAnimationTheme { Animation = "Skip", Audio = "Skip" },
             };
-            theme.Segments.Add(new StrategyAdvisorAnimationTheme { BitmapID = 10, WaveID = 30 });
-            theme.Segments.Add(new StrategyAdvisorAnimationTheme { BitmapID = 10, WaveID = 30 });
+            theme.Segments.Add(
+                new StrategyAdvisorAnimationTheme
+                {
+                    Animation = "Introduction",
+                    Audio = "Introduction",
+                }
+            );
+            theme.Segments.Add(
+                new StrategyAdvisorAnimationTheme
+                {
+                    Animation = "Introduction",
+                    Audio = "Introduction",
+                }
+            );
 
             ContentPreloadManifest manifest = theme.CreatePreloadManifest();
 
@@ -74,16 +84,16 @@ namespace Rebellion.Tests.UI.Runtime.Themes
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings/10",
-                    "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings/20",
+                    "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings/Introduction",
+                    "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings/Skip",
                 },
                 manifest.TextureDirectories
             );
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/briefing-0030",
-                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/briefing-0040",
+                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/Introduction",
+                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/Skip",
                 },
                 manifest.Audio
             );

--- a/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
+++ b/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
@@ -61,17 +61,17 @@ namespace Rebellion.Tests.UI.Runtime.Themes
             {
                 AnimationImageRoot = "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings",
                 AudioRoot = "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings",
-                Skip = new StrategyAdvisorAnimationTheme { Animation = "Skip", Audio = "Skip" },
+                Skip = new StrategyBriefingSegmentTheme { Animation = "Skip", Audio = "Skip" },
             };
             theme.Segments.Add(
-                new StrategyAdvisorAnimationTheme
+                new StrategyBriefingSegmentTheme
                 {
                     Animation = "Introduction",
                     Audio = "Introduction",
                 }
             );
             theme.Segments.Add(
-                new StrategyAdvisorAnimationTheme
+                new StrategyBriefingSegmentTheme
                 {
                     Animation = "Introduction",
                     Audio = "Introduction",

--- a/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
+++ b/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
@@ -6,18 +6,34 @@ namespace Rebellion.Tests.UI.Runtime.Themes
     public class StrategyAdvisorThemeTests
     {
         [Test]
-        public void GetFramePath_ReturnsNormalizedRoleAndFramePath()
+        public void GetFramePath_ReturnsRoleResourceAndFramePath()
         {
             StrategyAdvisorTheme theme = new StrategyAdvisorTheme
             {
-                AnimationImageRoot = "Pack/Factions/Example/Strategy/UI/Advisor",
-                AnimationFilePrefix = "advisor",
+                AnimationImageRoot =
+                    "Pack/Factions/Example/Strategy/Advisor/Animations/Notifications",
             };
 
             string path = theme.GetFramePath(3331, 4, true);
 
             Assert.AreEqual(
-                "Pack/Factions/Example/Strategy/UI/Advisor/Droid/3331/advisor-droid-3331-frame-004",
+                "Pack/Factions/Example/Strategy/Advisor/Animations/Notifications/Alert/3331/frame-004",
+                path
+            );
+        }
+
+        [Test]
+        public void BriefingGetFramePath_ReturnsResourceAndFramePath()
+        {
+            StrategyBriefingTheme theme = new StrategyBriefingTheme
+            {
+                AnimationImageRoot = "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings",
+            };
+
+            string path = theme.GetFramePath(2100, 12);
+
+            Assert.AreEqual(
+                "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings/2100/frame-012",
                 path
             );
         }
@@ -27,13 +43,16 @@ namespace Rebellion.Tests.UI.Runtime.Themes
         {
             StrategyAdvisorTheme theme = new StrategyAdvisorTheme
             {
-                AudioRoot = "Pack/Factions/Example/Strategy/Audio/Advisor",
+                AudioRoot = "Pack/Factions/Example/Strategy/Advisor/Audio/Notifications",
                 AudioFilePrefix = "advisor",
             };
 
             string path = theme.GetAudioPath(42);
 
-            Assert.AreEqual("Pack/Factions/Example/Strategy/Audio/Advisor/advisor-0042", path);
+            Assert.AreEqual(
+                "Pack/Factions/Example/Strategy/Advisor/Audio/Notifications/advisor-0042",
+                path
+            );
         }
 
         [Test]
@@ -41,8 +60,8 @@ namespace Rebellion.Tests.UI.Runtime.Themes
         {
             StrategyBriefingTheme theme = new StrategyBriefingTheme
             {
-                AnimationImageRoot = "Pack/Factions/Example/Strategy/UI/Briefing/Protocol",
-                AudioRoot = "Pack/Factions/Example/Strategy/Audio/Briefing",
+                AnimationImageRoot = "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings",
+                AudioRoot = "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings",
                 AudioFilePrefix = "briefing",
                 Skip = new StrategyAdvisorAnimationTheme { BitmapID = 20, WaveID = 40 },
             };
@@ -55,16 +74,16 @@ namespace Rebellion.Tests.UI.Runtime.Themes
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    "Pack/Factions/Example/Strategy/UI/Briefing/Protocol/10",
-                    "Pack/Factions/Example/Strategy/UI/Briefing/Protocol/20",
+                    "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings/10",
+                    "Pack/Factions/Example/Strategy/Advisor/Animations/Briefings/20",
                 },
                 manifest.TextureDirectories
             );
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    "Pack/Factions/Example/Strategy/Audio/Briefing/briefing-0030",
-                    "Pack/Factions/Example/Strategy/Audio/Briefing/briefing-0040",
+                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/briefing-0030",
+                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/briefing-0040",
                 },
                 manifest.Audio
             );

--- a/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
+++ b/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
@@ -6,7 +6,7 @@ namespace Rebellion.Tests.UI.Runtime.Themes
     public class StrategyAdvisorThemeTests
     {
         [Test]
-        public void GetFramePath_ReturnsRoleResourceAndFramePath()
+        public void GetFramePath_AdvisorTheme_ReturnsRoleResourceAndFramePath()
         {
             StrategyAdvisorTheme theme = new StrategyAdvisorTheme
             {
@@ -23,7 +23,7 @@ namespace Rebellion.Tests.UI.Runtime.Themes
         }
 
         [Test]
-        public void BriefingGetFramePath_ReturnsResourceAndFramePath()
+        public void GetFramePath_BriefingTheme_ReturnsResourceAndFramePath()
         {
             StrategyBriefingTheme theme = new StrategyBriefingTheme
             {
@@ -39,7 +39,7 @@ namespace Rebellion.Tests.UI.Runtime.Themes
         }
 
         [Test]
-        public void GetAudioPath_ReturnsNamedAudioPath()
+        public void GetAudioPath_AdvisorTheme_ReturnsNamedAudioPath()
         {
             StrategyAdvisorTheme theme = new StrategyAdvisorTheme
             {

--- a/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
+++ b/Assets/Tests/EditMode/UI/Runtime/Themes/StrategyAdvisorThemeTests.cs
@@ -35,5 +35,39 @@ namespace Rebellion.Tests.UI.Runtime.Themes
 
             Assert.AreEqual("Pack/Factions/Example/Strategy/Audio/Advisor/advisor-0042", path);
         }
+
+        [Test]
+        public void CreatePreloadManifest_RepeatedAssets_ReturnsDistinctBriefingMedia()
+        {
+            StrategyBriefingTheme theme = new StrategyBriefingTheme
+            {
+                AnimationImageRoot = "Pack/Factions/Example/Strategy/UI/Briefing/Protocol",
+                AudioRoot = "Pack/Factions/Example/Strategy/Audio/Briefing",
+                AudioFilePrefix = "briefing",
+                Skip = new StrategyAdvisorAnimationTheme { BitmapID = 20, WaveID = 40 },
+            };
+            theme.Segments.Add(new StrategyAdvisorAnimationTheme { BitmapID = 10, WaveID = 30 });
+            theme.Segments.Add(new StrategyAdvisorAnimationTheme { BitmapID = 10, WaveID = 30 });
+
+            ContentPreloadManifest manifest = theme.CreatePreloadManifest();
+
+            Assert.AreEqual(64, manifest.TexturesPerFrame);
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "Pack/Factions/Example/Strategy/UI/Briefing/Protocol/10",
+                    "Pack/Factions/Example/Strategy/UI/Briefing/Protocol/20",
+                },
+                manifest.TextureDirectories
+            );
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "Pack/Factions/Example/Strategy/Audio/Briefing/briefing-0030",
+                    "Pack/Factions/Example/Strategy/Audio/Briefing/briefing-0040",
+                },
+                manifest.Audio
+            );
+        }
     }
 }

--- a/Assets/Tests/EditMode/UI/SceneUI/Cutscenes/CutsceneManagerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/Cutscenes/CutsceneManagerTests.cs
@@ -18,6 +18,7 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
         private CutsceneManager _manager;
         private GameObject _managerObject;
         private GameObject _playerPrefab;
+        private AudioManager _audioManager;
 
         [SetUp]
         public void SetUp()
@@ -26,6 +27,8 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
             _managerObject = new GameObject("CutsceneManager");
             _manager = _managerObject.AddComponent<CutsceneManager>();
             _manager.Initialize(_playerPrefab);
+            _audioManager = _managerObject.AddComponent<AudioManager>();
+            _manager.InitializeAudio(_audioManager);
             _clip = AssetDatabase.LoadAssetAtPath<VideoClip>(_clipPath);
         }
 
@@ -79,6 +82,18 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
             Assert.IsNotNull(player);
             Assert.AreEqual(0f, Time.timeScale);
             Assert.AreSame(_clip, player.GetComponent<VideoPlayer>().clip);
+        }
+
+        [Test]
+        public void Play_ValidClip_AppliesMasterScaledVideoVolume()
+        {
+            _audioManager.SetMasterVolume(0.5f);
+            _audioManager.SetVideoVolume(0.25f);
+
+            _manager.Play(_clip, null);
+            CutscenePlayer player = GetField<CutscenePlayer>("activePlayer");
+
+            Assert.AreEqual(0.125f, player.GetComponent<AudioSource>().volume);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UI/SceneUI/Cutscenes/CutscenePlayerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/Cutscenes/CutscenePlayerTests.cs
@@ -71,6 +71,14 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
         }
 
         [Test]
+        public void SetVolume_ValueOutsideRange_ClampsAudioSourceVolume()
+        {
+            _player.SetVolume(2f);
+
+            Assert.AreEqual(1f, _audioSource.volume);
+        }
+
+        [Test]
         public void ConfigureUrlPlayback_ValidUrl_ConfiguresUrlVideoSource()
         {
             const string videoUrl = "file:///tmp/cutscene.mp4";

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
@@ -275,6 +275,71 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
+        public void Project_BriefingUnexploredSystems_UsesBlueHighlightForUnexploredPlanets()
+        {
+            GamePlanetSystem system = CreateSystem("system", "Outer Rim", 0, 0);
+            Planet exploredPlanet = CreatePlanet("explored", _playerFactionId, 1, 2);
+            Planet unexploredPlanet = CreatePlanet("unexplored", null, 3, 4);
+            unexploredPlanet.IsUnexploredView = true;
+            GalaxyMapSector sector = CreateSector(system, exploredPlanet, unexploredPlanet);
+            FactionTheme playerTheme = _uiContext.GetPlayerFactionTheme();
+            FactionTheme defaultTheme = _uiContext.GetTheme(null);
+            StrategyBriefingMapPresentation briefing = new StrategyBriefingMapPresentation(
+                StrategyBriefingMapMode.UnexploredSystems,
+                "Unexplored Systems",
+                null,
+                null,
+                _playerFactionId,
+                _opposingFactionId
+            );
+
+            GalaxyMapRenderData data = _projector.Project(
+                new[] { sector },
+                _playerFactionId,
+                GalacticInformationFilterMode.DisplayOff,
+                null,
+                briefing
+            );
+
+            Assert.AreSame(
+                _uiContext.GetTexture(playerTheme.GalaxyBackground.PlanetIcons.Small),
+                data.Clusters[0].Stars[0].StarTexture
+            );
+            Assert.AreSame(
+                _uiContext.GetTexture(defaultTheme.GalaxyBackground.PlanetIcons.XL),
+                data.Clusters[0].Stars[1].StarTexture
+            );
+        }
+
+        [Test]
+        public void Project_DimmedBriefing_DimsOnlyGalaxyBackground()
+        {
+            GamePlanetSystem system = CreateSystem("system", "Corellia", 0, 0);
+            Planet planet = CreatePlanet("planet", _playerFactionId, 1, 2);
+            GalaxyMapSector sector = CreateSector(system, planet);
+            StrategyBriefingMapPresentation briefing = new StrategyBriefingMapPresentation(
+                StrategyBriefingMapMode.Default,
+                null,
+                null,
+                null,
+                _playerFactionId,
+                _opposingFactionId,
+                true
+            );
+
+            GalaxyMapRenderData data = _projector.Project(
+                new[] { sector },
+                _playerFactionId,
+                GalacticInformationFilterMode.DisplayOff,
+                null,
+                briefing
+            );
+
+            Assert.AreEqual(new Color(0.5f, 0.5f, 0.5f, 1f), data.BackgroundColor);
+            Assert.IsNotNull(data.Clusters[0].Stars[0].StarTexture);
+        }
+
+        [Test]
         public void Project_BriefingTarget_RevealsTargetSystemAndOverridesLabel()
         {
             GamePlanetSystem system = CreateSystem("system", "Corellia", 0, 0);
@@ -304,6 +369,32 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
                     _uiContext.GetPlayerFactionTheme().GalaxyBackground.PlanetIcons.XL
                 ),
                 data.Clusters[0].Stars[0].StarTexture
+            );
+        }
+
+        [Test]
+        public void Project_UnsupportedBriefingMode_ThrowsArgumentOutOfRangeException()
+        {
+            GamePlanetSystem system = CreateSystem("system", "Corellia", 0, 0);
+            Planet planet = CreatePlanet("planet", _playerFactionId, 1, 2);
+            GalaxyMapSector sector = CreateSector(system, planet);
+            StrategyBriefingMapPresentation briefing = new StrategyBriefingMapPresentation(
+                (StrategyBriefingMapMode)int.MaxValue,
+                "Invalid",
+                null,
+                null,
+                _playerFactionId,
+                _opposingFactionId
+            );
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                _projector.Project(
+                    new[] { sector },
+                    _playerFactionId,
+                    GalacticInformationFilterMode.DisplayOff,
+                    null,
+                    briefing
+                )
             );
         }
 

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
@@ -236,6 +236,78 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
+        public void Project_BriefingLoyalty_HighlightsOnlyConfiguredFactionAndUsesCueLabel()
+        {
+            GamePlanetSystem system = CreateSystem("system", "Corellia", 0, 0);
+            Planet playerPlanet = CreatePlanet("player", _playerFactionId, 1, 2);
+            Planet opposingPlanet = CreatePlanet("opposing", _opposingFactionId, 3, 4);
+            playerPlanet.SetFullPopularSupport(_playerFactionId);
+            opposingPlanet.SetFullPopularSupport(_opposingFactionId);
+            GalaxyMapSector sector = CreateSector(system, playerPlanet, opposingPlanet);
+            FactionTheme playerTheme = _uiContext.GetPlayerFactionTheme();
+            FactionTheme opposingTheme = _uiContext.GetTheme(_opposingFactionId);
+            StrategyBriefingMapPresentation briefing = new StrategyBriefingMapPresentation(
+                StrategyBriefingMapMode.OpponentLoyalty,
+                "Systems Loyal to the Empire",
+                null,
+                null,
+                _playerFactionId,
+                _opposingFactionId
+            );
+
+            GalaxyMapRenderData data = _projector.Project(
+                new[] { sector },
+                _playerFactionId,
+                GalacticInformationFilterMode.DisplayOff,
+                null,
+                briefing
+            );
+
+            Assert.AreEqual("Systems Loyal to the Empire", data.ActiveFilterLabel.Text);
+            Assert.AreSame(
+                _uiContext.GetTexture(playerTheme.GalaxyBackground.PlanetIcons.Small),
+                data.Clusters[0].Stars[0].StarTexture
+            );
+            Assert.AreSame(
+                _uiContext.GetTexture(opposingTheme.GalaxyBackground.PlanetIcons.XL),
+                data.Clusters[0].Stars[1].StarTexture
+            );
+        }
+
+        [Test]
+        public void Project_BriefingTarget_RevealsTargetSystemAndOverridesLabel()
+        {
+            GamePlanetSystem system = CreateSystem("system", "Corellia", 0, 0);
+            Planet targetPlanet = CreatePlanet("planet", _playerFactionId, 1, 2);
+            GalaxyMapSector sector = CreateSector(system, targetPlanet);
+            StrategyBriefingMapPresentation briefing = new StrategyBriefingMapPresentation(
+                StrategyBriefingMapMode.Spotlight,
+                "Mon Mothma",
+                system.InstanceID,
+                targetPlanet.InstanceID,
+                _playerFactionId,
+                _opposingFactionId
+            );
+
+            GalaxyMapRenderData data = _projector.Project(
+                new[] { sector },
+                _playerFactionId,
+                GalacticInformationFilterMode.DisplayOff,
+                null,
+                briefing
+            );
+
+            Assert.AreEqual("Mon Mothma", data.ActiveFilterLabel.Text);
+            Assert.IsTrue(data.Clusters[0].ShowLabel);
+            Assert.AreSame(
+                _uiContext.GetTexture(
+                    _uiContext.GetPlayerFactionTheme().GalaxyBackground.PlanetIcons.XL
+                ),
+                data.Clusters[0].Stars[0].StarTexture
+            );
+        }
+
+        [Test]
         public void Project_MixedFactionFleets_ReturnsMixedMarker()
         {
             GamePlanetSystem system = CreateSystem("system", "Corellia", 0, 0);
@@ -375,11 +447,16 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             };
         }
 
-        private static GalaxyMapSector CreateSector(GamePlanetSystem system, Planet planet)
+        private static GalaxyMapSector CreateSector(
+            GamePlanetSystem system,
+            params Planet[] planets
+        )
         {
             return new GalaxyMapSector(
                 system,
-                new[] { new GalaxyMapPlanet(system, planet, string.Empty) }
+                planets
+                    .Select(planet => new GalaxyMapPlanet(system, planet, string.Empty))
+                    .ToArray()
             );
         }
 

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
@@ -236,7 +236,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
-        public void Project_BriefingLoyalty_HighlightsOnlyConfiguredFactionAndUsesCueLabel()
+        public void Project_OpponentLoyaltyBriefing_HighlightsOnlyOpponentAndUsesCueLabel()
         {
             GamePlanetSystem system = CreateSystem("system", "Corellia", 0, 0);
             Planet playerPlanet = CreatePlanet("player", _playerFactionId, 1, 2);
@@ -275,7 +275,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
-        public void Project_BriefingUnexploredSystems_UsesBlueHighlightForUnexploredPlanets()
+        public void Project_UnexploredSystemsBriefing_UsesBlueHighlightForUnexploredPlanets()
         {
             GamePlanetSystem system = CreateSystem("system", "Outer Rim", 0, 0);
             Planet exploredPlanet = CreatePlanet("explored", _playerFactionId, 1, 2);
@@ -340,7 +340,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
-        public void Project_BriefingTarget_RevealsTargetSystemAndOverridesLabel()
+        public void Project_TargetBriefing_RevealsTargetSystemAndOverridesLabel()
         {
             GamePlanetSystem system = CreateSystem("system", "Corellia", 0, 0);
             Planet targetPlanet = CreatePlanet("planet", _playerFactionId, 1, 2);

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapRenderDataTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapRenderDataTests.cs
@@ -121,6 +121,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             GalaxyMapRenderData data = new GalaxyMapRenderData(
                 _firstTexture,
                 bounds,
+                Color.gray,
                 label,
                 clusters
             );
@@ -128,6 +129,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
 
             Assert.AreSame(_firstTexture, data.BackgroundTexture);
             Assert.AreEqual(bounds, data.BackgroundBounds);
+            Assert.AreEqual(Color.gray, data.BackgroundColor);
             Assert.AreEqual("Filter", data.ActiveFilterLabel.Text);
             Assert.AreSame(cluster, data.Clusters[0]);
             Assert.Throws<NotSupportedException>(() =>
@@ -138,7 +140,13 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         [Test]
         public void Map_NullClusters_ReturnsEmptySnapshot()
         {
-            GalaxyMapRenderData data = new GalaxyMapRenderData(null, null, default, null);
+            GalaxyMapRenderData data = new GalaxyMapRenderData(
+                null,
+                null,
+                Color.white,
+                default,
+                null
+            );
 
             Assert.IsNull(data.BackgroundTexture);
             Assert.IsNull(data.BackgroundBounds);

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapViewTests.cs
@@ -65,6 +65,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             Assert.AreSame(_backgroundTexture, background.texture);
             Assert.IsTrue(background.enabled);
             Assert.IsFalse(background.raycastTarget);
+            Assert.AreEqual(Color.white, background.color);
             Assert.AreEqual(new Rect(0f, 0f, 1f, 1f), background.uvRect);
             Assert.AreEqual(
                 new RectInt(49, 26, 777, 392),
@@ -140,6 +141,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
                 new GalaxyMapRenderData(
                     null,
                     null,
+                    Color.white,
                     new GalaxyMapActiveFilterLabelRenderData(string.Empty, Color.white, default, 0),
                     null
                 )
@@ -299,6 +301,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             return new GalaxyMapRenderData(
                 _backgroundTexture,
                 new RectInt(49, 26, 777, 392),
+                Color.white,
                 new GalaxyMapActiveFilterLabelRenderData(
                     activeFilter,
                     Color.yellow,

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -222,6 +222,78 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             }
         }
 
+        [Test]
+        public void PlayBriefing_AdvancesConfiguredSegmentsAndCompletesInOrder()
+        {
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+            StrategyAdvisorTheme advisorTheme = CreateTheme();
+            StrategyBriefingTheme briefing = new StrategyBriefingTheme
+            {
+                AnimationImageRoot = "Pack/Test/Briefing/Protocol",
+                AnimationFilePrefix = "briefing",
+                AudioRoot = "Pack/Test/Briefing/Audio",
+                AudioFilePrefix = "briefing",
+            };
+            briefing.Segments.Add(
+                new StrategyAdvisorAnimationTheme
+                {
+                    BitmapID = 10,
+                    FrameCount = 1,
+                    WaveID = 20,
+                }
+            );
+            briefing.Segments.Add(
+                new StrategyAdvisorAnimationTheme
+                {
+                    BitmapID = 11,
+                    FrameCount = 1,
+                    WaveID = 21,
+                }
+            );
+            Texture2D idle = new Texture2D(1, 1);
+            Texture2D first = new Texture2D(1, 1);
+            Texture2D second = new Texture2D(1, 1);
+            Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
+            {
+                [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleBitmapID, 0, false)] = idle,
+                [advisorTheme.GetFramePath(advisorTheme.DroidIdleBitmapID, 0, true)] = idle,
+                [briefing.GetFramePath(10, 0)] = first,
+                [briefing.GetFramePath(11, 0)] = second,
+            };
+            try
+            {
+                UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+                StrategyAdvisorController controller = CreateController(textures);
+                controller.BindView(view);
+                controller.Render(advisorTheme);
+                List<int> focused = new List<int>();
+                bool completed = false;
+
+                controller.PlayBriefing(
+                    briefing,
+                    segment => focused.Add(segment.BitmapID),
+                    () => completed = true
+                );
+
+                Assert.AreSame(first, GetImage(rootObject, "ProtocolImage").texture);
+                view.AdvanceAnimation(0.5f);
+                Assert.AreSame(second, GetImage(rootObject, "ProtocolImage").texture);
+                Assert.IsFalse(completed);
+                view.AdvanceAnimation(0.5f);
+
+                CollectionAssert.AreEqual(new[] { 10, 11 }, focused);
+                Assert.IsTrue(completed);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(second);
+                UnityEngine.Object.DestroyImmediate(first);
+                UnityEngine.Object.DestroyImmediate(idle);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+            }
+        }
+
         private static StrategyAdvisorController CreateController(
             IReadOnlyDictionary<string, Texture2D> textures
         )

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -227,7 +227,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
-        public void ReplaceAnimation_InvokesPlaybackCallbacks()
+        public void ReplaceAnimation_ValidPlayback_InvokesPlaybackCallbacks()
         {
             GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
             StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
@@ -269,7 +269,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
-        public void CancelAnimation_DoesNotInvokeCompletion()
+        public void CancelAnimation_ActivePlayback_DoesNotInvokeCompletion()
         {
             GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
             StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
@@ -297,6 +297,47 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 controller.CancelAnimation();
 
                 Assert.IsFalse(completed);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(frame);
+                UnityEngine.Object.DestroyImmediate(idle);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+            }
+        }
+
+        [Test]
+        public void ReplaceAnimation_EmptyPlayback_CancelsActivePlaybackAndCompletesReplacement()
+        {
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+            StrategyAdvisorTheme advisorTheme = CreateTheme();
+            Texture2D idle = new Texture2D(1, 1);
+            Texture2D frame = new Texture2D(1, 1);
+            Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
+            {
+                [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleAnimation, 0, false)] = idle,
+                [advisorTheme.GetFramePath(advisorTheme.DroidIdleAnimation, 0, true)] = idle,
+            };
+            try
+            {
+                UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+                StrategyAdvisorController controller = CreateController(textures);
+                controller.BindView(view);
+                controller.Render(advisorTheme);
+                bool activeCompleted = false;
+                bool replacementCompleted = false;
+                controller.ReplaceAnimation(
+                    new StrategyAdvisorAnimationViewData(new[] { frame }, false, null),
+                    null,
+                    () => activeCompleted = true
+                );
+
+                controller.ReplaceAnimation(null, null, () => replacementCompleted = true);
+
+                Assert.AreSame(idle, GetImage(rootObject, "ProtocolImage").texture);
+                Assert.IsFalse(activeCompleted);
+                Assert.IsTrue(replacementCompleted);
             }
             finally
             {

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -231,7 +231,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             StrategyBriefingTheme briefing = new StrategyBriefingTheme
             {
                 AnimationImageRoot = "Pack/Test/Briefing/Protocol",
-                AnimationFilePrefix = "briefing",
                 AudioRoot = "Pack/Test/Briefing/Audio",
                 AudioFilePrefix = "briefing",
             };
@@ -303,7 +302,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             StrategyBriefingTheme briefing = new StrategyBriefingTheme
             {
                 AnimationImageRoot = "Pack/Test/Briefing/Protocol",
-                AnimationFilePrefix = "briefing",
             };
             briefing.Segments.Add(
                 new StrategyAdvisorAnimationTheme { BitmapID = 10, FrameCount = 1 }
@@ -356,7 +354,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             return new StrategyAdvisorTheme
             {
                 AnimationImageRoot = "Art/Test/Advisors",
-                AnimationFilePrefix = "test",
                 ProtocolIdleBitmapID = 2001,
                 DroidIdleBitmapID = 3331,
                 FrameIntervalSeconds = 0.5f,

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -227,95 +227,59 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
-        public void PlayBriefing_AdvancesConfiguredSegmentsAndCompletesInOrder()
+        public void ReplaceAnimation_InvokesPlaybackCallbacks()
         {
             GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
             StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
             StrategyAdvisorTheme advisorTheme = CreateTheme();
-            StrategyBriefingTheme briefing = new StrategyBriefingTheme
-            {
-                AnimationImageRoot = "Pack/Test/Briefing/Protocol",
-                AudioRoot = "Pack/Test/Briefing/Audio",
-            };
-            briefing.Segments.Add(
-                new StrategyAdvisorAnimationTheme
-                {
-                    Animation = "First",
-                    FrameCount = 1,
-                    Audio = "First",
-                }
-            );
-            briefing.Segments.Add(
-                new StrategyAdvisorAnimationTheme
-                {
-                    Animation = "Second",
-                    FrameCount = 1,
-                    Audio = "Second",
-                }
-            );
-            Texture2D idle = new Texture2D(1, 1);
-            Texture2D first = new Texture2D(1, 1);
-            Texture2D second = new Texture2D(1, 1);
-            Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
-            {
-                [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleAnimation, 0, false)] = idle,
-                [advisorTheme.GetFramePath(advisorTheme.DroidIdleAnimation, 0, true)] = idle,
-                [briefing.GetFramePath("First", 0)] = first,
-                [briefing.GetFramePath("Second", 0)] = second,
-            };
-            try
-            {
-                UIComponentTestHelper.InvokeLifecycle(view, "Awake");
-                StrategyAdvisorController controller = CreateController(textures);
-                controller.BindView(view);
-                controller.Render(advisorTheme);
-                List<string> focused = new List<string>();
-                bool completed = false;
-
-                controller.PlayBriefing(
-                    briefing,
-                    segment => focused.Add(segment.Animation),
-                    () => completed = true
-                );
-
-                Assert.AreSame(first, GetImage(rootObject, "ProtocolImage").texture);
-                view.AdvanceAnimation(0.5f);
-                Assert.AreSame(second, GetImage(rootObject, "ProtocolImage").texture);
-                Assert.IsFalse(completed);
-                view.AdvanceAnimation(0.5f);
-
-                CollectionAssert.AreEqual(new[] { "First", "Second" }, focused);
-                Assert.IsTrue(completed);
-            }
-            finally
-            {
-                UnityEngine.Object.DestroyImmediate(second);
-                UnityEngine.Object.DestroyImmediate(first);
-                UnityEngine.Object.DestroyImmediate(idle);
-                UnityEngine.Object.DestroyImmediate(rootObject);
-            }
-        }
-
-        [Test]
-        public void SkipBriefing_WithoutSkipResponse_CompletesImmediately()
-        {
-            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
-            StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
-            StrategyAdvisorTheme advisorTheme = CreateTheme();
-            StrategyBriefingTheme briefing = new StrategyBriefingTheme
-            {
-                AnimationImageRoot = "Pack/Test/Briefing/Protocol",
-            };
-            briefing.Segments.Add(
-                new StrategyAdvisorAnimationTheme { Animation = "First", FrameCount = 1 }
-            );
             Texture2D idle = new Texture2D(1, 1);
             Texture2D frame = new Texture2D(1, 1);
             Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
             {
                 [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleAnimation, 0, false)] = idle,
                 [advisorTheme.GetFramePath(advisorTheme.DroidIdleAnimation, 0, true)] = idle,
-                [briefing.GetFramePath("First", 0)] = frame,
+            };
+            try
+            {
+                UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+                StrategyAdvisorController controller = CreateController(textures);
+                controller.BindView(view);
+                controller.Render(advisorTheme);
+                bool started = false;
+                bool completed = false;
+
+                controller.ReplaceAnimation(
+                    new StrategyAdvisorAnimationViewData(new[] { frame }, false, null),
+                    () => started = true,
+                    () => completed = true
+                );
+
+                Assert.AreSame(frame, GetImage(rootObject, "ProtocolImage").texture);
+                Assert.IsTrue(started);
+                view.AdvanceAnimation(0.5f);
+
+                Assert.IsTrue(completed);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(frame);
+                UnityEngine.Object.DestroyImmediate(idle);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+            }
+        }
+
+        [Test]
+        public void CancelAnimation_DoesNotInvokeCompletion()
+        {
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+            StrategyAdvisorTheme advisorTheme = CreateTheme();
+            Texture2D idle = new Texture2D(1, 1);
+            Texture2D frame = new Texture2D(1, 1);
+            Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
+            {
+                [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleAnimation, 0, false)] = idle,
+                [advisorTheme.GetFramePath(advisorTheme.DroidIdleAnimation, 0, true)] = idle,
             };
             try
             {
@@ -324,11 +288,15 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 controller.BindView(view);
                 controller.Render(advisorTheme);
                 bool completed = false;
-                controller.PlayBriefing(briefing, _ => { }, () => completed = true);
+                controller.ReplaceAnimation(
+                    new StrategyAdvisorAnimationViewData(new[] { frame }, false, null),
+                    null,
+                    () => completed = true
+                );
 
-                controller.SkipBriefing(briefing);
+                controller.CancelAnimation();
 
-                Assert.IsTrue(completed);
+                Assert.IsFalse(completed);
             }
             finally
             {
@@ -345,8 +313,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             StrategyAdvisorController controller = new StrategyAdvisorController(
                 () => new Faction(),
                 path => textures.TryGetValue(path, out Texture2D texture) ? texture : null,
-                _ => { },
-                _ => 0f
+                _ => { }
             );
             controller.Initialize(new TestActions());
             return controller;

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -136,9 +136,9 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 Assert.IsFalse(GetImage(rootObject, "ProtocolImage").enabled);
                 Assert.IsFalse(GetImage(rootObject, "DroidImage").enabled);
 
-                textures[theme.GetFramePath(theme.ProtocolIdleBitmapID, 0, false)] =
+                textures[theme.GetFramePath(theme.ProtocolIdleAnimation, 0, false)] =
                     protocolIdleTexture;
-                textures[theme.GetFramePath(theme.DroidIdleBitmapID, 0, true)] = droidIdleTexture;
+                textures[theme.GetFramePath(theme.DroidIdleAnimation, 0, true)] = droidIdleTexture;
                 controller.Render(theme);
 
                 Assert.AreSame(protocolIdleTexture, GetImage(rootObject, "ProtocolImage").texture);
@@ -170,7 +170,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 new StrategyAdvisorNotificationTheme
                 {
                     TableID = 10,
-                    Droid = new StrategyAdvisorAnimationTheme { BitmapID = 3000, FrameCount = 2 },
+                    Droid = new StrategyAdvisorAnimationTheme
+                    {
+                        Animation = "Alert",
+                        FrameCount = 2,
+                    },
                 }
             );
             Texture2D protocolIdleTexture = new Texture2D(20, 30);
@@ -179,8 +183,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             Texture2D secondFrame = new Texture2D(20, 30);
             Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
             {
-                [theme.GetFramePath(theme.ProtocolIdleBitmapID, 0, false)] = protocolIdleTexture,
-                [theme.GetFramePath(theme.DroidIdleBitmapID, 0, true)] = droidIdleTexture,
+                [theme.GetFramePath(theme.ProtocolIdleAnimation, 0, false)] = protocolIdleTexture,
+                [theme.GetFramePath(theme.DroidIdleAnimation, 0, true)] = droidIdleTexture,
             };
             try
             {
@@ -205,8 +209,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 Assert.AreEqual(0, playbackCount);
                 Assert.AreSame(droidIdleTexture, GetImage(rootObject, "DroidImage").texture);
 
-                textures[theme.GetFramePath(3000, 0, true)] = firstFrame;
-                textures[theme.GetFramePath(3000, 1, true)] = secondFrame;
+                textures[theme.GetFramePath("Alert", 0, true)] = firstFrame;
+                textures[theme.GetFramePath("Alert", 1, true)] = secondFrame;
                 controller.ProcessPending(1, true);
 
                 Assert.AreEqual(1, playbackCount);
@@ -232,22 +236,21 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             {
                 AnimationImageRoot = "Pack/Test/Briefing/Protocol",
                 AudioRoot = "Pack/Test/Briefing/Audio",
-                AudioFilePrefix = "briefing",
             };
             briefing.Segments.Add(
                 new StrategyAdvisorAnimationTheme
                 {
-                    BitmapID = 10,
+                    Animation = "First",
                     FrameCount = 1,
-                    WaveID = 20,
+                    Audio = "First",
                 }
             );
             briefing.Segments.Add(
                 new StrategyAdvisorAnimationTheme
                 {
-                    BitmapID = 11,
+                    Animation = "Second",
                     FrameCount = 1,
-                    WaveID = 21,
+                    Audio = "Second",
                 }
             );
             Texture2D idle = new Texture2D(1, 1);
@@ -255,10 +258,10 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             Texture2D second = new Texture2D(1, 1);
             Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
             {
-                [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleBitmapID, 0, false)] = idle,
-                [advisorTheme.GetFramePath(advisorTheme.DroidIdleBitmapID, 0, true)] = idle,
-                [briefing.GetFramePath(10, 0)] = first,
-                [briefing.GetFramePath(11, 0)] = second,
+                [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleAnimation, 0, false)] = idle,
+                [advisorTheme.GetFramePath(advisorTheme.DroidIdleAnimation, 0, true)] = idle,
+                [briefing.GetFramePath("First", 0)] = first,
+                [briefing.GetFramePath("Second", 0)] = second,
             };
             try
             {
@@ -266,12 +269,12 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 StrategyAdvisorController controller = CreateController(textures);
                 controller.BindView(view);
                 controller.Render(advisorTheme);
-                List<int> focused = new List<int>();
+                List<string> focused = new List<string>();
                 bool completed = false;
 
                 controller.PlayBriefing(
                     briefing,
-                    segment => focused.Add(segment.BitmapID),
+                    segment => focused.Add(segment.Animation),
                     () => completed = true
                 );
 
@@ -281,7 +284,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 Assert.IsFalse(completed);
                 view.AdvanceAnimation(0.5f);
 
-                CollectionAssert.AreEqual(new[] { 10, 11 }, focused);
+                CollectionAssert.AreEqual(new[] { "First", "Second" }, focused);
                 Assert.IsTrue(completed);
             }
             finally
@@ -304,15 +307,15 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 AnimationImageRoot = "Pack/Test/Briefing/Protocol",
             };
             briefing.Segments.Add(
-                new StrategyAdvisorAnimationTheme { BitmapID = 10, FrameCount = 1 }
+                new StrategyAdvisorAnimationTheme { Animation = "First", FrameCount = 1 }
             );
             Texture2D idle = new Texture2D(1, 1);
             Texture2D frame = new Texture2D(1, 1);
             Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
             {
-                [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleBitmapID, 0, false)] = idle,
-                [advisorTheme.GetFramePath(advisorTheme.DroidIdleBitmapID, 0, true)] = idle,
-                [briefing.GetFramePath(10, 0)] = frame,
+                [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleAnimation, 0, false)] = idle,
+                [advisorTheme.GetFramePath(advisorTheme.DroidIdleAnimation, 0, true)] = idle,
+                [briefing.GetFramePath("First", 0)] = frame,
             };
             try
             {
@@ -354,8 +357,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             return new StrategyAdvisorTheme
             {
                 AnimationImageRoot = "Art/Test/Advisors",
-                ProtocolIdleBitmapID = 2001,
-                DroidIdleBitmapID = 3331,
+                ProtocolIdleAnimation = "Idle",
+                DroidIdleAnimation = "Standard",
                 FrameIntervalSeconds = 0.5f,
                 RepeatCooldownTicks = 10,
             };

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -294,6 +294,49 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             }
         }
 
+        [Test]
+        public void SkipBriefing_WithoutSkipResponse_CompletesImmediately()
+        {
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+            StrategyAdvisorTheme advisorTheme = CreateTheme();
+            StrategyBriefingTheme briefing = new StrategyBriefingTheme
+            {
+                AnimationImageRoot = "Pack/Test/Briefing/Protocol",
+                AnimationFilePrefix = "briefing",
+            };
+            briefing.Segments.Add(
+                new StrategyAdvisorAnimationTheme { BitmapID = 10, FrameCount = 1 }
+            );
+            Texture2D idle = new Texture2D(1, 1);
+            Texture2D frame = new Texture2D(1, 1);
+            Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
+            {
+                [advisorTheme.GetFramePath(advisorTheme.ProtocolIdleBitmapID, 0, false)] = idle,
+                [advisorTheme.GetFramePath(advisorTheme.DroidIdleBitmapID, 0, true)] = idle,
+                [briefing.GetFramePath(10, 0)] = frame,
+            };
+            try
+            {
+                UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+                StrategyAdvisorController controller = CreateController(textures);
+                controller.BindView(view);
+                controller.Render(advisorTheme);
+                bool completed = false;
+                controller.PlayBriefing(briefing, _ => { }, () => completed = true);
+
+                controller.SkipBriefing(briefing);
+
+                Assert.IsTrue(completed);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(frame);
+                UnityEngine.Object.DestroyImmediate(idle);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+            }
+        }
+
         private static StrategyAdvisorController CreateController(
             IReadOnlyDictionary<string, Texture2D> textures
         )
@@ -301,7 +344,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             StrategyAdvisorController controller = new StrategyAdvisorController(
                 () => new Faction(),
                 path => textures.TryGetValue(path, out Texture2D texture) ? texture : null,
-                _ => { }
+                _ => { },
+                _ => 0f
             );
             controller.Initialize(new TestActions());
             return controller;

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewDataTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewDataTests.cs
@@ -42,12 +42,16 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             StrategyAdvisorAnimationViewData data = new StrategyAdvisorAnimationViewData(
                 null,
                 true,
-                "Audio/Advisor"
+                "Audio/Advisor",
+                -1f,
+                -2f
             );
 
             Assert.IsEmpty(data.Frames);
             Assert.IsTrue(data.UsesDroid);
             Assert.AreEqual("Audio/Advisor", data.AudioPath);
+            Assert.AreEqual(0f, data.DelayBeforeSeconds);
+            Assert.AreEqual(0f, data.MinimumPlaybackSeconds);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewTests.cs
@@ -212,6 +212,31 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
+        public void EnqueuePlaybacks_DelayedAnimation_WaitsBeforeStarting()
+        {
+            _view.Render(CreatePresentation(true));
+            StrategyAdvisorAnimationViewData animation = new StrategyAdvisorAnimationViewData(
+                new[] { _protocolFirstTexture },
+                false,
+                "briefing",
+                2f
+            );
+            int startedCount = 0;
+            _view.PlaybackStarted += _ => startedCount++;
+
+            _view.EnqueuePlaybacks(new[] { animation });
+            _view.AdvanceAnimation(1.9f);
+
+            Assert.AreEqual(0, startedCount);
+            Assert.AreSame(_protocolIdleTexture, GetField<RawImage>("protocolImage").texture);
+
+            _view.AdvanceAnimation(0.1f);
+
+            Assert.AreEqual(1, startedCount);
+            Assert.AreSame(_protocolFirstTexture, GetField<RawImage>("protocolImage").texture);
+        }
+
+        [Test]
         public void EnqueuePlaybacks_NullAndEmptyAnimations_DoesNotStartPlayback()
         {
             _view.Render(CreatePresentation(true));

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewTests.cs
@@ -238,6 +238,38 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
+        public void CancelPlayback_PausedAnimation_AllowsSubsequentPlaybackToComplete()
+        {
+            _view.Render(CreatePresentation(true));
+            _view.EnqueuePlaybacks(
+                new[]
+                {
+                    new StrategyAdvisorAnimationViewData(
+                        new[] { _protocolFirstTexture, _protocolSecondTexture },
+                        false,
+                        "briefing"
+                    ),
+                }
+            );
+            _view.PausePlayback();
+
+            _view.CancelPlayback();
+            _view.EnqueuePlaybacks(
+                new[]
+                {
+                    new StrategyAdvisorAnimationViewData(
+                        new[] { _droidPlaybackTexture },
+                        true,
+                        "notification"
+                    ),
+                }
+            );
+            _view.AdvanceAnimation(0.5f);
+
+            Assert.AreSame(_droidIdleTexture, GetField<RawImage>("droidImage").texture);
+        }
+
+        [Test]
         public void EnqueuePlaybacks_DelayedAnimation_WaitsBeforeStarting()
         {
             _view.Render(CreatePresentation(true));

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewTests.cs
@@ -212,6 +212,32 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
+        public void PausePlayback_ActiveAnimation_FreezesAndResumesAtCurrentFrame()
+        {
+            _view.Render(CreatePresentation(true));
+            _view.EnqueuePlaybacks(
+                new[]
+                {
+                    new StrategyAdvisorAnimationViewData(
+                        new[] { _protocolFirstTexture, _protocolSecondTexture },
+                        false,
+                        "briefing"
+                    ),
+                }
+            );
+
+            _view.PausePlayback();
+            _view.AdvanceAnimation(1f);
+
+            Assert.AreSame(_protocolFirstTexture, GetField<RawImage>("protocolImage").texture);
+
+            _view.ResumePlayback();
+            _view.AdvanceAnimation(0.5f);
+
+            Assert.AreSame(_protocolSecondTexture, GetField<RawImage>("protocolImage").texture);
+        }
+
+        [Test]
         public void EnqueuePlaybacks_DelayedAnimation_WaitsBeforeStarting()
         {
             _view.Render(CreatePresentation(true));
@@ -234,6 +260,36 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
 
             Assert.AreEqual(1, startedCount);
             Assert.AreSame(_protocolFirstTexture, GetField<RawImage>("protocolImage").texture);
+        }
+
+        [Test]
+        public void EnqueuePlaybacks_AudioOutlastsFrames_HoldsFinalFrameUntilAudioDuration()
+        {
+            _view.Render(CreatePresentation(true));
+            bool completed = false;
+            _view.PlaybackCompleted += () => completed = true;
+            _view.EnqueuePlaybacks(
+                new[]
+                {
+                    new StrategyAdvisorAnimationViewData(
+                        new[] { _protocolFirstTexture },
+                        false,
+                        "briefing",
+                        0f,
+                        2f
+                    ),
+                }
+            );
+
+            _view.AdvanceAnimation(0.5f);
+
+            Assert.IsFalse(completed);
+            Assert.AreSame(_protocolFirstTexture, GetField<RawImage>("protocolImage").texture);
+
+            _view.AdvanceAnimation(1.5f);
+
+            Assert.IsTrue(completed);
+            Assert.AreSame(_protocolIdleTexture, GetField<RawImage>("protocolImage").texture);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyHudControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyHudControllerTests.cs
@@ -24,8 +24,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 () => new Faction(),
                 () => new FactionTheme(),
                 _ => null,
-                _ => { },
-                _ => 0f
+                _ => { }
             );
             _controller.Initialize(_actions);
         }
@@ -34,19 +33,16 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         public void Constructor_NullDependencies_ThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyHudController(null, () => null, _ => null, _ => { }, _ => 0f)
+                new StrategyHudController(null, () => null, _ => null, _ => { })
             );
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyHudController(() => null, null, _ => null, _ => { }, _ => 0f)
+                new StrategyHudController(() => null, null, _ => null, _ => { })
             );
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyHudController(() => null, () => null, null, _ => { }, _ => 0f)
+                new StrategyHudController(() => null, () => null, null, _ => { })
             );
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyHudController(() => null, () => null, _ => null, null, _ => 0f)
-            );
-            Assert.Throws<ArgumentNullException>(() =>
-                new StrategyHudController(() => null, () => null, _ => null, _ => { }, null)
+                new StrategyHudController(() => null, () => null, _ => null, null)
             );
         }
 

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyHudControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Hud/StrategyHudControllerTests.cs
@@ -24,7 +24,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 () => new Faction(),
                 () => new FactionTheme(),
                 _ => null,
-                _ => { }
+                _ => { },
+                _ => 0f
             );
             _controller.Initialize(_actions);
         }
@@ -33,16 +34,19 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         public void Constructor_NullDependencies_ThrowArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyHudController(null, () => null, _ => null, _ => { })
+                new StrategyHudController(null, () => null, _ => null, _ => { }, _ => 0f)
             );
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyHudController(() => null, null, _ => null, _ => { })
+                new StrategyHudController(() => null, null, _ => null, _ => { }, _ => 0f)
             );
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyHudController(() => null, () => null, null, _ => { })
+                new StrategyHudController(() => null, () => null, null, _ => { }, _ => 0f)
             );
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyHudController(() => null, () => null, _ => null, null)
+                new StrategyHudController(() => null, () => null, _ => null, null, _ => 0f)
+            );
+            Assert.Throws<ArgumentNullException>(() =>
+                new StrategyHudController(() => null, () => null, _ => null, _ => { }, null)
             );
         }
 

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Messages/MessagesWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Messages/MessagesWindowControllerTests.cs
@@ -206,6 +206,53 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
         }
 
         [Test]
+        public void Open_AdviceTab_OpensMessageIndexOnAgentAdvice()
+        {
+            Faction faction = new Faction { InstanceID = "FNALL1" };
+            faction.Messages[MessageType.Advice] = new List<Message>
+            {
+                new Message(MessageType.Advice, "Agent Advice"),
+            };
+            GameRoot game = new GameRoot(TestConfig.Create());
+            game.Factions.Add(faction);
+            game.Summary.PlayerFactionID = faction.InstanceID;
+            UIContext uiContext = TestContent.CreateUIContext(
+                game,
+                TestContent.CreateThemeLibrary(),
+                new EncyclopediaCatalog(Array.Empty<EncyclopediaEntry>())
+            );
+            GameObject root = UIComponentTestHelper.InstantiatePrefab(_strategyViewPrefabPath);
+
+            try
+            {
+                StrategyWindowLayerView windowLayer =
+                    root.GetComponentInChildren<StrategyWindowLayerView>(true);
+                UIWindowManager windowManager = root.GetComponentInChildren<UIWindowManager>(true);
+                MessagesWindowController controller = new MessagesWindowController(
+                    _ => { },
+                    () => uiContext,
+                    windowLayer,
+                    windowManager,
+                    () => Vector2Int.zero,
+                    windowManager.DestroyWindow,
+                    () => { }
+                );
+                controller.Initialize(new TestActions());
+
+                controller.Open(MessagesTab.Advice);
+
+                UIWindow window = windowManager.Windows.Single();
+                Assert.IsTrue(windowManager.TryGetWindowView(window, out MessagesWindowView view));
+                Assert.AreEqual(MessagesTab.Advice, controller.GetActiveTab(view));
+                Assert.IsFalse(controller.IsDetailVisible(view));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        [Test]
         public void NotificationOperations_NullFaction_ReturnDisabledWithoutThrowing()
         {
             Assert.IsFalse(

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Screen/StrategyBriefingControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Screen/StrategyBriefingControllerTests.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Rebellion.Game;
+using Rebellion.Game.Factions;
+using Rebellion.Game.Galaxy;
+using Rebellion.Game.Messages;
+using Rebellion.Game.Units;
+using UnityEngine;
+using GamePlanetSystem = Rebellion.Game.Galaxy.PlanetSystem;
+
+namespace Rebellion.Tests.UI.SceneUI.StrategyView.Screen
+{
+    [TestFixture]
+    public class StrategyBriefingControllerTests
+    {
+        private const string _opponentFactionID = "OPPONENT";
+        private const string _playerFactionID = "PLAYER";
+        private const string _prefabPath = "Assets/Prefabs/UI/StrategyView/StrategyViewRoot.prefab";
+
+        [Test]
+        public void Play_MultipleSegments_PlaysInOrderAndCompletes()
+        {
+            GameRoot game = CreateGame();
+            StrategyAdvisorTheme advisorTheme = CreateAdvisorTheme();
+            StrategyBriefingTheme briefing = CreateBriefing();
+            briefing.Segments.Add(CreateSegment("First"));
+            briefing.Segments.Add(CreateSegment("Second"));
+            Texture2D idle = new Texture2D(1, 1);
+            Texture2D first = new Texture2D(1, 1);
+            Texture2D second = new Texture2D(1, 1);
+            Dictionary<string, Texture2D> textures = CreateTextures(advisorTheme, idle);
+            textures[briefing.GetFramePath("First", 0)] = first;
+            textures[briefing.GetFramePath("Second", 0)] = second;
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            try
+            {
+                StrategyAdvisorView advisorView =
+                    rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+                StrategyBriefingController controller = CreateController(
+                    game,
+                    advisorTheme,
+                    textures,
+                    rootObject
+                );
+                bool completed = false;
+
+                controller.Play(briefing, () => completed = true);
+
+                Assert.AreSame(first, GetProtocolImage(rootObject).texture);
+                advisorView.AdvanceAnimation(0.5f);
+                Assert.AreSame(second, GetProtocolImage(rootObject).texture);
+                Assert.IsFalse(completed);
+                advisorView.AdvanceAnimation(0.5f);
+                Assert.IsTrue(completed);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(second);
+                UnityEngine.Object.DestroyImmediate(first);
+                UnityEngine.Object.DestroyImmediate(idle);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+            }
+        }
+
+        [Test]
+        public void Skip_ConfiguredResponse_ReplacesCurrentSegmentAndCompletesAfterResponse()
+        {
+            GameRoot game = CreateGame();
+            StrategyAdvisorTheme advisorTheme = CreateAdvisorTheme();
+            StrategyBriefingTheme briefing = CreateBriefing();
+            briefing.Segments.Add(CreateSegment("First"));
+            briefing.Skip = CreateSegment("Skip");
+            Texture2D idle = new Texture2D(1, 1);
+            Texture2D first = new Texture2D(1, 1);
+            Texture2D skip = new Texture2D(1, 1);
+            Dictionary<string, Texture2D> textures = CreateTextures(advisorTheme, idle);
+            textures[briefing.GetFramePath("First", 0)] = first;
+            textures[briefing.GetFramePath("Skip", 0)] = skip;
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            try
+            {
+                StrategyAdvisorView advisorView =
+                    rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+                StrategyBriefingController controller = CreateController(
+                    game,
+                    advisorTheme,
+                    textures,
+                    rootObject
+                );
+                bool completed = false;
+                controller.Play(briefing, () => completed = true);
+
+                controller.Skip();
+
+                Assert.AreSame(skip, GetProtocolImage(rootObject).texture);
+                Assert.IsFalse(completed);
+                advisorView.AdvanceAnimation(0.5f);
+                Assert.IsTrue(completed);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(skip);
+                UnityEngine.Object.DestroyImmediate(first);
+                UnityEngine.Object.DestroyImmediate(idle);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+            }
+        }
+
+        [Test]
+        public void CreateMapPresentation_Target_ResolvesPlanetAndSystem()
+        {
+            GameRoot game = CreateGame();
+            GamePlanetSystem system = new GamePlanetSystem { InstanceID = "SYSTEM" };
+            Planet planet = new Planet { InstanceID = "PLANET" };
+            game.AttachNode(system, game.Galaxy);
+            game.AttachNode(planet, system);
+            StrategyBriefingSegmentTheme segment = new StrategyBriefingSegmentTheme
+            {
+                Focus = StrategyBriefingFocus.Target,
+                TargetInstanceID = planet.InstanceID,
+            };
+
+            StrategyBriefingMapPresentation presentation =
+                StrategyBriefingController.CreateMapPresentation(game, segment);
+
+            Assert.AreEqual(StrategyBriefingMapMode.Spotlight, presentation.Mode);
+            Assert.AreEqual(system.InstanceID, presentation.TargetSystemInstanceID);
+            Assert.AreEqual(planet.InstanceID, presentation.TargetPlanetInstanceID);
+            Assert.IsTrue(presentation.DimBackground);
+        }
+
+        [Test]
+        public void CreateMapPresentation_MissingTarget_ThrowsInvalidOperationException()
+        {
+            GameRoot game = CreateGame();
+            StrategyBriefingSegmentTheme segment = new StrategyBriefingSegmentTheme
+            {
+                Focus = StrategyBriefingFocus.Target,
+                TargetInstanceID = "MISSING",
+            };
+
+            Assert.Throws<InvalidOperationException>(() =>
+                StrategyBriefingController.CreateMapPresentation(game, segment)
+            );
+        }
+
+        private static StrategyBriefingController CreateController(
+            GameRoot game,
+            StrategyAdvisorTheme advisorTheme,
+            IReadOnlyDictionary<string, Texture2D> textures,
+            GameObject rootObject
+        )
+        {
+            FactionTheme factionTheme = new FactionTheme { StrategyAdvisor = advisorTheme };
+            StrategyHudController hudController = new StrategyHudController(
+                game.GetPlayerFaction,
+                () => factionTheme,
+                path => textures.TryGetValue(path, out Texture2D texture) ? texture : null,
+                _ => { }
+            );
+            hudController.Initialize(new TestHudActions());
+            StrategyHudView hudView = rootObject.GetComponentInChildren<StrategyHudView>(true);
+            hudController.BindView(hudView);
+            hudController.Render(new StrategyHudRenderData("", "", "", "", TickSpeed.Paused, null));
+            GalaxyMapController mapController = new GalaxyMapController(() => null);
+            mapController.Initialize(new TestGalaxyMapActions());
+            return new StrategyBriefingController(
+                game,
+                path => textures.TryGetValue(path, out Texture2D texture) ? texture : null,
+                _ => 0f,
+                hudController,
+                mapController,
+                () => { }
+            );
+        }
+
+        private static GameRoot CreateGame()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            game.Factions.Add(new Faction { InstanceID = _playerFactionID });
+            game.Factions.Add(new Faction { InstanceID = _opponentFactionID });
+            game.Summary.PlayerFactionID = _playerFactionID;
+            return game;
+        }
+
+        private static StrategyAdvisorTheme CreateAdvisorTheme()
+        {
+            return new StrategyAdvisorTheme
+            {
+                AnimationImageRoot = "Pack/Test/Advisor",
+                ProtocolIdleAnimation = "Idle",
+                DroidIdleAnimation = "Standard",
+                FrameIntervalSeconds = 0.5f,
+            };
+        }
+
+        private static StrategyBriefingTheme CreateBriefing()
+        {
+            return new StrategyBriefingTheme
+            {
+                AnimationImageRoot = "Pack/Test/Briefing/Animations",
+                AudioRoot = "Pack/Test/Briefing/Audio",
+            };
+        }
+
+        private static StrategyBriefingSegmentTheme CreateSegment(string animation)
+        {
+            return new StrategyBriefingSegmentTheme { Animation = animation, FrameCount = 1 };
+        }
+
+        private static Dictionary<string, Texture2D> CreateTextures(
+            StrategyAdvisorTheme theme,
+            Texture2D idle
+        )
+        {
+            return new Dictionary<string, Texture2D>
+            {
+                [theme.GetFramePath(theme.ProtocolIdleAnimation, 0, false)] = idle,
+                [theme.GetFramePath(theme.DroidIdleAnimation, 0, true)] = idle,
+            };
+        }
+
+        private static UnityEngine.UI.RawImage GetProtocolImage(GameObject rootObject)
+        {
+            return Array.Find(
+                rootObject.GetComponentsInChildren<UnityEngine.UI.RawImage>(true),
+                image => image.name == "ProtocolImage"
+            );
+        }
+
+        private sealed class TestGalaxyMapActions : IGalaxyMapActions
+        {
+            public void OpenPlanetSystemWindow(
+                GamePlanetSystem system,
+                int sourceX,
+                int sourceY
+            ) { }
+
+            public void RequestGalaxyMapRender() { }
+        }
+
+        private sealed class TestHudActions : IStrategyHudActions
+        {
+            public void BeginAdvisorConstruction(
+                ManufacturingType manufacturingType,
+                int sourceX,
+                int sourceY
+            ) { }
+
+            public void OpenAdvisorCommandContextMenu(
+                ContextMenuRequest request,
+                int sourceX,
+                int sourceY
+            ) { }
+
+            public void OpenAdvisorNotificationContextMenu(
+                ContextMenuRequest request,
+                int sourceX,
+                int sourceY
+            ) { }
+
+            public void OpenAdvisorReport(AdvisorReportMode mode) { }
+
+            public void OpenMessagesTab(MessagesTab tab) { }
+
+            public void OpenSpeedContextMenu(
+                ContextMenuRequest request,
+                int sourceX,
+                int sourceY
+            ) { }
+
+            public void ReleaseHudButton(StrategyHudAction action, int sourceX, int sourceY) { }
+
+            public void RequestHudRender() { }
+
+            public void SetGameSpeed(TickSpeed speed) { }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
@@ -70,11 +70,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                 StrategyBriefing = new StrategyBriefingTheme
                 {
                     AudioRoot = "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings",
-                    Skip = new StrategyAdvisorAnimationTheme { Audio = "Skip" },
+                    Skip = new StrategyBriefingSegmentTheme { Audio = "Skip" },
                 },
             };
             theme.StrategyBriefing.Segments.Add(
-                new StrategyAdvisorAnimationTheme { Audio = "Introduction" }
+                new StrategyBriefingSegmentTheme { Audio = "Introduction" }
             );
 
             string[] paths = StrategyUISoundPaths.GetBriefingPreloadPaths(theme).ToArray();

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
@@ -70,19 +70,20 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                 StrategyBriefing = new StrategyBriefingTheme
                 {
                     AudioRoot = "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings",
-                    AudioFilePrefix = "briefing",
-                    Skip = new StrategyAdvisorAnimationTheme { WaveID = 42 },
+                    Skip = new StrategyAdvisorAnimationTheme { Audio = "Skip" },
                 },
             };
-            theme.StrategyBriefing.Segments.Add(new StrategyAdvisorAnimationTheme { WaveID = 41 });
+            theme.StrategyBriefing.Segments.Add(
+                new StrategyAdvisorAnimationTheme { Audio = "Introduction" }
+            );
 
             string[] paths = StrategyUISoundPaths.GetBriefingPreloadPaths(theme).ToArray();
 
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/briefing-0041",
-                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/briefing-0042",
+                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/Introduction",
+                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/Skip",
                 },
                 paths
             );

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
@@ -61,5 +61,31 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                 StrategyUISoundPaths.GetPreloadPaths(theme).ToArray()
             );
         }
+
+        [Test]
+        public void GetPreloadPaths_ConfiguredBriefing_ReturnsSegmentAndSkipAudio()
+        {
+            FactionTheme theme = new FactionTheme
+            {
+                StrategyBriefing = new StrategyBriefingTheme
+                {
+                    AudioRoot = "Pack/Factions/Example/Strategy/Audio/Briefing",
+                    AudioFilePrefix = "briefing",
+                    Skip = new StrategyAdvisorAnimationTheme { WaveID = 42 },
+                },
+            };
+            theme.StrategyBriefing.Segments.Add(new StrategyAdvisorAnimationTheme { WaveID = 41 });
+
+            string[] paths = StrategyUISoundPaths.GetBriefingPreloadPaths(theme).ToArray();
+
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "Pack/Factions/Example/Strategy/Audio/Briefing/briefing-0041",
+                    "Pack/Factions/Example/Strategy/Audio/Briefing/briefing-0042",
+                },
+                paths
+            );
+        }
     }
 }

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
@@ -69,7 +69,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
             {
                 StrategyBriefing = new StrategyBriefingTheme
                 {
-                    AudioRoot = "Pack/Factions/Example/Strategy/Audio/Briefing",
+                    AudioRoot = "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings",
                     AudioFilePrefix = "briefing",
                     Skip = new StrategyAdvisorAnimationTheme { WaveID = 42 },
                 },
@@ -81,8 +81,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
             CollectionAssert.AreEqual(
                 new[]
                 {
-                    "Pack/Factions/Example/Strategy/Audio/Briefing/briefing-0041",
-                    "Pack/Factions/Example/Strategy/Audio/Briefing/briefing-0042",
+                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/briefing-0041",
+                    "Pack/Factions/Example/Strategy/Advisor/Audio/Briefings/briefing-0042",
                 },
                 paths
             );

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Windows/StrategyWindowLayerViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Windows/StrategyWindowLayerViewTests.cs
@@ -106,7 +106,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
             RawImage blocker = GetField<RawImage>("modalInputBlockerImage");
             RawImage dimmer = GetField<RawImage>("modalBackgroundDimImage");
 
-            _view.RenderModalState(true);
+            _view.RenderModalState(true, true);
 
             Assert.IsTrue(blocker.gameObject.activeSelf);
             Assert.IsTrue(dimmer.gameObject.activeSelf);
@@ -119,11 +119,23 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
         {
             RawImage blocker = GetField<RawImage>("modalInputBlockerImage");
             RawImage dimmer = GetField<RawImage>("modalBackgroundDimImage");
-            _view.RenderModalState(true);
+            _view.RenderModalState(true, true);
 
-            _view.RenderModalState(false);
+            _view.RenderModalState(false, false);
 
             Assert.IsFalse(blocker.gameObject.activeSelf);
+            Assert.IsFalse(dimmer.gameObject.activeSelf);
+        }
+
+        [Test]
+        public void RenderModalState_InputBlockedWithoutModal_HidesDimmer()
+        {
+            RawImage blocker = GetField<RawImage>("modalInputBlockerImage");
+            RawImage dimmer = GetField<RawImage>("modalBackgroundDimImage");
+
+            _view.RenderModalState(true, false);
+
+            Assert.IsTrue(blocker.gameObject.activeSelf);
             Assert.IsFalse(dimmer.gameObject.activeSelf);
         }
 


### PR DESCRIPTION
## Summary

- Restores configuration-driven faction briefings with original timing, map presentation, focus changes, and advisor playback.
- Prevents normal Strategy interaction from interrupting a briefing and adds a pausing skip-confirmation flow.
- Applies video volume controls, stops dialog audio during scene changes, and registers briefing audio only after preload completes.
- Uses the original cyan marker family when the briefing highlights unexplored Outer Rim systems.
- Normalizes extensionless macOS build paths to the `.app` bundle Unity creates.

## Why

Faction introductions were incomplete and did not faithfully control the Strategy presentation. Audio preload assumptions also broke gameplay when briefings were disabled, while macOS CI rejected successful builds because it verified the wrong artifact path.

## Validation

- Passes 3,651 Unity EditMode tests.
- Passes formatting, analyzers, assembly builds, and lint.
- Builds a local StandaloneOSX player successfully from an extensionless game-ci-style output path.
- Verifies the affected UI through the production UI builder invoked by the test and player-build workflows.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.
