### PR TITLE
Removing the main-menu planet and keeping the atmosphere glow.

### DIFF
--- a/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
@@ -43,18 +43,14 @@ public static class MainMenuPrefabBuilder
     // Icon turntable speed: one full revolution per second (matched the original 2D flipbook loop).
     private const float _iconTurnDegreesPerSecond = 360f;
 
-    // Spinning-planet backdrop.
+    // Space backdrop.
     private const string _starfieldAddress = "Application/MainMenu/UI/starfield";
     private const string _atmosphereAddress = "Application/MainMenu/UI/atmosphere";
-    private const string _renderTexturePath = "Assets/Art/Models/MainMenu/Planet.renderTexture";
     private const string _citadelModelAddress = "Application/MainMenu/Models/citadel";
     private const string _citadelRenderTexturePath =
         "Assets/Art/Models/MainMenu/HqCitadel.renderTexture";
-    private const string _rigName = "PlanetRig";
     private const string _backdropName = "SpaceBackdrop";
     private const string _foregroundName = "Cockpit";
-    private const float _spinDegreesPerSecond = 0.2222f; // slow ambient spin
-    private static readonly Vector3 _planetRigOrigin = new Vector3(12000f, 12000f, 12000f);
 
     // Spinning 3D icon rigs.
     private const string _iconRigsName = "IconRigs"; // container for the lights and all icon rigs
@@ -162,7 +158,7 @@ public static class MainMenuPrefabBuilder
         {
             BuildBaseHierarchy(root);
             RebuildViewBindings(root);
-            InstallPlanet(root);
+            InstallSpaceBackdrop(root);
             InstallSpinning3DIcons(root);
             InstallHqCitadel(root);
             PrefabUtility.SaveAsPrefabAsset(root, _prefabPath);
@@ -1858,21 +1854,16 @@ public static class MainMenuPrefabBuilder
     }
 
     /// <summary>
-    /// Builds the Planet rig and inserts the spinning-planet backdrop behind the cockpit
-    /// windshield.
+    /// Redraws the cockpit as a child image and inserts the starfield backdrop behind it.
     /// </summary>
     /// <param name="root">The prefab root.</param>
-    private static void InstallPlanet(GameObject root)
+    private static void InstallSpaceBackdrop(GameObject root)
     {
-        RenderTexture rt = LoadOrCreateRenderTexture();
-
-        BuildPlanetRig(root, rt);
-
         // The cockpit image is on the root Canvas GameObject itself -> the backmost layer of
         // that canvas, so nothing under it can render behind it (and a separate canvas did not
         // sort reliably behind it). So disable the root's own image and redraw the cockpit as a
-        // CHILD image; the planet can then sit as an EARLIER sibling (behind the cockpit) in the
-        // same canvas -- deterministic hierarchy order, no cross-canvas sorting.
+        // CHILD image; the starfield can then sit as an EARLIER sibling (behind the cockpit) in
+        // the same canvas -- deterministic hierarchy order, no cross-canvas sorting.
         Image rootImage = FindBackgroundImage(root);
         Transform canvasT = rootImage.transform;
         // The current root image is the alpha-windowed cockpit; reuse its sprite as-is.
@@ -1904,7 +1895,8 @@ public static class MainMenuPrefabBuilder
         backdropRect.SetParent(canvasT, false);
         FillParent(backdropRect);
 
-        // Render order within the canvas: space backdrop (behind) -> cockpit -> controls.
+        // Render order within the canvas: starfield (behind) -> cockpit -> controls. The soft glow
+        // at the top of the windshield comes from the starfield texture itself.
         backdrop.transform.SetSiblingIndex(0);
         foreground.transform.SetSiblingIndex(1);
 
@@ -1912,120 +1904,18 @@ public static class MainMenuPrefabBuilder
         SetBoundTexture(stars, _starfieldAddress);
         FillParent(stars.rectTransform);
 
-        // Atmosphere glow sits behind the globe on the same rect so it lines up with the limb.
-        RawImage atmosphere = NewRawImage(backdrop.transform, "Atmosphere", null);
-        SetBoundTexture(atmosphere, _atmosphereAddress);
-        atmosphere.color = new Color(1f, 1f, 1f, 0.6f); // dimmed so the glow stays subtle
-        ApplyPlanetBackdropRect(atmosphere.rectTransform);
-
-        RawImage planet = NewRawImage(backdrop.transform, "Planet", rt);
-        // Tilted and positioned in the windshield canopy; values tuned in the editor.
-        ApplyPlanetBackdropRect(planet.rectTransform);
-    }
-
-    /// <summary>
-    /// Applies the shared placement of the planet backdrop layer (globe and its atmosphere) so both
-    /// overlay the same region and stay aligned.
-    /// </summary>
-    /// <param name="rect">The RectTransform to place.</param>
-    private static void ApplyPlanetBackdropRect(RectTransform rect)
-    {
-        rect.anchorMin = new Vector2(0.5f, 0.63f);
-        rect.anchorMax = new Vector2(0.5f, 0.63f);
-        rect.pivot = new Vector2(0.5f, 0.5f);
-        rect.sizeDelta = new Vector2(3770.957f, 3526.246f);
-        rect.anchoredPosition = new Vector2(74f, -734f);
-        rect.localRotation = Quaternion.Euler(0f, 0f, -20.228f);
-    }
-
-    /// <summary>
-    /// Builds the off-screen planet model, lighting, and camera rig. The model is normalized and
-    /// recentered before spinning because its exported scale and origin are arbitrary.
-    /// </summary>
-    /// <param name="root">The prefab root to parent the rig under.</param>
-    /// <param name="renderTexture">The texture the rig camera renders into.</param>
-    private static void BuildPlanetRig(GameObject root, RenderTexture renderTexture)
-    {
-        GameObject rig = new GameObject(_rigName);
-        rig.transform.SetParent(root.transform, false);
-        rig.transform.position = _planetRigOrigin;
-
-        GameObject pivot = new GameObject("Pivot");
-        pivot.transform.SetParent(rig.transform, false);
-        // Spin around vertical, which is the planet's pole once the model is stood upright below.
-        pivot.AddComponent<AutoRotate>().Configure(-_spinDegreesPerSecond, Vector3.up);
-
-        // The planet ships as a pre-skinned GLB in the content pack. Load it at runtime and apply
-        // the same pole-forward rotation, unit normalization, centering, and render layer the baked
-        // model used. Posing stays here in code; only the model travels inside the GLB.
-        const int planetLayer = 31;
-        GameObject planetModelNode = new GameObject("Model");
-        planetModelNode.transform.SetParent(pivot.transform, false);
-        planetModelNode
-            .AddComponent<ContentModelBinding>()
-            .SetModel(
-                "Application/MainMenu/Models/planet",
-                1f,
-                new Vector3(0f, 180f, 0f),
-                overwrite: true,
-                normalize: true,
-                center: true,
-                layer: planetLayer
-            );
-
-        // Dedicated sun for the planet, masked to their layer so it never touches the icons.
-        // Gives the rocky surface real directional shading; the emission only lifts the night side.
-        GameObject sunObject = new GameObject("PlanetSun", typeof(Light));
-        sunObject.transform.SetParent(rig.transform, false);
-        sunObject.transform.localRotation = Quaternion.Euler(45.63f, 122.25f, 0f);
-        Light sun = sunObject.GetComponent<Light>();
-        sun.type = LightType.Directional;
-        sun.intensity = 0.9f;
-        sun.color = new Color(1f, 0.94f, 0.88f);
-        sun.cullingMask = 1 << planetLayer;
-        sun.shadows = LightShadows.None;
-
-        GameObject cameraObject = new GameObject("Camera", typeof(Camera));
-        cameraObject.transform.SetParent(rig.transform, false);
-        cameraObject.transform.localPosition = new Vector3(0f, 0f, -6f);
-        Camera camera = cameraObject.GetComponent<Camera>();
-        camera.clearFlags = CameraClearFlags.SolidColor;
-        camera.backgroundColor = new Color(0f, 0f, 0f, 0f);
-        camera.orthographic = true;
-        camera.orthographicSize = 1.75f; // frame the globe (radius 1) with margin
-        camera.nearClipPlane = 0.1f;
-        camera.farClipPlane = 50f;
-        camera.cullingMask = 1 << planetLayer;
-        camera.targetTexture = renderTexture;
-    }
-
-    /// <summary>
-    /// Loads the planet RenderTexture asset, creating it if it does not yet exist.
-    /// </summary>
-    /// <returns>The planet RenderTexture asset.</returns>
-    private static RenderTexture LoadOrCreateRenderTexture()
-    {
-        const int size = 2048; // matches the ~1965px on-screen planet so the HD texture reads crisp
-        RenderTexture existing = AssetDatabase.LoadAssetAtPath<RenderTexture>(_renderTexturePath);
-        if (existing != null)
-        {
-            if (existing.width != size || existing.height != size)
-            {
-                existing.Release();
-                existing.width = size;
-                existing.height = size;
-                EditorUtility.SetDirty(existing);
-            }
-            return existing;
-        }
-
-        RenderTexture created = new RenderTexture(size, size, 16, RenderTextureFormat.ARGB32)
-        {
-            name = "Planet",
-            antiAliasing = 4,
-        };
-        AssetDatabase.CreateAsset(created, _renderTexturePath);
-        return created;
+        // Soft background glow seen through the windshield, dimmed so it stays subtle. The planet is
+        // gone, so this is a standalone atmosphere glow rather than a limb around a globe.
+        RawImage glow = NewRawImage(backdrop.transform, "Atmosphere", null);
+        SetBoundTexture(glow, _atmosphereAddress);
+        glow.color = new Color(1f, 1f, 1f, 0.6f);
+        RectTransform glowRect = glow.rectTransform;
+        glowRect.anchorMin = new Vector2(0.5f, 0.63f);
+        glowRect.anchorMax = new Vector2(0.5f, 0.63f);
+        glowRect.pivot = new Vector2(0.5f, 0.5f);
+        glowRect.sizeDelta = new Vector2(3770.957f, 3526.246f);
+        glowRect.anchoredPosition = new Vector2(74f, -734f);
+        glowRect.localRotation = Quaternion.Euler(0f, 0f, -20.228f);
     }
 
     /// <summary>
@@ -2524,8 +2414,8 @@ public static class MainMenuPrefabBuilder
         light.intensity = intensity;
         light.color = color;
         light.shadows = shadows;
-        // Skip the planet's isolated layer -- it has its own warm sun, and this set's cool fill
-        // light would tint the red planet magenta/purple. (Layer 31 = _planetLayer in BuildPlanetRig.)
+        // Exclude layer 31 (kept reserved for isolated backdrop rigs) so this shared cool fill set
+        // never tints anything parked there.
         light.cullingMask = ~(1 << 31);
     }
 

--- a/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
@@ -843,7 +843,19 @@ public static class MainMenuPrefabBuilder
     /// <param name="address">The stable content address of the texture.</param>
     private static void SetBoundTexture(RawImage image, string address)
     {
-        image.texture = LoadTexture(address);
+        // The editor-display texture is best-effort: content is stripped from player builds and can be
+        // absent where the full media set is not present (e.g. CI). The runtime binding below restores
+        // it from installed content regardless, so a missing asset must not fail prefab generation.
+        try
+        {
+            image.texture = LoadTexture(address);
+        }
+        catch (System.IO.FileNotFoundException)
+        {
+            Debug.LogWarning(
+                $"Content texture '{address}' unavailable for editor display; runtime binding will restore it."
+            );
+        }
         ContentTextureBinding binding = image.gameObject.AddComponent<ContentTextureBinding>();
         binding.SetAddress(address);
     }

--- a/Assets/Tests/EditMode/Content/ContentModelCacheTests.cs
+++ b/Assets/Tests/EditMode/Content/ContentModelCacheTests.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 public sealed class ContentModelCacheTests
 {
-    private const string _planetAddress = "Application/MainMenu/Models/planet";
+    private const string _citadelAddress = "Application/MainMenu/Models/citadel";
 
     [Test]
     public async Task InstantiateAsync_PreloadedModel_CreatesIndependentInstancesAsync()
@@ -19,14 +19,14 @@ public sealed class ContentModelCacheTests
         ContentModelInstance second = null;
         try
         {
-            await cache.PreloadAsync(new[] { _planetAddress });
+            await cache.PreloadAsync(new[] { _citadelAddress });
             first = await cache.InstantiateAsync(
-                _planetAddress,
+                _citadelAddress,
                 firstParent.transform,
                 CancellationToken.None
             );
             second = await cache.InstantiateAsync(
-                _planetAddress,
+                _citadelAddress,
                 secondParent.transform,
                 CancellationToken.None
             );

--- a/Assets/Tests/EditMode/Content/ContentModelLoaderTests.cs
+++ b/Assets/Tests/EditMode/Content/ContentModelLoaderTests.cs
@@ -5,15 +5,15 @@ using UnityEngine;
 
 public sealed class ContentModelLoaderTests
 {
-    private const string _planetAddress = "Application/MainMenu/Models/planet";
+    private const string _citadelAddress = "Application/MainMenu/Models/citadel";
 
     [Test]
     public async Task LoadAsync_ValidGlb_ReturnsDisposableModelAsync()
     {
         ContentPack pack = ContentPackLoader.OpenActive();
         using ContentAssets assets = new ContentAssets(pack.ContentRootPath, pack.PackRootPath);
-        string filePath = assets.ResolveFile(_planetAddress, ".glb");
-        Assert.That(filePath, Is.Not.Null, $"Test GLB is missing: {_planetAddress}");
+        string filePath = assets.ResolveFile(_citadelAddress, ".glb");
+        Assert.That(filePath, Is.Not.Null, $"Test GLB is missing: {_citadelAddress}");
 
         GameObject parent = new GameObject("ContentModelLoaderTest");
         ContentModelInstance instance = null;

--- a/Assets/Tests/EditMode/UI/SceneUI/MainMenu/MainMenuViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/MainMenu/MainMenuViewTests.cs
@@ -74,7 +74,7 @@ namespace Rebellion.Tests.UI.SceneUI.MainMenu
         }
 
         [Test]
-        public void AuthoredPrefab_CockpitPlanetAndControlsShareFullCanvas()
+        public void AuthoredPrefab_CockpitBackdropAndControlsShareFullCanvas()
         {
             Transform canvas = _prefabRoot.transform.Find("UI/Canvas");
             Transform viewport = canvas.Find("Viewport");
@@ -84,10 +84,11 @@ namespace Rebellion.Tests.UI.SceneUI.MainMenu
                 AspectRatioFitter.AspectMode.FitInParent,
                 viewport.GetComponent<AspectRatioFitter>().aspectMode
             );
-            Assert.IsNotNull(viewport.Find("SpaceBackdrop/Planet"));
+            Assert.IsNotNull(viewport.Find("SpaceBackdrop/Starfield"));
+            Assert.IsNull(viewport.Find("SpaceBackdrop/Planet"));
             Assert.IsNotNull(viewport.Find("Cockpit"));
             Assert.AreSame(viewport, viewport.Find("MainMenuControls").parent);
-            Assert.AreEqual(7, _prefabRoot.GetComponentsInChildren<AutoRotate>(true).Length);
+            Assert.AreEqual(6, _prefabRoot.GetComponentsInChildren<AutoRotate>(true).Length);
         }
 
         [Test]


### PR DESCRIPTION
Removes the spinning-planet backdrop from the main menu entirely: the 3D rig (model, sun, camera), its render texture, the on-screen globe, and the planet-only constants. The menu now shows the cockpit over the starfield with just the atmosphere glow behind the windshield.

Follow-up to #91 (which added the glow and removed the asteroid ring); this drops the planet itself, matching the intended look.

## Tests
- `MainMenuViewTests`: no `Planet`, asserts `Starfield` present, `AutoRotate` count 7 -> 6.