### PR TITLE
Add and stabilize in-game options menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,12 +67,14 @@ Assets/_Recovery/
 Assets/Videos/
 Assets/TextMesh Pro/
 /Assets/Content/
+/Assets/UI/
 # Installed content is supplied by rebellion2-media beside the project/player.
 /Content/
 
 # UI builders and committed base-scene templates are the source of truth for generated UI assets.
 /Assets/Prefabs/UI/Common/*.prefab
 /Assets/Prefabs/UI/MainMenu/*.prefab
+/Assets/Prefabs/UI/OptionsMenu/*.prefab
 /Assets/Prefabs/UI/SaveMenu/*.prefab
 /Assets/Prefabs/UI/StrategyView/**/*.prefab
 /Assets/Scenes/MainMenu.unity

--- a/Assets/Editor/OptionsMenuPreview.cs
+++ b/Assets/Editor/OptionsMenuPreview.cs
@@ -1,0 +1,230 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Creates preview images for the Options menu.
+/// </summary>
+public static class OptionsMenuPreview
+{
+    private const string _prefabPath = "Assets/Prefabs/UI/OptionsMenu/OptionsMenu.prefab";
+    private const string _outputDirectory = "C:/Users/David/Downloads/optionsmenu_mockup";
+
+    /// <summary>
+    /// Creates a preview image for each Options menu page.
+    /// </summary>
+    public static void Capture()
+    {
+        UIBuilderMenu.BuildStrategy();
+
+        GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(_prefabPath);
+        if (prefab == null)
+        {
+            Debug.LogError($"OptionsMenuPreview: prefab not found at {_prefabPath}");
+            return;
+        }
+
+        Directory.CreateDirectory(_outputDirectory);
+        foreach (OptionsMenuTab tab in System.Enum.GetValues(typeof(OptionsMenuTab)))
+            CaptureTab(prefab, tab);
+    }
+
+    /// <summary>
+    /// Renders one Options page to a PNG.
+    /// </summary>
+    /// <param name="prefab">The Options overlay prefab.</param>
+    /// <param name="tab">The page to display.</param>
+    private static void CaptureTab(GameObject prefab, OptionsMenuTab tab)
+    {
+        const int rtWidth = 1706;
+        const int rtHeight = 960;
+        const float surfaceWidth = 853.33f;
+        const float surfaceHeight = 480f;
+
+        // Strategy Window Bounds.
+        const float boundsX = 55f;
+        const float boundsY = 36f;
+        const float boundsWidth = 693f;
+        const float boundsHeight = 349f;
+
+        RenderTexture renderTexture = new RenderTexture(rtWidth, rtHeight, 24);
+        GameObject cameraObject = new GameObject("OptionsPreviewCamera");
+        GameObject canvasObject = new GameObject("OptionsPreviewCanvas");
+        GameObject instance = null;
+        try
+        {
+            Camera camera = cameraObject.AddComponent<Camera>();
+            camera.orthographic = true;
+            camera.orthographicSize = surfaceHeight / 2f;
+            camera.aspect = (float)rtWidth / rtHeight;
+            camera.clearFlags = CameraClearFlags.SolidColor;
+            camera.backgroundColor = new Color(0.02f, 0.02f, 0.03f);
+            camera.nearClipPlane = 0.1f;
+            camera.farClipPlane = 100f;
+            camera.transform.position = new Vector3(0f, 0f, -10f);
+            camera.targetTexture = renderTexture;
+
+            Canvas canvas = canvasObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.WorldSpace;
+            canvas.worldCamera = camera;
+            RectTransform canvasRect = canvas.GetComponent<RectTransform>();
+            canvasRect.sizeDelta = new Vector2(surfaceWidth, surfaceHeight);
+            canvasRect.position = Vector3.zero;
+
+            // Preview Background.
+            CreatePreviewRect(
+                canvas.transform,
+                "Surface",
+                0f,
+                0f,
+                surfaceWidth,
+                surfaceHeight,
+                new Color(0.06f, 0.08f, 0.11f)
+            );
+            CreatePreviewRect(
+                canvas.transform,
+                "Bounds",
+                boundsX,
+                boundsY,
+                boundsWidth,
+                boundsHeight,
+                new Color(0.10f, 0.14f, 0.19f)
+            );
+
+            instance = Object.Instantiate(prefab, canvas.transform);
+            OptionsMenuView view = instance.GetComponent<OptionsMenuView>();
+            RectTransform windowRect = instance.GetComponent<RectTransform>();
+            view.Render(BuildSampleData(tab));
+
+            // Center the Options menu.
+            float windowWidth = windowRect.sizeDelta.x;
+            float windowHeight = windowRect.sizeDelta.y;
+            float windowX = Mathf.Round((surfaceWidth - windowWidth) / 2f);
+            float windowY = Mathf.Round((surfaceHeight - windowHeight) / 2f);
+            windowRect.anchorMin = new Vector2(0f, 1f);
+            windowRect.anchorMax = new Vector2(0f, 1f);
+            windowRect.pivot = new Vector2(0f, 1f);
+            windowRect.anchoredPosition = new Vector2(windowX, -windowY);
+            instance.SetActive(true);
+
+            Canvas.ForceUpdateCanvases();
+            camera.Render();
+
+            RenderTexture previous = RenderTexture.active;
+            RenderTexture.active = renderTexture;
+            Texture2D texture = new Texture2D(rtWidth, rtHeight, TextureFormat.RGB24, false);
+            texture.ReadPixels(new Rect(0f, 0f, rtWidth, rtHeight), 0, 0);
+            texture.Apply();
+            RenderTexture.active = previous;
+
+            File.WriteAllBytes(
+                Path.Combine(_outputDirectory, $"preview_{tab}.png"),
+                texture.EncodeToPNG()
+            );
+            Object.DestroyImmediate(texture);
+            Debug.Log($"OptionsMenuPreview: captured {tab}");
+        }
+        finally
+        {
+            if (instance != null)
+                Object.DestroyImmediate(instance);
+            Object.DestroyImmediate(canvasObject);
+            Object.DestroyImmediate(cameraObject);
+            renderTexture.Release();
+            Object.DestroyImmediate(renderTexture);
+        }
+    }
+
+    /// <summary>
+    /// Creates a rectangle in the preview.
+    /// </summary>
+    /// <param name="parent">The canvas transform.</param>
+    /// <param name="name">The rectangle name.</param>
+    /// <param name="x">The left offset in source units.</param>
+    /// <param name="y">The top offset in source units.</param>
+    /// <param name="width">The source-space width.</param>
+    /// <param name="height">The source-space height.</param>
+    /// <param name="color">The fill color.</param>
+    private static void CreatePreviewRect(
+        Transform parent,
+        string name,
+        float x,
+        float y,
+        float width,
+        float height,
+        Color color
+    )
+    {
+        GameObject rectObject = new GameObject(name, typeof(RectTransform), typeof(Image));
+        rectObject.transform.SetParent(parent, false);
+        Image image = rectObject.GetComponent<Image>();
+        image.color = color;
+        RectTransform rect = rectObject.GetComponent<RectTransform>();
+        rect.anchorMin = new Vector2(0f, 1f);
+        rect.anchorMax = new Vector2(0f, 1f);
+        rect.pivot = new Vector2(0f, 1f);
+        rect.anchoredPosition = new Vector2(x, -y);
+        rect.sizeDelta = new Vector2(width, height);
+    }
+
+    /// <summary>
+    /// Creates sample data for an Options menu page.
+    /// </summary>
+    /// <param name="tab">The page to display.</param>
+    /// <returns>The sample Options menu data.</returns>
+    private static OptionsMenuRenderData BuildSampleData(OptionsMenuTab tab)
+    {
+        Dictionary<UserTacticalOption, bool> tactical = new Dictionary<UserTacticalOption, bool>
+        {
+            { UserTacticalOption.Starfield, true },
+            { UserTacticalOption.Planet, true },
+            { UserTacticalOption.Pyro, false },
+            { UserTacticalOption.HighDetail, true },
+            { UserTacticalOption.Holocube, true },
+        };
+        float[] volumes = { 0.85f, 0.70f, 0.90f, 0.60f, 0.80f };
+        List<OptionsBindingRow> bindings = new List<OptionsBindingRow>
+        {
+            new OptionsBindingRow("GLOBAL", string.Empty),
+            new OptionsBindingRow("Cancel Or Settings", "Esc"),
+            new OptionsBindingRow("Quick Save", "F4"),
+            new OptionsBindingRow("Quick Load", "F9"),
+            new OptionsBindingRow("Increase Game Speed", "Ctrl+="),
+            new OptionsBindingRow("Decrease Game Speed", "Ctrl+-"),
+            new OptionsBindingRow("STRATEGY", string.Empty),
+            new OptionsBindingRow("Multi Select", "Ctrl"),
+            new OptionsBindingRow("Range Select", "Shift"),
+            new OptionsBindingRow("Alternate Select", "Alt"),
+            new OptionsBindingRow("WINDOW", string.Empty),
+            new OptionsBindingRow("Confirm", "Enter"),
+            new OptionsBindingRow("Close", "Esc"),
+        };
+        List<OptionsSaveSlot> slots = new List<OptionsSaveSlot>
+        {
+            new OptionsSaveSlot("Create New Save", string.Empty, null, true, null),
+            new OptionsSaveSlot("Battle of Endor", "2026-08-10 14:32", null, false, "save1"),
+            new OptionsSaveSlot("Hoth Holdout", "2026-08-09 21:07", null, false, "save2"),
+            new OptionsSaveSlot("Coruscant Gambit", "2026-08-08 10:55", null, false, "save3"),
+        };
+        return new OptionsMenuRenderData(
+            0,
+            0,
+            tab,
+            "1920 x 1080",
+            "Fullscreen",
+            tactical,
+            volumes,
+            bindings,
+            slots,
+            0,
+            true,
+            true,
+            true,
+            true,
+            -1,
+            false
+        );
+    }
+}

--- a/Assets/Editor/OptionsMenuSpritePostprocessor.cs
+++ b/Assets/Editor/OptionsMenuSpritePostprocessor.cs
@@ -1,0 +1,48 @@
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Configures the Options menu sprites when they are imported.
+/// </summary>
+public sealed class OptionsMenuSpritePostprocessor : AssetPostprocessor
+{
+    private const string _directory = "Assets/UI/OptionsMenu/";
+
+    /// <summary>
+    /// Applies the Options menu sprite settings.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Roslynator",
+        "RCS1213",
+        Justification = "Unity invokes AssetPostprocessor callbacks by method name."
+    )]
+    private void OnPreprocessTexture()
+    {
+        if (!assetPath.StartsWith(_directory) || !assetPath.EndsWith(".png"))
+            return;
+
+        TextureImporter importer = (TextureImporter)assetImporter;
+        importer.textureType = TextureImporterType.Sprite;
+        importer.spriteImportMode = SpriteImportMode.Single;
+        importer.spriteBorder = GetSliceBorder(assetPath);
+        importer.alphaIsTransparency = true;
+        importer.mipmapEnabled = false;
+        importer.wrapMode = TextureWrapMode.Clamp;
+        importer.filterMode = FilterMode.Bilinear;
+        importer.textureCompression = TextureImporterCompression.Uncompressed;
+    }
+
+    /// <summary>
+    /// Returns the border used to slice a sprite.
+    /// </summary>
+    /// <param name="path">The sprite asset path.</param>
+    /// <returns>The slice border, or zero for fixed-aspect art.</returns>
+    private static Vector4 GetSliceBorder(string path)
+    {
+        if (path.Contains("toggle") || path.Contains("knob"))
+            return Vector4.zero;
+        if (path.Contains("badge"))
+            return new Vector4(6f, 6f, 6f, 6f);
+        return new Vector4(7f, 7f, 7f, 7f);
+    }
+}

--- a/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
@@ -20,6 +20,8 @@ using Object = UnityEngine.Object;
 public static class MainMenuPrefabBuilder
 {
     private const string _scenePath = "Assets/Scenes/MainMenu.unity";
+    private const string _optionsMenuPrefabPath =
+        "Assets/Prefabs/UI/OptionsMenu/OptionsMenu.prefab";
     private const string _sceneTemplatePath =
         "Assets/Editor/PrefabBuilders/Templates/MainMenu.unity";
     private const string _sceneInstanceName = "MainMenuRoot";
@@ -39,6 +41,7 @@ public static class MainMenuPrefabBuilder
     private const string _selectSfxPath = "Application/MainMenu/Audio/select";
     private const string _exitSelectSfxPath = "Application/MainMenu/Audio/exit-select";
     private const string _galaxySizeSelectSfxPath = "Application/MainMenu/Audio/galaxysize-select";
+    private const string _factionSelectSfxPath = "Application/MainMenu/Audio/faction-select";
 
     // Icon turntable speed: one full revolution per second (matched the original 2D flipbook loop).
     private const float _iconTurnDegreesPerSecond = 360f;
@@ -267,14 +270,14 @@ public static class MainMenuPrefabBuilder
             ("EasyDifficultyToggle", _selectSfxPath),
             ("MediumDifficultyToggle", _selectSfxPath),
             ("HardDifficultyToggle", _selectSfxPath),
-            ("SmallGalaxyToggle", _selectSfxPath),
-            ("MediumGalaxyToggle", _selectSfxPath),
-            ("LargeGalaxyToggle", _selectSfxPath),
+            ("SmallGalaxyToggle", _galaxySizeSelectSfxPath),
+            ("MediumGalaxyToggle", _galaxySizeSelectSfxPath),
+            ("LargeGalaxyToggle", _galaxySizeSelectSfxPath),
             ("ExitButton", _exitSelectSfxPath),
             ("CreditsButton", _selectSfxPath),
             ("LoadGameButton", _selectSfxPath),
-            ("LeftFactionLaunchButton", _galaxySizeSelectSfxPath),
-            ("RightFactionLaunchButton", _galaxySizeSelectSfxPath),
+            ("LeftFactionLaunchButton", _factionSelectSfxPath),
+            ("RightFactionLaunchButton", _factionSelectSfxPath),
             ("VictoryConditionButton", _selectSfxPath),
             ("VictoryConditionIcon", _selectSfxPath),
         };
@@ -342,6 +345,11 @@ public static class MainMenuPrefabBuilder
         MainMenuController controller = controllerObject.AddComponent<MainMenuController>();
         MainMenuView view = controllerObject.AddComponent<MainMenuView>();
         AssignReference(controller, "view", view);
+        AssignReference(
+            controller,
+            "_optionsMenuPrefab",
+            AssetDatabase.LoadAssetAtPath<OptionsMenuView>(_optionsMenuPrefabPath)
+        );
         AssignFloat(controller, "creditsMusicFadeDuration", 0.5f);
         return controller;
     }

--- a/Assets/Editor/PrefabBuilders/OptionsMenu.meta
+++ b/Assets/Editor/PrefabBuilders/OptionsMenu.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f2da014e79cbdd5468dff88873d2129c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs
@@ -1,0 +1,1056 @@
+using System.IO;
+using TMPro;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Builds the Options menu prefab.
+/// </summary>
+public static partial class StrategyViewPrefabBuilder
+{
+    /// <summary>
+    /// Builds the Options menu prefab.
+    /// </summary>
+    /// <returns>The Options menu view.</returns>
+    private static OptionsMenuView BuildOptionsMenuPrefab()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_optionsMenuWindowPrefabPath));
+
+        Color accent = new Color(0.373f, 0.659f, 0.925f);
+        Color textColor = new Color(0.875f, 0.910f, 0.941f);
+        Color textDim = new Color(0.573f, 0.635f, 0.706f);
+
+        GameObject window = new GameObject(
+            "OptionsMenu",
+            typeof(RectTransform),
+            typeof(UIWindow),
+            typeof(OptionsMenuView)
+        );
+        OptionsMenuView view = EnableRuntimeComponent(window.GetComponent<OptionsMenuView>());
+        ConfigureWindowRoot(window.GetComponent<UIWindow>());
+        SetSourceRect(window.GetComponent<RectTransform>(), 0, 0, 454, 341);
+
+        // Options Menu Content.
+        RectTransform contentRoot = CreateSourceRectLayer(
+            "ContentRoot",
+            window.transform,
+            632,
+            474
+        );
+        contentRoot.localScale = new Vector3(0.719f, 0.719f, 1f);
+
+        RawImage background = CreateRawImage(
+            "BackgroundImage",
+            contentRoot,
+            "Application/OptionsMenu/UI/ui_settingsmenu_background",
+            0,
+            0,
+            632,
+            474
+        );
+        background.raycastTarget = true;
+        CreateSlicedImage(
+            "FrameGlow",
+            contentRoot,
+            _optionsFrameGlowSpritePath,
+            2,
+            2,
+            628,
+            470,
+            Color.white
+        );
+
+        CreateSlicedImage(
+            "NavPanel",
+            contentRoot,
+            _optionsPanelSpritePath,
+            23,
+            69,
+            192,
+            365,
+            Color.white
+        );
+        CreateSlicedImage(
+            "ContentPanel",
+            contentRoot,
+            _optionsPanelSpritePath,
+            228,
+            69,
+            382,
+            365,
+            Color.white
+        );
+
+        TextMeshProUGUI header = CreateTextLabel("HeaderTextField", contentRoot);
+        header.text = "OPTIONS";
+        header.color = textColor;
+        header.fontSize = 22;
+        header.alignment = TextAlignmentOptions.Midline;
+        ApplyOptionsDisplayFont(header);
+        SetSourceRect(header.rectTransform, 41, 32, 155, 26);
+
+        TextMeshProUGUI pageTitle = CreateTextLabel("PageTitleTextField", contentRoot);
+        pageTitle.text = "GRAPHICS";
+        pageTitle.color = accent;
+        pageTitle.fontSize = 14;
+        pageTitle.alignment = TextAlignmentOptions.Midline;
+        ApplyOptionsDisplayFont(pageTitle);
+        SetSourceRect(pageTitle.rectTransform, 240, 36, 357, 22);
+
+        string[] tabNames = { "GRAPHICS", "AUDIO", "SAVE / LOAD", "CONTROLS" };
+        string[] tabObjectNames = { "GraphicsTab", "AudioTab", "SaveLoadTab", "ControlsTab" };
+        Button[] tabButtons = new Button[4];
+        TextMeshProUGUI[] tabLabels = new TextMeshProUGUI[4];
+        for (int i = 0; i < tabNames.Length; i++)
+        {
+            Button tabButton = CreateSlicedButton(
+                tabObjectNames[i],
+                contentRoot,
+                _optionsRowSpritePath,
+                38,
+                82 + i * 36,
+                163,
+                30,
+                Color.white
+            );
+            tabButtons[i] = tabButton;
+            ApplyOptionsButtonFeedback(tabButton);
+            AddOptionsButtonBorder(tabButton.targetGraphic);
+            TextMeshProUGUI tabLabel = CreateTextLabel(
+                $"{tabObjectNames[i]}Label",
+                tabButton.transform
+            );
+            tabLabel.text = tabNames[i];
+            tabLabel.color = textColor;
+            tabLabel.fontSize = 13;
+            tabLabel.alignment = TextAlignmentOptions.MidlineLeft;
+            ApplyOptionsDisplayFont(tabLabel);
+            SetSourceRect(tabLabel.rectTransform, 14, 5, 140, 20);
+            tabLabels[i] = tabLabel;
+        }
+
+        RectTransform graphicsPage = CreateChildLayer("GraphicsPage", contentRoot);
+        SetSourceRect(graphicsPage, 228, 69, 382, 365);
+        RectTransform audioPage = CreateChildLayer("AudioPage", contentRoot);
+        SetSourceRect(audioPage, 228, 69, 382, 365);
+        RectTransform saveLoadPage = CreateChildLayer("SaveLoadPage", contentRoot);
+        SetSourceRect(saveLoadPage, 228, 69, 382, 365);
+        RectTransform controlsPage = CreateChildLayer("ControlsPage", contentRoot);
+        SetSourceRect(controlsPage, 228, 69, 382, 365);
+
+        // Hidden Pages.
+        audioPage.gameObject.SetActive(false);
+        saveLoadPage.gameObject.SetActive(false);
+        controlsPage.gameObject.SetActive(false);
+
+        Button backToGameButton = CreateOptionsNavRow(
+            contentRoot,
+            "BackToGame",
+            "BACK TO GAME",
+            226,
+            textDim
+        );
+        Button mainMenuButton = CreateOptionsNavRow(
+            contentRoot,
+            "MainMenu",
+            "MAIN MENU",
+            265,
+            textDim
+        );
+        Button quitButton = CreateOptionsNavRow(contentRoot, "Quit", "QUIT", 304, textDim);
+
+        RectTransform settingsActions = CreateChildLayer("SettingsActions", contentRoot);
+        Button defaultsButton = CreateOptionsActionButton(
+            settingsActions,
+            "DefaultsButton",
+            "DEFAULTS",
+            338,
+            textColor
+        );
+        Button applyButton = CreateOptionsActionButton(
+            settingsActions,
+            "ApplyButton",
+            "APPLY",
+            424,
+            textColor
+        );
+
+        CreateOptionsSectionHeader(graphicsPage, "DisplayHeader", "DISPLAY", 16, accent);
+        TextMeshProUGUI resolutionValue = CreateOptionsFieldRow(
+            graphicsPage,
+            "Resolution",
+            "Resolution",
+            41,
+            out Button resolutionPrev,
+            out Button resolutionNext
+        );
+        TextMeshProUGUI fullScreenValue = CreateOptionsFieldRow(
+            graphicsPage,
+            "Display",
+            "Display Mode",
+            68,
+            out Button fullScreenPrev,
+            out Button fullScreenNext
+        );
+        CreateOptionsSectionHeader(graphicsPage, "DetailHeader", "DETAIL", 101, accent);
+
+        UserTacticalOption[] options =
+        {
+            UserTacticalOption.Starfield,
+            UserTacticalOption.Planet,
+            UserTacticalOption.Pyro,
+            UserTacticalOption.HighDetail,
+            UserTacticalOption.Holocube,
+        };
+        string[] optionLabels =
+        {
+            "Starfield",
+            "Planet Backdrop",
+            "Pyrotechnics",
+            "High Detail Textures",
+            "Holocube",
+        };
+        OptionsToggleRowView[] tacticalRows = new OptionsToggleRowView[5];
+        for (int i = 0; i < options.Length; i++)
+            tacticalRows[i] = CreateOptionsTacticalRow(
+                graphicsPage,
+                $"Tactical{options[i]}",
+                options[i],
+                optionLabels[i],
+                20,
+                126 + i * 26
+            );
+
+        CreateOptionsSectionHeader(audioPage, "VolumeHeader", "VOLUME", 16, accent);
+        string[] volumeLabels = { "Master", "Music", "Sound Effects", "Ambience", "Video" };
+        SaveMenuSliderView[] volumeSliders = new SaveMenuSliderView[5];
+        TextMeshProUGUI[] volumeValues = new TextMeshProUGUI[5];
+        for (int i = 0; i < volumeLabels.Length; i++)
+        {
+            int rowY = 44 + i * 34;
+            TextMeshProUGUI volumeLabel = CreateTextLabel($"VolumeLabel{i}", audioPage);
+            volumeLabel.text = volumeLabels[i];
+            volumeLabel.color = textColor;
+            volumeLabel.fontSize = 11;
+            volumeLabel.alignment = TextAlignmentOptions.MidlineLeft;
+            SetSourceRect(volumeLabel.rectTransform, 20, rowY - 1, 100, 14);
+            volumeSliders[i] = CreateOptionsSlider(
+                audioPage,
+                $"VolumeSlider{i}",
+                181,
+                rowY + 2,
+                146
+            );
+            TextMeshProUGUI volumeValue = CreateTextLabel($"VolumeValue{i}", audioPage);
+            volumeValue.text = "100";
+            volumeValue.color = textColor;
+            volumeValue.fontSize = 10;
+            volumeValue.alignment = TextAlignmentOptions.MidlineLeft;
+            SetSourceRect(volumeValue.rectTransform, 336, rowY - 1, 30, 14);
+            volumeValues[i] = volumeValue;
+        }
+
+        TextMeshProUGUI savedGamesLabel = CreateOptionsSectionHeader(
+            saveLoadPage,
+            "SavedGamesLabel",
+            "SAVED GAMES",
+            13,
+            accent
+        );
+        savedGamesLabel.rectTransform.anchoredPosition = new Vector2(18f, -13f);
+        RawImage saveIcon = CreateRawImage(
+            "SaveIcon",
+            saveLoadPage,
+            "Application/OptionsMenu/UI/ui_settingsmenu_savedgames_save_icon",
+            258,
+            11,
+            49,
+            23
+        );
+        Button saveButton = CreateButton(saveIcon);
+        saveIcon
+            .GetComponent<ContentPressVisualBinding>()
+            .SetAddresses(
+                "Application/OptionsMenu/UI/ui_settingsmenu_savedgames_save_icon",
+                "Application/OptionsMenu/UI/ui_settingsmenu_savedgames_save_icon_pressed"
+            );
+        RawImage saveDisabledIcon = CreateRawImage(
+            "SaveIconDisabled",
+            saveLoadPage,
+            "Application/OptionsMenu/UI/ui_settingsmenu_savedgames_save_icon_disabled",
+            258,
+            11,
+            49,
+            23
+        );
+        saveDisabledIcon.gameObject.SetActive(false);
+        RawImage loadIcon = CreateRawImage(
+            "LoadIcon",
+            saveLoadPage,
+            "Application/OptionsMenu/UI/ui_settingsmenu_savedgames_load_icon",
+            313,
+            11,
+            49,
+            23
+        );
+        Button loadButton = CreateButton(loadIcon);
+        loadIcon
+            .GetComponent<ContentPressVisualBinding>()
+            .SetAddresses(
+                "Application/OptionsMenu/UI/ui_settingsmenu_savedgames_load_icon",
+                "Application/OptionsMenu/UI/ui_settingsmenu_savedgames_load_icon_pressed"
+            );
+        RawImage loadDisabledIcon = CreateRawImage(
+            "LoadIconDisabled",
+            saveLoadPage,
+            "Application/OptionsMenu/UI/ui_settingsmenu_savedgames_load_icon_disabled",
+            313,
+            11,
+            49,
+            23
+        );
+        loadDisabledIcon.gameObject.SetActive(false);
+        ApplyOptionsButtonFeedback(saveButton, saveIcon);
+        ApplyOptionsButtonFeedback(loadButton, loadIcon);
+        ScrollAreaView saveSlotScrollArea = CreateScrollAreaView(
+            saveLoadPage,
+            "SaveSlotScrollArea",
+            18,
+            40,
+            349,
+            290,
+            0,
+            0,
+            337,
+            290,
+            337,
+            0,
+            12,
+            290,
+            out RectTransform slotContent
+        );
+        Image slotRowTemplate = CreateSlicedImage(
+            "SlotRowTemplate",
+            slotContent,
+            _optionsRowSpritePath,
+            0,
+            0,
+            337,
+            28,
+            Color.white
+        );
+        slotRowTemplate.raycastTarget = true;
+        Button slotRowButton = slotRowTemplate.gameObject.AddComponent<Button>();
+        slotRowButton.targetGraphic = slotRowTemplate;
+        slotRowButton.transition = Selectable.Transition.None;
+        slotRowTemplate.gameObject.SetActive(false);
+        RawImage slotIconTemplate = CreateRawButton("SlotIconTemplate", slotContent, null);
+        slotIconTemplate.raycastTarget = false;
+        SetSourceRect(slotIconTemplate.rectTransform, 8, 4, 20, 20);
+        slotIconTemplate.gameObject.SetActive(false);
+        TextMeshProUGUI slotNameTemplate = CreateTextLabel("SlotNameTemplate", slotContent);
+        slotNameTemplate.text = "Save";
+        slotNameTemplate.color = textColor;
+        slotNameTemplate.fontSize = 12;
+        slotNameTemplate.alignment = TextAlignmentOptions.TopLeft;
+        slotNameTemplate.raycastTarget = false;
+        ApplyOptionsDisplayFont(slotNameTemplate);
+        SetSourceRect(slotNameTemplate.rectTransform, 34, 2, 300, 13);
+        slotNameTemplate.gameObject.SetActive(false);
+        TextMeshProUGUI slotMetaTemplate = CreateTextLabel("SlotDateTemplate", slotContent);
+        slotMetaTemplate.text = "Date";
+        slotMetaTemplate.color = textDim;
+        slotMetaTemplate.fontSize = 9;
+        slotMetaTemplate.alignment = TextAlignmentOptions.TopLeft;
+        slotMetaTemplate.raycastTarget = false;
+        SetSourceRect(slotMetaTemplate.rectTransform, 34, 16, 300, 10);
+        slotMetaTemplate.gameObject.SetActive(false);
+
+        GameObject deleteObject = new GameObject(
+            "SlotDeleteTemplate",
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image)
+        );
+        deleteObject.transform.SetParent(slotContent, false);
+        Image deleteHit = deleteObject.GetComponent<Image>();
+        deleteHit.color = Color.clear;
+        deleteHit.raycastTarget = true;
+        SetSourceRect(deleteObject.GetComponent<RectTransform>(), 0, 0, 16, 16);
+        Button slotDeleteTemplate = deleteObject.AddComponent<Button>();
+        TextMeshProUGUI deleteGlyph = CreateTextLabel("Glyph", deleteObject.transform);
+        deleteGlyph.text = "×";
+        deleteGlyph.color = new Color(0.78f, 0.45f, 0.47f);
+        deleteGlyph.fontSize = 16;
+        deleteGlyph.alignment = TextAlignmentOptions.Midline;
+        deleteGlyph.raycastTarget = false;
+        SetSourceRect(deleteGlyph.rectTransform, 0, 0, 16, 16);
+        ApplyOptionsButtonFeedback(slotDeleteTemplate, deleteGlyph);
+        slotDeleteTemplate.gameObject.SetActive(false);
+
+        TMP_InputField slotRenameField = CreateTextInputField(
+            "SlotRenameField",
+            slotContent,
+            "Save name",
+            32,
+            0,
+            275,
+            16
+        );
+        Image renameBackground = slotRenameField.GetComponent<Image>();
+        renameBackground.color = new Color(0.08f, 0.10f, 0.13f, 0.98f);
+        slotRenameField.textComponent.fontSize = 12;
+        slotRenameField.textComponent.alignment = TextAlignmentOptions.MidlineLeft;
+        StretchFillInputChild((RectTransform)slotRenameField.textComponent.transform);
+        slotRenameField.customCaretColor = true;
+        slotRenameField.caretColor = Color.white;
+        slotRenameField.caretWidth = 2;
+        slotRenameField.caretBlinkRate = 0.85f;
+        if (slotRenameField.placeholder is TextMeshProUGUI renamePlaceholder)
+        {
+            renamePlaceholder.fontSize = 12;
+            renamePlaceholder.alignment = TextAlignmentOptions.MidlineLeft;
+            renamePlaceholder.color = new Color(0.60f, 0.65f, 0.72f);
+            StretchFillInputChild(renamePlaceholder.rectTransform);
+        }
+        slotRenameField.onFocusSelectAll = false;
+        slotRenameField.gameObject.SetActive(false);
+
+        ScrollAreaView controlsScrollArea = CreateScrollAreaView(
+            controlsPage,
+            "ControlsScrollArea",
+            18,
+            16,
+            356,
+            312,
+            0,
+            0,
+            342,
+            312,
+            344,
+            0,
+            12,
+            312,
+            out RectTransform controlsContent
+        );
+
+        TextMeshProUGUI primaryColumnHeader = CreateTextLabel("PrimaryColumnHeader", controlsPage);
+        primaryColumnHeader.text = "PRIMARY";
+        primaryColumnHeader.color = textDim;
+        primaryColumnHeader.fontSize = 9;
+        primaryColumnHeader.alignment = TextAlignmentOptions.Midline;
+        ApplyOptionsDisplayFont(primaryColumnHeader);
+        SetSourceRect(primaryColumnHeader.rectTransform, 216, 2, 63, 12);
+        TextMeshProUGUI secondaryColumnHeader = CreateTextLabel(
+            "SecondaryColumnHeader",
+            controlsPage
+        );
+        secondaryColumnHeader.text = "SECONDARY";
+        secondaryColumnHeader.color = textDim;
+        secondaryColumnHeader.fontSize = 9;
+        secondaryColumnHeader.alignment = TextAlignmentOptions.Midline;
+        ApplyOptionsDisplayFont(secondaryColumnHeader);
+        SetSourceRect(secondaryColumnHeader.rectTransform, 283, 2, 63, 12);
+
+        Image bindingRowTemplate = CreateSlicedImage(
+            "BindingRowTemplate",
+            controlsContent,
+            _optionsRowSpritePath,
+            0,
+            0,
+            342,
+            23,
+            Color.white
+        );
+        bindingRowTemplate.gameObject.SetActive(false);
+        TextMeshProUGUI bindingHeaderTemplate = CreateTextLabel(
+            "BindingHeaderTemplate",
+            controlsContent
+        );
+        bindingHeaderTemplate.text = "GROUP";
+        bindingHeaderTemplate.color = accent;
+        bindingHeaderTemplate.fontSize = 12;
+        bindingHeaderTemplate.alignment = TextAlignmentOptions.TopLeft;
+        ApplyOptionsDisplayFont(bindingHeaderTemplate);
+        SetSourceRect(bindingHeaderTemplate.rectTransform, 0, 0, 220, 16);
+        bindingHeaderTemplate.gameObject.SetActive(false);
+        TextMeshProUGUI bindingActionTemplate = CreateTextLabel(
+            "BindingActionTemplate",
+            controlsContent
+        );
+        bindingActionTemplate.text = "Action";
+        bindingActionTemplate.color = textDim;
+        bindingActionTemplate.fontSize = 11;
+        bindingActionTemplate.alignment = TextAlignmentOptions.TopLeft;
+        SetSourceRect(bindingActionTemplate.rectTransform, 11, 4, 245, 15);
+        bindingActionTemplate.gameObject.SetActive(false);
+        Image bindingKeyBadgeTemplate = CreateSlicedImage(
+            "BindingKeyBadgeTemplate",
+            controlsContent,
+            _optionsBadgeSpritePath,
+            266,
+            3,
+            61,
+            16,
+            Color.white
+        );
+        bindingKeyBadgeTemplate.raycastTarget = true;
+        Button bindingKeyBadgeButton = bindingKeyBadgeTemplate.gameObject.AddComponent<Button>();
+        bindingKeyBadgeButton.targetGraphic = bindingKeyBadgeTemplate;
+        bindingKeyBadgeButton.transition = Selectable.Transition.None;
+        bindingKeyBadgeTemplate.gameObject.SetActive(false);
+        TextMeshProUGUI bindingKeyTemplate = CreateTextLabel("BindingKeyTemplate", controlsContent);
+        bindingKeyTemplate.text = "Key";
+        bindingKeyTemplate.color = textColor;
+        bindingKeyTemplate.fontSize = 10;
+        bindingKeyTemplate.alignment = TextAlignmentOptions.Midline;
+        SetSourceRect(bindingKeyTemplate.rectTransform, 266, 3, 61, 16);
+        bindingKeyTemplate.gameObject.SetActive(false);
+
+        // Confirmation Dialog.
+        SaveMenuConfirmDialogView confirmDialog = SaveMenuPrefabBuilder.CreateConfirmDialog(
+            contentRoot
+        );
+        confirmDialog.transform.SetAsLastSibling();
+        confirmDialog.gameObject.SetActive(false);
+        ConfigureOptionsNavigationLayout(contentRoot, backToGameButton, mainMenuButton, quitButton);
+
+        AssignReference(view, "_backgroundImage", background);
+        AssignReference(view, "_headerTextField", header);
+        AssignReference(view, "_pageTitleTextField", pageTitle);
+        AssignReference(
+            view,
+            "_rowIdleSprite",
+            AssetDatabase.LoadAssetAtPath<Sprite>(_optionsRowSpritePath)
+        );
+        AssignReference(
+            view,
+            "_rowActiveSprite",
+            AssetDatabase.LoadAssetAtPath<Sprite>(_optionsRowActiveSpritePath)
+        );
+        AssignReferenceArray(view, "_tabButtons", tabButtons);
+        AssignReferenceArray(view, "_tabLabelFields", tabLabels);
+        AssignReference(view, "_graphicsPage", graphicsPage.gameObject);
+        AssignReference(view, "_audioPage", audioPage.gameObject);
+        AssignReference(view, "_saveLoadPage", saveLoadPage.gameObject);
+        AssignReference(view, "_controlsPage", controlsPage.gameObject);
+        AssignReference(view, "_backToGameButton", backToGameButton);
+        AssignReference(view, "_mainMenuButton", mainMenuButton);
+        AssignReference(view, "_quitButton", quitButton);
+        AssignReferenceArray(view, "_tacticalRows", tacticalRows);
+        AssignReference(view, "_resolutionValueField", resolutionValue);
+        AssignReference(view, "_resolutionPrevButton", resolutionPrev);
+        AssignReference(view, "_resolutionNextButton", resolutionNext);
+        AssignReference(view, "_fullScreenValueField", fullScreenValue);
+        AssignReference(view, "_fullScreenPrevButton", fullScreenPrev);
+        AssignReference(view, "_fullScreenNextButton", fullScreenNext);
+        AssignReferenceArray(view, "_volumeSliders", volumeSliders);
+        AssignReferenceArray(view, "_volumeValueFields", volumeValues);
+        AssignReference(view, "_saveButton", saveButton);
+        AssignReference(view, "_loadButton", loadButton);
+        AssignReference(view, "_saveDisabledImage", saveDisabledIcon);
+        AssignReference(view, "_loadDisabledImage", loadDisabledIcon);
+        AssignReference(view, "_settingsActions", settingsActions.gameObject);
+        AssignReference(view, "_applyButton", applyButton);
+        AssignReference(view, "_defaultsButton", defaultsButton);
+        AssignReference(view, "_confirmDialog", confirmDialog);
+        AssignReference(view, "_saveSlotScrollArea", saveSlotScrollArea);
+        AssignReference(view, "_slotRowTemplate", slotRowTemplate);
+        AssignReference(view, "_slotIconTemplate", slotIconTemplate);
+        AssignReference(view, "_slotNameTemplate", slotNameTemplate);
+        AssignReference(view, "_slotMetaTemplate", slotMetaTemplate);
+        AssignReference(view, "_slotDeleteTemplate", slotDeleteTemplate);
+        AssignReference(view, "_slotRenameField", slotRenameField);
+        AssignReference(view, "_controlsScrollArea", controlsScrollArea);
+        AssignReference(view, "_bindingRowTemplate", bindingRowTemplate);
+        AssignReference(view, "_bindingHeaderTemplate", bindingHeaderTemplate);
+        AssignReference(view, "_bindingActionTemplate", bindingActionTemplate);
+        AssignReference(view, "_bindingKeyBadgeTemplate", bindingKeyBadgeTemplate);
+        AssignReference(view, "_bindingKeyTemplate", bindingKeyTemplate);
+
+        GameObject saved = SaveGeneratedPrefabAsset(window, _optionsMenuWindowPrefabPath);
+        Object.DestroyImmediate(window);
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+        return saved.GetComponent<OptionsMenuView>();
+    }
+
+    /// <summary>
+    /// Adds color feedback to a button.
+    /// </summary>
+    /// <param name="button">The button to restyle.</param>
+    /// <param name="target">The graphic to tint, or null to keep the button's target graphic.</param>
+    private static void ApplyOptionsButtonFeedback(Button button, Graphic target = null)
+    {
+        if (button == null)
+            return;
+
+        if (target != null)
+            button.targetGraphic = target;
+
+        button.transition = Selectable.Transition.ColorTint;
+        ColorBlock colors = button.colors;
+        colors.normalColor = new Color(0.88f, 0.91f, 0.96f);
+        colors.highlightedColor = Color.white;
+        colors.pressedColor = new Color(0.52f, 0.60f, 0.72f);
+        colors.selectedColor = colors.normalColor;
+        colors.disabledColor = new Color(0.45f, 0.48f, 0.54f, 0.4f);
+        colors.colorMultiplier = 1f;
+        colors.fadeDuration = 0.08f;
+        button.colors = colors;
+    }
+
+    /// <summary>
+    /// Adds color feedback to a filled button.
+    /// </summary>
+    /// <param name="button">The fill button to restyle.</param>
+    private static void ApplyOptionsFillButtonFeedback(Button button)
+    {
+        if (button == null)
+            return;
+
+        button.transition = Selectable.Transition.ColorTint;
+        ColorBlock colors = button.colors;
+        colors.normalColor = new Color(0.34f, 0.44f, 0.60f);
+        colors.highlightedColor = new Color(0.49f, 0.61f, 0.80f);
+        colors.pressedColor = new Color(0.66f, 0.79f, 0.98f);
+        colors.selectedColor = colors.normalColor;
+        colors.disabledColor = new Color(0.22f, 0.24f, 0.28f, 0.55f);
+        colors.colorMultiplier = 1f;
+        colors.fadeDuration = 0.08f;
+        button.colors = colors;
+    }
+
+    /// <summary>
+    /// Adds a border to a button.
+    /// </summary>
+    /// <param name="graphic">The button fill graphic to outline.</param>
+    private static void AddOptionsButtonBorder(Graphic graphic)
+    {
+        if (graphic == null)
+            return;
+
+        Outline outline = graphic.gameObject.AddComponent<Outline>();
+        outline.effectColor = new Color(0.60f, 0.69f, 0.85f, 0.9f);
+        outline.effectDistance = new Vector2(1.2f, -1.2f);
+        outline.useGraphicAlpha = false;
+    }
+
+    /// <summary>
+    /// Positions text inside an input field.
+    /// </summary>
+    /// <param name="child">The text or placeholder rect transform.</param>
+    private static void StretchFillInputChild(RectTransform child)
+    {
+        child.anchorMin = new Vector2(0f, 0f);
+        child.anchorMax = new Vector2(1f, 1f);
+        child.offsetMin = new Vector2(6f, 0f);
+        child.offsetMax = new Vector2(-6f, 0f);
+    }
+
+    /// <summary>
+    /// Applies the Options menu font.
+    /// </summary>
+    /// <param name="text">The text field to restyle.</param>
+    private static void ApplyOptionsDisplayFont(TextMeshProUGUI text)
+    {
+        TMP_FontAsset font = AssetDatabase.LoadAssetAtPath<TMP_FontAsset>(
+            "Assets/TextMesh Pro/Examples & Extras/Resources/Fonts & Materials/Oswald Bold SDF.asset"
+        );
+        if (font != null)
+            text.font = font;
+    }
+
+    /// <summary>
+    /// Creates an Options menu section header.
+    /// </summary>
+    /// <param name="parent">The page container.</param>
+    /// <param name="name">The header object name.</param>
+    /// <param name="caption">The header caption.</param>
+    /// <param name="y">The source-space header top.</param>
+    /// <param name="accent">The accent color.</param>
+    /// <returns>The header text field.</returns>
+    private static TextMeshProUGUI CreateOptionsSectionHeader(
+        RectTransform parent,
+        string name,
+        string caption,
+        int y,
+        Color accent
+    )
+    {
+        TextMeshProUGUI headerField = CreateTextLabel(name, parent);
+        headerField.text = caption;
+        headerField.color = accent;
+        headerField.fontSize = 13;
+        headerField.alignment = TextAlignmentOptions.MidlineLeft;
+        ApplyOptionsDisplayFont(headerField);
+        SetSourceRect(headerField.rectTransform, 20, y, 200, 16);
+        return headerField;
+    }
+
+    /// <summary>
+    /// Creates an Options menu navigation row.
+    /// </summary>
+    /// <param name="parent">The content-root transform.</param>
+    /// <param name="name">The button object name.</param>
+    /// <param name="label">The caps row caption.</param>
+    /// <param name="y">The source-space row top.</param>
+    /// <param name="color">The label color.</param>
+    /// <returns>The configured button.</returns>
+    private static Button CreateOptionsNavRow(
+        Transform parent,
+        string name,
+        string label,
+        int y,
+        Color color
+    )
+    {
+        Button button = CreateSlicedButton(
+            name,
+            parent,
+            _optionsBadgeSpritePath,
+            38,
+            y,
+            163,
+            30,
+            Color.white
+        );
+        TextMeshProUGUI text = CreateTextLabel("Label", button.transform);
+        text.text = label;
+        text.color = color;
+        text.fontSize = 13;
+        text.alignment = TextAlignmentOptions.MidlineLeft;
+        ApplyOptionsDisplayFont(text);
+        SetSourceRect(text.rectTransform, 14, 5, 140, 20);
+        ApplyOptionsFillButtonFeedback(button);
+        AddOptionsButtonBorder(button.targetGraphic);
+        return button;
+    }
+
+    /// <summary>
+    /// Creates the navigation layout.
+    /// </summary>
+    private static void ConfigureOptionsNavigationLayout(
+        RectTransform contentRoot,
+        Button backToGameButton,
+        Button mainMenuButton,
+        Button quitButton
+    )
+    {
+        VerticalLayoutGroup layout = contentRoot.gameObject.AddComponent<VerticalLayoutGroup>();
+        layout.padding = new RectOffset(38, 0, 226, 0);
+        layout.spacing = 9f;
+        layout.childAlignment = TextAnchor.UpperLeft;
+        layout.childControlWidth = false;
+        layout.childControlHeight = false;
+        layout.childForceExpandWidth = false;
+        layout.childForceExpandHeight = false;
+
+        for (int index = 0; index < contentRoot.childCount; index++)
+        {
+            Transform child = contentRoot.GetChild(index);
+            bool navigationChild =
+                child == backToGameButton.transform
+                || child == mainMenuButton.transform
+                || child == quitButton.transform;
+            LayoutElement element = child.gameObject.AddComponent<LayoutElement>();
+            element.ignoreLayout = !navigationChild;
+            if (navigationChild)
+            {
+                element.preferredWidth = 163f;
+                element.preferredHeight = 30f;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a settings button.
+    /// </summary>
+    /// <param name="parent">The settings-actions container.</param>
+    /// <param name="name">The button object name.</param>
+    /// <param name="label">The caps caption.</param>
+    /// <param name="x">The source-space left position.</param>
+    /// <param name="color">The label color.</param>
+    /// <returns>The configured button.</returns>
+    private static Button CreateOptionsActionButton(
+        Transform parent,
+        string name,
+        string label,
+        int x,
+        Color color
+    )
+    {
+        Button button = CreateSlicedButton(
+            name,
+            parent,
+            _optionsBadgeSpritePath,
+            x,
+            408,
+            76,
+            22,
+            Color.white
+        );
+        TextMeshProUGUI text = CreateTextLabel("Label", button.transform);
+        text.text = label;
+        text.color = color;
+        text.fontSize = 11;
+        text.alignment = TextAlignmentOptions.Midline;
+        ApplyOptionsDisplayFont(text);
+        SetSourceRect(text.rectTransform, 0, 4, 76, 14);
+        ApplyOptionsFillButtonFeedback(button);
+        AddOptionsButtonBorder(button.targetGraphic);
+        return button;
+    }
+
+    /// <summary>
+    /// Creates a display setting row.
+    /// </summary>
+    /// <param name="parent">The Graphics-page container.</param>
+    /// <param name="name">The row object-name prefix.</param>
+    /// <param name="caption">The row caption.</param>
+    /// <param name="y">The source-space row top.</param>
+    /// <param name="prevButton">Receives the previous-step button.</param>
+    /// <param name="nextButton">Receives the next-step button.</param>
+    /// <returns>The value text field.</returns>
+    private static TextMeshProUGUI CreateOptionsFieldRow(
+        RectTransform parent,
+        string name,
+        string caption,
+        int y,
+        out Button prevButton,
+        out Button nextButton
+    )
+    {
+        TextMeshProUGUI labelField = CreateTextLabel($"{name}Label", parent);
+        labelField.text = caption;
+        labelField.color = new Color(0.875f, 0.910f, 0.941f);
+        labelField.fontSize = 11;
+        labelField.alignment = TextAlignmentOptions.MidlineLeft;
+        SetSourceRect(labelField.rectTransform, 20, y + 2, 150, 14);
+
+        CreateSlicedImage(
+            $"{name}Badge",
+            parent,
+            _optionsBadgeSpritePath,
+            194,
+            y,
+            155,
+            18,
+            Color.white
+        );
+        prevButton = CreateOptionsStepperButton(parent, $"{name}Prev", "<", 194, y, 78, 0);
+        TextMeshProUGUI valueField = CreateTextLabel($"{name}Value", parent);
+        valueField.text = "-";
+        valueField.color = new Color(0.875f, 0.910f, 0.941f);
+        valueField.fontSize = 10;
+        valueField.alignment = TextAlignmentOptions.Midline;
+        SetSourceRect(valueField.rectTransform, 218, y, 107, 18);
+        nextButton = CreateOptionsStepperButton(parent, $"{name}Next", ">", 272, y, 77, 51);
+        return valueField;
+    }
+
+    /// <summary>
+    /// Creates a display setting step button.
+    /// </summary>
+    /// <param name="parent">The row container.</param>
+    /// <param name="name">The button object name.</param>
+    /// <param name="glyph">The chevron glyph.</param>
+    /// <param name="x">The source-space hotspot left.</param>
+    /// <param name="y">The source-space hotspot top.</param>
+    /// <param name="hitWidth">The full clickable width.</param>
+    /// <param name="glyphX">The chevron's horizontal position inside the hotspot.</param>
+    /// <returns>The configured button.</returns>
+    private static Button CreateOptionsStepperButton(
+        Transform parent,
+        string name,
+        string glyph,
+        int x,
+        int y,
+        int hitWidth,
+        int glyphX
+    )
+    {
+        GameObject hotspot = new GameObject(
+            name,
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image)
+        );
+        hotspot.transform.SetParent(parent, false);
+        Image hitArea = hotspot.GetComponent<Image>();
+        hitArea.color = Color.clear;
+        hitArea.raycastTarget = true;
+        SetSourceRect(hotspot.GetComponent<RectTransform>(), x, y, hitWidth, 18);
+        Button button = hotspot.AddComponent<Button>();
+        button.targetGraphic = hitArea;
+        button.transition = Selectable.Transition.None;
+        TextMeshProUGUI glyphText = CreateTextLabel("Glyph", hotspot.transform);
+        glyphText.text = glyph;
+        glyphText.color = new Color(0.373f, 0.659f, 0.925f);
+        glyphText.fontSize = 10;
+        glyphText.alignment = TextAlignmentOptions.Midline;
+        SetSourceRect(glyphText.rectTransform, glyphX, 0, 26, 18);
+        ApplyOptionsButtonFeedback(button, glyphText);
+        return button;
+    }
+
+    /// <summary>
+    /// Creates a volume slider.
+    /// </summary>
+    /// <param name="parent">The Audio-page container.</param>
+    /// <param name="name">The slider object name.</param>
+    /// <param name="x">The source-space slider left.</param>
+    /// <param name="y">The source-space slider top.</param>
+    /// <param name="width">The source-space track width.</param>
+    /// <returns>The configured slider view.</returns>
+    private static SaveMenuSliderView CreateOptionsSlider(
+        Transform parent,
+        string name,
+        int x,
+        int y,
+        int width
+    )
+    {
+        Texture2D knobTexture = AssetDatabase.LoadAssetAtPath<Texture2D>(_optionsKnobTexturePath);
+        Vector2Int knobSize =
+            knobTexture != null
+                ? UILayout.GetTextureSourceSize(knobTexture)
+                : new Vector2Int(10, 10);
+
+        GameObject root = new GameObject(
+            name,
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image),
+            typeof(Slider),
+            typeof(SaveMenuSliderView)
+        );
+        root.transform.SetParent(parent, false);
+        SetSourceRect(root.GetComponent<RectTransform>(), x, y, width, knobSize.y);
+
+        Image hitArea = root.GetComponent<Image>();
+        hitArea.color = Color.clear;
+        hitArea.raycastTarget = true;
+
+        RectTransform trackBand = CreateChildLayer("TrackBand", root.transform);
+        SetSourceRect(trackBand, 0, Mathf.Max(0, (knobSize.y - 4) / 2), width, 4);
+        GameObject trackBackground = new GameObject(
+            "TrackBackground",
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image)
+        );
+        trackBackground.transform.SetParent(trackBand, false);
+        Image trackImage = trackBackground.GetComponent<Image>();
+        trackImage.color = new Color(0.180f, 0.220f, 0.275f);
+        trackImage.raycastTarget = false;
+        FillParent(trackBackground.GetComponent<RectTransform>());
+        RectTransform fillArea = CreateChildLayer("FillArea", trackBand);
+        FillParent(fillArea);
+        Image fillImage = fillArea.gameObject.AddComponent<Image>();
+        fillImage.color = new Color(0.373f, 0.659f, 0.925f);
+        fillImage.raycastTarget = false;
+
+        GameObject thumb = new GameObject(
+            "ThumbImage",
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(RawImage)
+        );
+        thumb.transform.SetParent(root.transform, false);
+        RawImage thumbImage = thumb.GetComponent<RawImage>();
+        thumbImage.texture = knobTexture;
+        thumbImage.raycastTarget = true;
+        SetSourceRect(thumbImage.rectTransform, 0, 0, knobSize.x, knobSize.y);
+
+        Slider slider = root.GetComponent<Slider>();
+        slider.enabled = true;
+        slider.minValue = 0f;
+        slider.maxValue = 1f;
+        slider.wholeNumbers = false;
+        slider.direction = Slider.Direction.LeftToRight;
+        slider.fillRect = fillArea;
+        slider.handleRect = null;
+        slider.targetGraphic = null;
+        slider.transition = Selectable.Transition.None;
+
+        SaveMenuSliderView view = EnableRuntimeComponent(root.GetComponent<SaveMenuSliderView>());
+        AssignReference(view, "slider", slider);
+        AssignReference(view, "thumbImage", thumbImage);
+        return view;
+    }
+
+    /// <summary>
+    /// Creates a tactical option row.
+    /// </summary>
+    /// <param name="parent">The Graphics-page container.</param>
+    /// <param name="name">The row object name.</param>
+    /// <param name="option">The tactical option the row toggles.</param>
+    /// <param name="label">The row caption.</param>
+    /// <param name="x">The source-space row left.</param>
+    /// <param name="y">The source-space row top.</param>
+    /// <returns>The configured toggle-row view.</returns>
+    private static OptionsToggleRowView CreateOptionsTacticalRow(
+        Transform parent,
+        string name,
+        UserTacticalOption option,
+        string label,
+        int x,
+        int y
+    )
+    {
+        RectTransform root = CreateChildLayer(name, parent);
+        SetSourceRect(root, x, y, 330, 14);
+        OptionsToggleRowView view = EnableRuntimeComponent(
+            root.gameObject.AddComponent<OptionsToggleRowView>()
+        );
+
+        TextMeshProUGUI labelField = CreateTextLabel("LabelTextField", root);
+        labelField.text = label;
+        labelField.color = new Color(0.875f, 0.910f, 0.941f);
+        labelField.fontSize = 11;
+        labelField.alignment = TextAlignmentOptions.MidlineLeft;
+        SetSourceRect(labelField.rectTransform, 0, 0, 170, 14);
+
+        GameObject toggle = new GameObject(
+            "ToggleImage",
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image)
+        );
+        toggle.transform.SetParent(root, false);
+        Image toggleImage = toggle.GetComponent<Image>();
+        toggleImage.sprite = AssetDatabase.LoadAssetAtPath<Sprite>(_optionsToggleOffSpritePath);
+        toggleImage.type = Image.Type.Simple;
+        toggleImage.raycastTarget = true;
+        SetSourceRect(toggle.GetComponent<RectTransform>(), 299, 0, 30, 14);
+        Button button = toggle.AddComponent<Button>();
+        button.targetGraphic = toggleImage;
+        button.transition = Selectable.Transition.None;
+
+        TextMeshProUGUI stateField = CreateTextLabel("StateTextField", root);
+        stateField.text = "ON";
+        stateField.color = new Color(0.875f, 0.910f, 0.941f);
+        stateField.fontSize = 9;
+        stateField.alignment = TextAlignmentOptions.MidlineRight;
+        SetSourceRect(stateField.rectTransform, 239, 0, 50, 14);
+
+        AssignInt(view, "_option", (int)option);
+        AssignReference(view, "_toggleImage", toggleImage);
+        AssignReference(
+            view,
+            "_offSprite",
+            AssetDatabase.LoadAssetAtPath<Sprite>(_optionsToggleOffSpritePath)
+        );
+        AssignReference(
+            view,
+            "_onSprite",
+            AssetDatabase.LoadAssetAtPath<Sprite>(_optionsToggleOnSpritePath)
+        );
+        AssignReference(view, "_button", button);
+        AssignReference(view, "_labelTextField", labelField);
+        AssignReference(view, "_stateTextField", stateField);
+        return view;
+    }
+}

--- a/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs.meta
+++ b/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cab8cd5a261cca747845227593271512

--- a/Assets/Editor/PrefabBuilders/SaveMenu/SaveMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/SaveMenu/SaveMenuPrefabBuilder.cs
@@ -669,17 +669,35 @@ public static class SaveMenuPrefabBuilder
 
         TMP_InputField input = InstantiateNested<TMP_InputField>(prefab, parent, "NameInputField");
         SetSourceRect(input.transform as RectTransform, 86, 8, 150, 18);
-        input.textComponent.alignment = TextAlignmentOptions.BaselineLeft;
+        input.textComponent.alignment = TextAlignmentOptions.MidlineLeft;
         input.textComponent.color = _whiteTextColor;
-        SetSourceRect(input.textComponent.rectTransform, 2, 0, 148, 18);
+        StretchSaveNameText(input.textComponent.rectTransform);
+        input.customCaretColor = true;
+        input.caretColor = _whiteTextColor;
+        input.caretWidth = 2;
+        input.caretBlinkRate = 0.85f;
+        input.onFocusSelectAll = false;
 
         if (input.placeholder is not TextMeshProUGUI placeholder)
             throw new MissingReferenceException("Save-slot text input placeholder is missing.");
         placeholder.text = "Empty Save Slot";
-        placeholder.alignment = TextAlignmentOptions.BaselineLeft;
+        placeholder.alignment = TextAlignmentOptions.MidlineLeft;
         placeholder.color = _whiteTextColor;
-        SetSourceRect(placeholder.rectTransform, 2, 0, 148, 18);
+        StretchSaveNameText(placeholder.rectTransform);
         return input;
+    }
+
+    /// <summary>
+    /// Positions the save name and cursor inside the input field.
+    /// </summary>
+    /// <param name="rect">The text or placeholder rectangle.</param>
+    private static void StretchSaveNameText(RectTransform rect)
+    {
+        rect.anchorMin = Vector2.zero;
+        rect.anchorMax = Vector2.one;
+        rect.pivot = new Vector2(0.5f, 0.5f);
+        rect.offsetMin = new Vector2(2f, 0f);
+        rect.offsetMax = new Vector2(-2f, 0f);
     }
 
     /// <summary>
@@ -702,7 +720,7 @@ public static class SaveMenuPrefabBuilder
         GameObject blockerObject = CreateRectObject("InputBlocker", root.transform);
         blockerObject.AddComponent<CanvasRenderer>();
         Image blocker = blockerObject.AddComponent<Image>();
-        blocker.color = Color.clear;
+        blocker.color = new Color(0f, 0f, 0f, 0.8f);
         blocker.raycastTarget = true;
         SetSourceRect(blocker.rectTransform, 0, 0, _windowWidth, _windowHeight);
 
@@ -749,14 +767,16 @@ public static class SaveMenuPrefabBuilder
             "MessageTextField",
             root.transform,
             "Are you sure you want to quit?",
-            114,
-            218,
-            412,
-            12,
-            12,
-            TextAlignmentOptions.Baseline
+            160,
+            172,
+            320,
+            100,
+            13,
+            TextAlignmentOptions.Center
         );
         message.color = _whiteTextColor;
+        message.textWrappingMode = TextWrappingModes.Normal;
+        message.overflowMode = TextOverflowModes.Overflow;
 
         AssignReference(view, "backgroundImage", background);
         AssignColor(view, "messageTextColor", _whiteTextColor);

--- a/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
@@ -9,7 +9,7 @@ using UnityEngine.UI;
 /// <summary>
 /// Authors the generated Strategy View and related window prefabs.
 /// </summary>
-public static class StrategyViewPrefabBuilder
+public static partial class StrategyViewPrefabBuilder
 {
     private const string _fallbackPreviewThemeId = "DEFAULT";
     private const string _prefabPath = "Assets/Prefabs/UI/StrategyView/StrategyViewRoot.prefab";
@@ -47,6 +47,20 @@ public static class StrategyViewPrefabBuilder
         "Assets/Prefabs/UI/StrategyView/MessagesWindow.prefab";
     private const string _encyclopediaWindowPrefabPath =
         "Assets/Prefabs/UI/StrategyView/EncyclopediaWindow.prefab";
+    private const string _optionsMenuWindowPrefabPath =
+        "Assets/Prefabs/UI/OptionsMenu/OptionsMenu.prefab";
+    private const string _optionsPanelSpritePath = "Assets/UI/OptionsMenu/optionsmenu_panel.png";
+    private const string _optionsRowSpritePath = "Assets/UI/OptionsMenu/optionsmenu_row.png";
+    private const string _optionsRowActiveSpritePath =
+        "Assets/UI/OptionsMenu/optionsmenu_row_active.png";
+    private const string _optionsBadgeSpritePath = "Assets/UI/OptionsMenu/optionsmenu_badge.png";
+    private const string _optionsFrameGlowSpritePath =
+        "Assets/UI/OptionsMenu/optionsmenu_frame_glow.png";
+    private const string _optionsToggleOnSpritePath =
+        "Assets/UI/OptionsMenu/optionsmenu_toggle_on.png";
+    private const string _optionsToggleOffSpritePath =
+        "Assets/UI/OptionsMenu/optionsmenu_toggle_off.png";
+    private const string _optionsKnobTexturePath = "Assets/UI/OptionsMenu/optionsmenu_knob.png";
     private const string _planetSystemClusterPrefabPath =
         "Assets/Prefabs/UI/StrategyView/PlanetSystemCluster.prefab";
     private const string _commonScrollAreaPrefabPath = "Assets/Prefabs/UI/Common/ScrollArea.prefab";
@@ -254,7 +268,7 @@ public static class StrategyViewPrefabBuilder
     private const int _constructionCountButtonWidth = 13;
     private const int _constructionCountButtonHeight = 8;
     private static readonly Color32 _sectorWindowBackgroundOverlay = new Color32(57, 57, 57, 230);
-    private static readonly Color32 _modalBackgroundDimColor = new Color32(80, 80, 80, 160);
+    private static readonly Color32 _modalBackgroundDimColor = new Color32(0, 0, 0, 204);
 
     private static FactionThemes _previewThemes;
     private static string _previewThemeId;
@@ -613,6 +627,9 @@ public static class StrategyViewPrefabBuilder
         EncyclopediaWindowView encyclopediaWindowPrefab = LoadWindowPrefab<EncyclopediaWindowView>(
             _encyclopediaWindowPrefabPath
         );
+        OptionsMenuView optionsMenuWindowPrefab = LoadWindowPrefab<OptionsMenuView>(
+            _optionsMenuWindowPrefabPath
+        );
         PlanetSystemClusterView planetSystemClusterPrefab =
             LoadPrefabComponent<PlanetSystemClusterView>(_planetSystemClusterPrefabPath);
 
@@ -836,8 +853,13 @@ public static class StrategyViewPrefabBuilder
         float briefingHorizontalOffset = (_screenWidth - 640f) / 2f;
         foreach (RectTransform child in briefingConfirmationRect)
         {
-            if (child.name != "InputBlocker")
-                child.anchoredPosition += Vector2.right * briefingHorizontalOffset;
+            if (child.name == "InputBlocker")
+            {
+                FillParent(child);
+                continue;
+            }
+
+            child.anchoredPosition += Vector2.right * briefingHorizontalOffset;
         }
         briefingSkipConfirmation.transform.SetAsLastSibling();
 
@@ -874,7 +896,8 @@ public static class StrategyViewPrefabBuilder
             confirmDialogWindowPrefab,
             battleAlertWindowPrefab,
             finderWindowPrefab,
-            encyclopediaWindowPrefab
+            encyclopediaWindowPrefab,
+            optionsMenuWindowPrefab
         );
         AssignWindowLayerLayout(windowsView);
         AssignReference(hudView, "backgroundImage", hudBackgroundImage);
@@ -933,6 +956,7 @@ public static class StrategyViewPrefabBuilder
         BuildFinderWindowPrefab();
         BuildMessagesWindowPrefab();
         BuildEncyclopediaWindowPrefab();
+        BuildOptionsMenuPrefab();
         BuildStrategyViewRootPrefab();
         AssetDatabase.SaveAssets();
         AssetDatabase.Refresh();
@@ -3592,7 +3616,8 @@ public static class StrategyViewPrefabBuilder
                 LoadWindowPrefab<ConfirmDialogWindowView>(_confirmDialogWindowPrefabPath),
                 LoadWindowPrefab<BattleAlertWindowView>(_battleAlertWindowPrefabPath),
                 LoadWindowPrefab<FinderWindowView>(_finderWindowPrefabPath),
-                LoadWindowPrefab<EncyclopediaWindowView>(_encyclopediaWindowPrefabPath)
+                LoadWindowPrefab<EncyclopediaWindowView>(_encyclopediaWindowPrefabPath),
+                LoadWindowPrefab<OptionsMenuView>(_optionsMenuWindowPrefabPath)
             );
 
             PrefabUtility.SaveAsPrefabAsset(root, _prefabPath, out bool success);
@@ -3858,6 +3883,76 @@ public static class StrategyViewPrefabBuilder
         AssetDatabase.SaveAssets();
         AssetDatabase.Refresh();
         return saved.GetComponent<StatusWindowView>();
+    }
+
+    /// <summary>
+    /// Creates a sliced panel image.
+    /// </summary>
+    /// <param name="name">The image object name.</param>
+    /// <param name="parent">The parent transform.</param>
+    /// <param name="spritePath">The chrome sprite asset path.</param>
+    /// <param name="x">The source-space left.</param>
+    /// <param name="y">The source-space top.</param>
+    /// <param name="width">The source-space width.</param>
+    /// <param name="height">The source-space height.</param>
+    /// <param name="color">The image tint.</param>
+    /// <returns>The configured image.</returns>
+    private static Image CreateSlicedImage(
+        string name,
+        Transform parent,
+        string spritePath,
+        int x,
+        int y,
+        int width,
+        int height,
+        Color color
+    )
+    {
+        GameObject go = new GameObject(
+            name,
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image)
+        );
+        go.transform.SetParent(parent, false);
+        Image image = go.GetComponent<Image>();
+        image.sprite = AssetDatabase.LoadAssetAtPath<Sprite>(spritePath);
+        image.type = Image.Type.Sliced;
+        image.color = color;
+        image.raycastTarget = false;
+        SetSourceRect(go.GetComponent<RectTransform>(), x, y, width, height);
+        return image;
+    }
+
+    /// <summary>
+    /// Creates a sliced button.
+    /// </summary>
+    /// <param name="name">The button object name.</param>
+    /// <param name="parent">The parent transform.</param>
+    /// <param name="spritePath">The chrome sprite asset path.</param>
+    /// <param name="x">The source-space left.</param>
+    /// <param name="y">The source-space top.</param>
+    /// <param name="width">The source-space width.</param>
+    /// <param name="height">The source-space height.</param>
+    /// <param name="color">The image tint.</param>
+    /// <returns>The configured button.</returns>
+    private static Button CreateSlicedButton(
+        string name,
+        Transform parent,
+        string spritePath,
+        int x,
+        int y,
+        int width,
+        int height,
+        Color color
+    )
+    {
+        Image image = CreateSlicedImage(name, parent, spritePath, x, y, width, height, color);
+        image.raycastTarget = true;
+        Button button = image.gameObject.AddComponent<Button>();
+        button.targetGraphic = image;
+        button.transition = Selectable.Transition.None;
+        return button;
     }
 
     /// <summary>
@@ -8577,6 +8672,7 @@ public static class StrategyViewPrefabBuilder
     /// <param name="battleAlertWindowPrefab">The battle-alert window prefab.</param>
     /// <param name="finderWindowPrefab">The Finder window prefab.</param>
     /// <param name="encyclopediaWindowPrefab">The encyclopedia window prefab.</param>
+    /// <param name="optionsMenuWindowPrefab">The shared Options window prefab.</param>
     private static void AssignWindowPrefabs(
         StrategyWindowLayerView target,
         PlanetSystemWindowView planetSystemWindowPrefab,
@@ -8592,7 +8688,8 @@ public static class StrategyViewPrefabBuilder
         ConfirmDialogWindowView confirmDialogWindowPrefab,
         BattleAlertWindowView battleAlertWindowPrefab,
         FinderWindowView finderWindowPrefab,
-        EncyclopediaWindowView encyclopediaWindowPrefab
+        EncyclopediaWindowView encyclopediaWindowPrefab,
+        OptionsMenuView optionsMenuWindowPrefab
     )
     {
         AssignWindowPrefab(target, "planetSystemWindowPrefab", planetSystemWindowPrefab);
@@ -8609,6 +8706,7 @@ public static class StrategyViewPrefabBuilder
         AssignWindowPrefab(target, "battleAlertWindowPrefab", battleAlertWindowPrefab);
         AssignWindowPrefab(target, "finderWindowPrefab", finderWindowPrefab);
         AssignWindowPrefab(target, "encyclopediaWindowPrefab", encyclopediaWindowPrefab);
+        AssignWindowPrefab(target, "_optionsMenuWindowPrefab", optionsMenuWindowPrefab);
     }
 
     /// <summary>

--- a/Assets/Input/DefaultInputActions.inputactions
+++ b/Assets/Input/DefaultInputActions.inputactions
@@ -32,24 +32,6 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
-                },
-                {
-                    "name": "DecreaseGameSpeed",
-                    "type": "Button",
-                    "id": "00000000-0000-0000-0000-000000000056",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
-                },
-                {
-                    "name": "IncreaseGameSpeed",
-                    "type": "Button",
-                    "id": "00000000-0000-0000-0000-000000000057",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -83,6 +65,479 @@
                     "processors": "",
                     "groups": "Keyboard&Mouse",
                     "action": "QuickLoad",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "Strategy",
+            "id": "00000000-0000-0000-0000-000000000012",
+            "actions": [
+                {
+                    "name": "DecreaseGameSpeed",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000056",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "IncreaseGameSpeed",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000057",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "MultiSelectModifier",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000013",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "RangeSelectModifier",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000014",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "AlternateSelectModifier",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000015",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "BookmarkSlot1",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000201",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot2",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000203",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot3",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000205",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot4",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000207",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot5",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000209",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot6",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000211",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot7",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000213",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot8",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000215",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot9",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000217",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot10",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000219",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot11",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000221",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "BookmarkSlot12",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000223",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "OpenSystemFinder",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000225",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "OpenFleetFinder",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000227",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "OpenPersonnelFinder",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000229",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "OpenPlanetFinder",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000231",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "OpenEncyclopedia",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000233",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "OpenAllMessages",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000235",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "DestroySelectedUnits",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000237",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "OpenMissionSetup",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000239",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "IssueMoveOrder",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000240",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ConfirmMoveOrder",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000241",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowPopularSupport",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000242",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowUprisings",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000243",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowIdleFleets",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000244",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowFleetsEnroute",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000245",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowIdlePersonnel",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000246",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowActivePersonnel",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000247",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowAvailableEnergy",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000248",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowAvailableRawMaterial",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000249",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowMines",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000250",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowRefineries",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000251",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowShipyards",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000252",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowTrainingFacilities",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000253",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowConstructionYards",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000254",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowIdleShipyards",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000255",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowIdleTrainingFacilities",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000256",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowIdleConstructionYards",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000257",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowTroopers",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000258",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowFighterSquadrons",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000259",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowDeathStarShields",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000260",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowPlanetaryShieldGenerators",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000261",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShowPlanetaryDefenseBatteries",
+                    "type": "Button",
+                    "id": "00000000-0000-0000-0000-000000000262",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000016",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "MultiSelectModifier",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000017",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "RangeSelectModifier",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000018",
+                    "path": "<Keyboard>/alt",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "AlternateSelectModifier",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
@@ -481,72 +936,213 @@
                     "action": "IncreaseGameSpeed",
                     "isComposite": false,
                     "isPartOfComposite": true
-                }
-            ]
-        },
-        {
-            "name": "Strategy",
-            "id": "00000000-0000-0000-0000-000000000012",
-            "actions": [
-                {
-                    "name": "MultiSelectModifier",
-                    "type": "Button",
-                    "id": "00000000-0000-0000-0000-000000000013",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": true
                 },
-                {
-                    "name": "RangeSelectModifier",
-                    "type": "Button",
-                    "id": "00000000-0000-0000-0000-000000000014",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": true
-                },
-                {
-                    "name": "AlternateSelectModifier",
-                    "type": "Button",
-                    "id": "00000000-0000-0000-0000-000000000015",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": true
-                }
-            ],
-            "bindings": [
                 {
                     "name": "",
-                    "id": "00000000-0000-0000-0000-000000000016",
-                    "path": "<Keyboard>/ctrl",
+                    "id": "00000000-0000-0000-0000-000000000202",
+                    "path": "<Keyboard>/1",
                     "interactions": "",
                     "processors": "",
                     "groups": "Keyboard&Mouse",
-                    "action": "MultiSelectModifier",
+                    "action": "BookmarkSlot1",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
                 {
                     "name": "",
-                    "id": "00000000-0000-0000-0000-000000000017",
-                    "path": "<Keyboard>/shift",
+                    "id": "00000000-0000-0000-0000-000000000204",
+                    "path": "<Keyboard>/2",
                     "interactions": "",
                     "processors": "",
                     "groups": "Keyboard&Mouse",
-                    "action": "RangeSelectModifier",
+                    "action": "BookmarkSlot2",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },
                 {
                     "name": "",
-                    "id": "00000000-0000-0000-0000-000000000018",
-                    "path": "<Keyboard>/alt",
+                    "id": "00000000-0000-0000-0000-000000000206",
+                    "path": "<Keyboard>/3",
                     "interactions": "",
                     "processors": "",
                     "groups": "Keyboard&Mouse",
-                    "action": "AlternateSelectModifier",
+                    "action": "BookmarkSlot3",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000208",
+                    "path": "<Keyboard>/4",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BookmarkSlot4",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000210",
+                    "path": "<Keyboard>/5",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BookmarkSlot5",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000212",
+                    "path": "<Keyboard>/6",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BookmarkSlot6",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000214",
+                    "path": "<Keyboard>/7",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BookmarkSlot7",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000216",
+                    "path": "<Keyboard>/8",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BookmarkSlot8",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000218",
+                    "path": "<Keyboard>/9",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BookmarkSlot9",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000220",
+                    "path": "<Keyboard>/0",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BookmarkSlot10",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000222",
+                    "path": "<Keyboard>/minus",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BookmarkSlot11",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000224",
+                    "path": "<Keyboard>/equals",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "BookmarkSlot12",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000226",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "OpenSystemFinder",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000228",
+                    "path": "<Keyboard>/f",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "OpenFleetFinder",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000230",
+                    "path": "<Keyboard>/o",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "OpenPersonnelFinder",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000232",
+                    "path": "<Keyboard>/p",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "OpenPlanetFinder",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000234",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "OpenEncyclopedia",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000236",
+                    "path": "<Keyboard>/m",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "OpenAllMessages",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "00000000-0000-0000-0000-000000000238",
+                    "path": "<Keyboard>/delete",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "DestroySelectedUnits",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Input/PlayerInputActions.cs
+++ b/Assets/Input/PlayerInputActions.cs
@@ -120,24 +120,6 @@ namespace Rebellion.Input
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
-                },
-                {
-                    ""name"": ""DecreaseGameSpeed"",
-                    ""type"": ""Button"",
-                    ""id"": ""00000000-0000-0000-0000-000000000056"",
-                    ""expectedControlType"": ""Button"",
-                    ""processors"": """",
-                    ""interactions"": """",
-                    ""initialStateCheck"": false
-                },
-                {
-                    ""name"": ""IncreaseGameSpeed"",
-                    ""type"": ""Button"",
-                    ""id"": ""00000000-0000-0000-0000-000000000057"",
-                    ""expectedControlType"": ""Button"",
-                    ""processors"": """",
-                    ""interactions"": """",
-                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -171,6 +153,479 @@ namespace Rebellion.Input
                     ""processors"": """",
                     ""groups"": ""Keyboard&Mouse"",
                     ""action"": ""QuickLoad"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                }
+            ]
+        },
+        {
+            ""name"": ""Strategy"",
+            ""id"": ""00000000-0000-0000-0000-000000000012"",
+            ""actions"": [
+                {
+                    ""name"": ""DecreaseGameSpeed"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000056"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""IncreaseGameSpeed"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000057"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""MultiSelectModifier"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000013"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": true
+                },
+                {
+                    ""name"": ""RangeSelectModifier"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000014"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": true
+                },
+                {
+                    ""name"": ""AlternateSelectModifier"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000015"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": true
+                },
+                {
+                    ""name"": ""BookmarkSlot1"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000201"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot2"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000203"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot3"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000205"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot4"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000207"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot5"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000209"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot6"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000211"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot7"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000213"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot8"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000215"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot9"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000217"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot10"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000219"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot11"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000221"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""BookmarkSlot12"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000223"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""OpenSystemFinder"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000225"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""OpenFleetFinder"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000227"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""OpenPersonnelFinder"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000229"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""OpenPlanetFinder"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000231"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""OpenEncyclopedia"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000233"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""OpenAllMessages"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000235"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""DestroySelectedUnits"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000237"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""OpenMissionSetup"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000239"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""IssueMoveOrder"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000240"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ConfirmMoveOrder"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000241"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowPopularSupport"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000242"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowUprisings"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000243"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowIdleFleets"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000244"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowFleetsEnroute"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000245"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowIdlePersonnel"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000246"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowActivePersonnel"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000247"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowAvailableEnergy"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000248"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowAvailableRawMaterial"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000249"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowMines"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000250"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowRefineries"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000251"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowShipyards"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000252"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowTrainingFacilities"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000253"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowConstructionYards"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000254"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowIdleShipyards"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000255"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowIdleTrainingFacilities"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000256"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowIdleConstructionYards"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000257"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowTroopers"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000258"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowFighterSquadrons"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000259"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowDeathStarShields"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000260"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowPlanetaryShieldGenerators"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000261"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""ShowPlanetaryDefenseBatteries"",
+                    ""type"": ""Button"",
+                    ""id"": ""00000000-0000-0000-0000-000000000262"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                }
+            ],
+            ""bindings"": [
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000016"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""MultiSelectModifier"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000017"",
+                    ""path"": ""<Keyboard>/shift"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""RangeSelectModifier"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000018"",
+                    ""path"": ""<Keyboard>/alt"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""AlternateSelectModifier"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
@@ -569,72 +1024,213 @@ namespace Rebellion.Input
                     ""action"": ""IncreaseGameSpeed"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": true
-                }
-            ]
-        },
-        {
-            ""name"": ""Strategy"",
-            ""id"": ""00000000-0000-0000-0000-000000000012"",
-            ""actions"": [
-                {
-                    ""name"": ""MultiSelectModifier"",
-                    ""type"": ""Button"",
-                    ""id"": ""00000000-0000-0000-0000-000000000013"",
-                    ""expectedControlType"": ""Button"",
-                    ""processors"": """",
-                    ""interactions"": """",
-                    ""initialStateCheck"": true
                 },
-                {
-                    ""name"": ""RangeSelectModifier"",
-                    ""type"": ""Button"",
-                    ""id"": ""00000000-0000-0000-0000-000000000014"",
-                    ""expectedControlType"": ""Button"",
-                    ""processors"": """",
-                    ""interactions"": """",
-                    ""initialStateCheck"": true
-                },
-                {
-                    ""name"": ""AlternateSelectModifier"",
-                    ""type"": ""Button"",
-                    ""id"": ""00000000-0000-0000-0000-000000000015"",
-                    ""expectedControlType"": ""Button"",
-                    ""processors"": """",
-                    ""interactions"": """",
-                    ""initialStateCheck"": true
-                }
-            ],
-            ""bindings"": [
                 {
                     ""name"": """",
-                    ""id"": ""00000000-0000-0000-0000-000000000016"",
-                    ""path"": ""<Keyboard>/ctrl"",
+                    ""id"": ""00000000-0000-0000-0000-000000000202"",
+                    ""path"": ""<Keyboard>/1"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""Keyboard&Mouse"",
-                    ""action"": ""MultiSelectModifier"",
+                    ""action"": ""BookmarkSlot1"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
                 {
                     ""name"": """",
-                    ""id"": ""00000000-0000-0000-0000-000000000017"",
-                    ""path"": ""<Keyboard>/shift"",
+                    ""id"": ""00000000-0000-0000-0000-000000000204"",
+                    ""path"": ""<Keyboard>/2"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""Keyboard&Mouse"",
-                    ""action"": ""RangeSelectModifier"",
+                    ""action"": ""BookmarkSlot2"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 },
                 {
                     ""name"": """",
-                    ""id"": ""00000000-0000-0000-0000-000000000018"",
-                    ""path"": ""<Keyboard>/alt"",
+                    ""id"": ""00000000-0000-0000-0000-000000000206"",
+                    ""path"": ""<Keyboard>/3"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""Keyboard&Mouse"",
-                    ""action"": ""AlternateSelectModifier"",
+                    ""action"": ""BookmarkSlot3"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000208"",
+                    ""path"": ""<Keyboard>/4"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""BookmarkSlot4"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000210"",
+                    ""path"": ""<Keyboard>/5"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""BookmarkSlot5"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000212"",
+                    ""path"": ""<Keyboard>/6"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""BookmarkSlot6"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000214"",
+                    ""path"": ""<Keyboard>/7"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""BookmarkSlot7"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000216"",
+                    ""path"": ""<Keyboard>/8"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""BookmarkSlot8"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000218"",
+                    ""path"": ""<Keyboard>/9"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""BookmarkSlot9"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000220"",
+                    ""path"": ""<Keyboard>/0"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""BookmarkSlot10"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000222"",
+                    ""path"": ""<Keyboard>/minus"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""BookmarkSlot11"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000224"",
+                    ""path"": ""<Keyboard>/equals"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""BookmarkSlot12"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000226"",
+                    ""path"": ""<Keyboard>/s"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""OpenSystemFinder"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000228"",
+                    ""path"": ""<Keyboard>/f"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""OpenFleetFinder"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000230"",
+                    ""path"": ""<Keyboard>/o"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""OpenPersonnelFinder"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000232"",
+                    ""path"": ""<Keyboard>/p"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""OpenPlanetFinder"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000234"",
+                    ""path"": ""<Keyboard>/e"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""OpenEncyclopedia"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000236"",
+                    ""path"": ""<Keyboard>/m"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""OpenAllMessages"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""00000000-0000-0000-0000-000000000238"",
+                    ""path"": ""<Keyboard>/delete"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": ""Keyboard&Mouse"",
+                    ""action"": ""DestroySelectedUnits"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
                 }
@@ -1041,13 +1637,56 @@ namespace Rebellion.Input
             m_Global_CancelOrSettings = m_Global.FindAction("CancelOrSettings", throwIfNotFound: true);
             m_Global_QuickSave = m_Global.FindAction("QuickSave", throwIfNotFound: true);
             m_Global_QuickLoad = m_Global.FindAction("QuickLoad", throwIfNotFound: true);
-            m_Global_DecreaseGameSpeed = m_Global.FindAction("DecreaseGameSpeed", throwIfNotFound: true);
-            m_Global_IncreaseGameSpeed = m_Global.FindAction("IncreaseGameSpeed", throwIfNotFound: true);
             // Strategy
             m_Strategy = asset.FindActionMap("Strategy", throwIfNotFound: true);
+            m_Strategy_DecreaseGameSpeed = m_Strategy.FindAction("DecreaseGameSpeed", throwIfNotFound: true);
+            m_Strategy_IncreaseGameSpeed = m_Strategy.FindAction("IncreaseGameSpeed", throwIfNotFound: true);
             m_Strategy_MultiSelectModifier = m_Strategy.FindAction("MultiSelectModifier", throwIfNotFound: true);
             m_Strategy_RangeSelectModifier = m_Strategy.FindAction("RangeSelectModifier", throwIfNotFound: true);
             m_Strategy_AlternateSelectModifier = m_Strategy.FindAction("AlternateSelectModifier", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot1 = m_Strategy.FindAction("BookmarkSlot1", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot2 = m_Strategy.FindAction("BookmarkSlot2", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot3 = m_Strategy.FindAction("BookmarkSlot3", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot4 = m_Strategy.FindAction("BookmarkSlot4", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot5 = m_Strategy.FindAction("BookmarkSlot5", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot6 = m_Strategy.FindAction("BookmarkSlot6", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot7 = m_Strategy.FindAction("BookmarkSlot7", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot8 = m_Strategy.FindAction("BookmarkSlot8", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot9 = m_Strategy.FindAction("BookmarkSlot9", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot10 = m_Strategy.FindAction("BookmarkSlot10", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot11 = m_Strategy.FindAction("BookmarkSlot11", throwIfNotFound: true);
+            m_Strategy_BookmarkSlot12 = m_Strategy.FindAction("BookmarkSlot12", throwIfNotFound: true);
+            m_Strategy_OpenSystemFinder = m_Strategy.FindAction("OpenSystemFinder", throwIfNotFound: true);
+            m_Strategy_OpenFleetFinder = m_Strategy.FindAction("OpenFleetFinder", throwIfNotFound: true);
+            m_Strategy_OpenPersonnelFinder = m_Strategy.FindAction("OpenPersonnelFinder", throwIfNotFound: true);
+            m_Strategy_OpenPlanetFinder = m_Strategy.FindAction("OpenPlanetFinder", throwIfNotFound: true);
+            m_Strategy_OpenEncyclopedia = m_Strategy.FindAction("OpenEncyclopedia", throwIfNotFound: true);
+            m_Strategy_OpenAllMessages = m_Strategy.FindAction("OpenAllMessages", throwIfNotFound: true);
+            m_Strategy_DestroySelectedUnits = m_Strategy.FindAction("DestroySelectedUnits", throwIfNotFound: true);
+            m_Strategy_OpenMissionSetup = m_Strategy.FindAction("OpenMissionSetup", throwIfNotFound: true);
+            m_Strategy_IssueMoveOrder = m_Strategy.FindAction("IssueMoveOrder", throwIfNotFound: true);
+            m_Strategy_ConfirmMoveOrder = m_Strategy.FindAction("ConfirmMoveOrder", throwIfNotFound: true);
+            m_Strategy_ShowPopularSupport = m_Strategy.FindAction("ShowPopularSupport", throwIfNotFound: true);
+            m_Strategy_ShowUprisings = m_Strategy.FindAction("ShowUprisings", throwIfNotFound: true);
+            m_Strategy_ShowIdleFleets = m_Strategy.FindAction("ShowIdleFleets", throwIfNotFound: true);
+            m_Strategy_ShowFleetsEnroute = m_Strategy.FindAction("ShowFleetsEnroute", throwIfNotFound: true);
+            m_Strategy_ShowIdlePersonnel = m_Strategy.FindAction("ShowIdlePersonnel", throwIfNotFound: true);
+            m_Strategy_ShowActivePersonnel = m_Strategy.FindAction("ShowActivePersonnel", throwIfNotFound: true);
+            m_Strategy_ShowAvailableEnergy = m_Strategy.FindAction("ShowAvailableEnergy", throwIfNotFound: true);
+            m_Strategy_ShowAvailableRawMaterial = m_Strategy.FindAction("ShowAvailableRawMaterial", throwIfNotFound: true);
+            m_Strategy_ShowMines = m_Strategy.FindAction("ShowMines", throwIfNotFound: true);
+            m_Strategy_ShowRefineries = m_Strategy.FindAction("ShowRefineries", throwIfNotFound: true);
+            m_Strategy_ShowShipyards = m_Strategy.FindAction("ShowShipyards", throwIfNotFound: true);
+            m_Strategy_ShowTrainingFacilities = m_Strategy.FindAction("ShowTrainingFacilities", throwIfNotFound: true);
+            m_Strategy_ShowConstructionYards = m_Strategy.FindAction("ShowConstructionYards", throwIfNotFound: true);
+            m_Strategy_ShowIdleShipyards = m_Strategy.FindAction("ShowIdleShipyards", throwIfNotFound: true);
+            m_Strategy_ShowIdleTrainingFacilities = m_Strategy.FindAction("ShowIdleTrainingFacilities", throwIfNotFound: true);
+            m_Strategy_ShowIdleConstructionYards = m_Strategy.FindAction("ShowIdleConstructionYards", throwIfNotFound: true);
+            m_Strategy_ShowTroopers = m_Strategy.FindAction("ShowTroopers", throwIfNotFound: true);
+            m_Strategy_ShowFighterSquadrons = m_Strategy.FindAction("ShowFighterSquadrons", throwIfNotFound: true);
+            m_Strategy_ShowDeathStarShields = m_Strategy.FindAction("ShowDeathStarShields", throwIfNotFound: true);
+            m_Strategy_ShowPlanetaryShieldGenerators = m_Strategy.FindAction("ShowPlanetaryShieldGenerators", throwIfNotFound: true);
+            m_Strategy_ShowPlanetaryDefenseBatteries = m_Strategy.FindAction("ShowPlanetaryDefenseBatteries", throwIfNotFound: true);
             // Window
             m_Window = asset.FindActionMap("Window", throwIfNotFound: true);
             m_Window_Confirm = m_Window.FindAction("Confirm", throwIfNotFound: true);
@@ -1152,8 +1791,6 @@ namespace Rebellion.Input
         private readonly InputAction m_Global_CancelOrSettings;
         private readonly InputAction m_Global_QuickSave;
         private readonly InputAction m_Global_QuickLoad;
-        private readonly InputAction m_Global_DecreaseGameSpeed;
-        private readonly InputAction m_Global_IncreaseGameSpeed;
         /// <summary>
         /// Provides access to input actions defined in input action map "Global".
         /// </summary>
@@ -1177,14 +1814,6 @@ namespace Rebellion.Input
             /// Provides access to the underlying input action "Global/QuickLoad".
             /// </summary>
             public InputAction @QuickLoad => m_Wrapper.m_Global_QuickLoad;
-            /// <summary>
-            /// Provides access to the underlying input action "Global/DecreaseGameSpeed".
-            /// </summary>
-            public InputAction @DecreaseGameSpeed => m_Wrapper.m_Global_DecreaseGameSpeed;
-            /// <summary>
-            /// Provides access to the underlying input action "Global/IncreaseGameSpeed".
-            /// </summary>
-            public InputAction @IncreaseGameSpeed => m_Wrapper.m_Global_IncreaseGameSpeed;
             /// <summary>
             /// Provides access to the underlying input action map instance.
             /// </summary>
@@ -1220,12 +1849,6 @@ namespace Rebellion.Input
                 @QuickLoad.started += instance.OnQuickLoad;
                 @QuickLoad.performed += instance.OnQuickLoad;
                 @QuickLoad.canceled += instance.OnQuickLoad;
-                @DecreaseGameSpeed.started += instance.OnDecreaseGameSpeed;
-                @DecreaseGameSpeed.performed += instance.OnDecreaseGameSpeed;
-                @DecreaseGameSpeed.canceled += instance.OnDecreaseGameSpeed;
-                @IncreaseGameSpeed.started += instance.OnIncreaseGameSpeed;
-                @IncreaseGameSpeed.performed += instance.OnIncreaseGameSpeed;
-                @IncreaseGameSpeed.canceled += instance.OnIncreaseGameSpeed;
             }
 
             /// <summary>
@@ -1246,12 +1869,6 @@ namespace Rebellion.Input
                 @QuickLoad.started -= instance.OnQuickLoad;
                 @QuickLoad.performed -= instance.OnQuickLoad;
                 @QuickLoad.canceled -= instance.OnQuickLoad;
-                @DecreaseGameSpeed.started -= instance.OnDecreaseGameSpeed;
-                @DecreaseGameSpeed.performed -= instance.OnDecreaseGameSpeed;
-                @DecreaseGameSpeed.canceled -= instance.OnDecreaseGameSpeed;
-                @IncreaseGameSpeed.started -= instance.OnIncreaseGameSpeed;
-                @IncreaseGameSpeed.performed -= instance.OnIncreaseGameSpeed;
-                @IncreaseGameSpeed.canceled -= instance.OnIncreaseGameSpeed;
             }
 
             /// <summary>
@@ -1289,9 +1906,54 @@ namespace Rebellion.Input
         // Strategy
         private readonly InputActionMap m_Strategy;
         private List<IStrategyActions> m_StrategyActionsCallbackInterfaces = new List<IStrategyActions>();
+        private readonly InputAction m_Strategy_DecreaseGameSpeed;
+        private readonly InputAction m_Strategy_IncreaseGameSpeed;
         private readonly InputAction m_Strategy_MultiSelectModifier;
         private readonly InputAction m_Strategy_RangeSelectModifier;
         private readonly InputAction m_Strategy_AlternateSelectModifier;
+        private readonly InputAction m_Strategy_BookmarkSlot1;
+        private readonly InputAction m_Strategy_BookmarkSlot2;
+        private readonly InputAction m_Strategy_BookmarkSlot3;
+        private readonly InputAction m_Strategy_BookmarkSlot4;
+        private readonly InputAction m_Strategy_BookmarkSlot5;
+        private readonly InputAction m_Strategy_BookmarkSlot6;
+        private readonly InputAction m_Strategy_BookmarkSlot7;
+        private readonly InputAction m_Strategy_BookmarkSlot8;
+        private readonly InputAction m_Strategy_BookmarkSlot9;
+        private readonly InputAction m_Strategy_BookmarkSlot10;
+        private readonly InputAction m_Strategy_BookmarkSlot11;
+        private readonly InputAction m_Strategy_BookmarkSlot12;
+        private readonly InputAction m_Strategy_OpenSystemFinder;
+        private readonly InputAction m_Strategy_OpenFleetFinder;
+        private readonly InputAction m_Strategy_OpenPersonnelFinder;
+        private readonly InputAction m_Strategy_OpenPlanetFinder;
+        private readonly InputAction m_Strategy_OpenEncyclopedia;
+        private readonly InputAction m_Strategy_OpenAllMessages;
+        private readonly InputAction m_Strategy_DestroySelectedUnits;
+        private readonly InputAction m_Strategy_OpenMissionSetup;
+        private readonly InputAction m_Strategy_IssueMoveOrder;
+        private readonly InputAction m_Strategy_ConfirmMoveOrder;
+        private readonly InputAction m_Strategy_ShowPopularSupport;
+        private readonly InputAction m_Strategy_ShowUprisings;
+        private readonly InputAction m_Strategy_ShowIdleFleets;
+        private readonly InputAction m_Strategy_ShowFleetsEnroute;
+        private readonly InputAction m_Strategy_ShowIdlePersonnel;
+        private readonly InputAction m_Strategy_ShowActivePersonnel;
+        private readonly InputAction m_Strategy_ShowAvailableEnergy;
+        private readonly InputAction m_Strategy_ShowAvailableRawMaterial;
+        private readonly InputAction m_Strategy_ShowMines;
+        private readonly InputAction m_Strategy_ShowRefineries;
+        private readonly InputAction m_Strategy_ShowShipyards;
+        private readonly InputAction m_Strategy_ShowTrainingFacilities;
+        private readonly InputAction m_Strategy_ShowConstructionYards;
+        private readonly InputAction m_Strategy_ShowIdleShipyards;
+        private readonly InputAction m_Strategy_ShowIdleTrainingFacilities;
+        private readonly InputAction m_Strategy_ShowIdleConstructionYards;
+        private readonly InputAction m_Strategy_ShowTroopers;
+        private readonly InputAction m_Strategy_ShowFighterSquadrons;
+        private readonly InputAction m_Strategy_ShowDeathStarShields;
+        private readonly InputAction m_Strategy_ShowPlanetaryShieldGenerators;
+        private readonly InputAction m_Strategy_ShowPlanetaryDefenseBatteries;
         /// <summary>
         /// Provides access to input actions defined in input action map "Strategy".
         /// </summary>
@@ -1304,6 +1966,14 @@ namespace Rebellion.Input
             /// </summary>
             public StrategyActions(@PlayerInputActions wrapper) { m_Wrapper = wrapper; }
             /// <summary>
+            /// Provides access to the underlying input action "Strategy/DecreaseGameSpeed".
+            /// </summary>
+            public InputAction @DecreaseGameSpeed => m_Wrapper.m_Strategy_DecreaseGameSpeed;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/IncreaseGameSpeed".
+            /// </summary>
+            public InputAction @IncreaseGameSpeed => m_Wrapper.m_Strategy_IncreaseGameSpeed;
+            /// <summary>
             /// Provides access to the underlying input action "Strategy/MultiSelectModifier".
             /// </summary>
             public InputAction @MultiSelectModifier => m_Wrapper.m_Strategy_MultiSelectModifier;
@@ -1315,6 +1985,178 @@ namespace Rebellion.Input
             /// Provides access to the underlying input action "Strategy/AlternateSelectModifier".
             /// </summary>
             public InputAction @AlternateSelectModifier => m_Wrapper.m_Strategy_AlternateSelectModifier;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot1".
+            /// </summary>
+            public InputAction @BookmarkSlot1 => m_Wrapper.m_Strategy_BookmarkSlot1;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot2".
+            /// </summary>
+            public InputAction @BookmarkSlot2 => m_Wrapper.m_Strategy_BookmarkSlot2;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot3".
+            /// </summary>
+            public InputAction @BookmarkSlot3 => m_Wrapper.m_Strategy_BookmarkSlot3;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot4".
+            /// </summary>
+            public InputAction @BookmarkSlot4 => m_Wrapper.m_Strategy_BookmarkSlot4;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot5".
+            /// </summary>
+            public InputAction @BookmarkSlot5 => m_Wrapper.m_Strategy_BookmarkSlot5;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot6".
+            /// </summary>
+            public InputAction @BookmarkSlot6 => m_Wrapper.m_Strategy_BookmarkSlot6;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot7".
+            /// </summary>
+            public InputAction @BookmarkSlot7 => m_Wrapper.m_Strategy_BookmarkSlot7;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot8".
+            /// </summary>
+            public InputAction @BookmarkSlot8 => m_Wrapper.m_Strategy_BookmarkSlot8;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot9".
+            /// </summary>
+            public InputAction @BookmarkSlot9 => m_Wrapper.m_Strategy_BookmarkSlot9;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot10".
+            /// </summary>
+            public InputAction @BookmarkSlot10 => m_Wrapper.m_Strategy_BookmarkSlot10;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot11".
+            /// </summary>
+            public InputAction @BookmarkSlot11 => m_Wrapper.m_Strategy_BookmarkSlot11;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/BookmarkSlot12".
+            /// </summary>
+            public InputAction @BookmarkSlot12 => m_Wrapper.m_Strategy_BookmarkSlot12;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/OpenSystemFinder".
+            /// </summary>
+            public InputAction @OpenSystemFinder => m_Wrapper.m_Strategy_OpenSystemFinder;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/OpenFleetFinder".
+            /// </summary>
+            public InputAction @OpenFleetFinder => m_Wrapper.m_Strategy_OpenFleetFinder;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/OpenPersonnelFinder".
+            /// </summary>
+            public InputAction @OpenPersonnelFinder => m_Wrapper.m_Strategy_OpenPersonnelFinder;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/OpenPlanetFinder".
+            /// </summary>
+            public InputAction @OpenPlanetFinder => m_Wrapper.m_Strategy_OpenPlanetFinder;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/OpenEncyclopedia".
+            /// </summary>
+            public InputAction @OpenEncyclopedia => m_Wrapper.m_Strategy_OpenEncyclopedia;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/OpenAllMessages".
+            /// </summary>
+            public InputAction @OpenAllMessages => m_Wrapper.m_Strategy_OpenAllMessages;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/DestroySelectedUnits".
+            /// </summary>
+            public InputAction @DestroySelectedUnits => m_Wrapper.m_Strategy_DestroySelectedUnits;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/OpenMissionSetup".
+            /// </summary>
+            public InputAction @OpenMissionSetup => m_Wrapper.m_Strategy_OpenMissionSetup;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/IssueMoveOrder".
+            /// </summary>
+            public InputAction @IssueMoveOrder => m_Wrapper.m_Strategy_IssueMoveOrder;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ConfirmMoveOrder".
+            /// </summary>
+            public InputAction @ConfirmMoveOrder => m_Wrapper.m_Strategy_ConfirmMoveOrder;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowPopularSupport".
+            /// </summary>
+            public InputAction @ShowPopularSupport => m_Wrapper.m_Strategy_ShowPopularSupport;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowUprisings".
+            /// </summary>
+            public InputAction @ShowUprisings => m_Wrapper.m_Strategy_ShowUprisings;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowIdleFleets".
+            /// </summary>
+            public InputAction @ShowIdleFleets => m_Wrapper.m_Strategy_ShowIdleFleets;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowFleetsEnroute".
+            /// </summary>
+            public InputAction @ShowFleetsEnroute => m_Wrapper.m_Strategy_ShowFleetsEnroute;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowIdlePersonnel".
+            /// </summary>
+            public InputAction @ShowIdlePersonnel => m_Wrapper.m_Strategy_ShowIdlePersonnel;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowActivePersonnel".
+            /// </summary>
+            public InputAction @ShowActivePersonnel => m_Wrapper.m_Strategy_ShowActivePersonnel;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowAvailableEnergy".
+            /// </summary>
+            public InputAction @ShowAvailableEnergy => m_Wrapper.m_Strategy_ShowAvailableEnergy;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowAvailableRawMaterial".
+            /// </summary>
+            public InputAction @ShowAvailableRawMaterial => m_Wrapper.m_Strategy_ShowAvailableRawMaterial;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowMines".
+            /// </summary>
+            public InputAction @ShowMines => m_Wrapper.m_Strategy_ShowMines;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowRefineries".
+            /// </summary>
+            public InputAction @ShowRefineries => m_Wrapper.m_Strategy_ShowRefineries;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowShipyards".
+            /// </summary>
+            public InputAction @ShowShipyards => m_Wrapper.m_Strategy_ShowShipyards;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowTrainingFacilities".
+            /// </summary>
+            public InputAction @ShowTrainingFacilities => m_Wrapper.m_Strategy_ShowTrainingFacilities;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowConstructionYards".
+            /// </summary>
+            public InputAction @ShowConstructionYards => m_Wrapper.m_Strategy_ShowConstructionYards;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowIdleShipyards".
+            /// </summary>
+            public InputAction @ShowIdleShipyards => m_Wrapper.m_Strategy_ShowIdleShipyards;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowIdleTrainingFacilities".
+            /// </summary>
+            public InputAction @ShowIdleTrainingFacilities => m_Wrapper.m_Strategy_ShowIdleTrainingFacilities;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowIdleConstructionYards".
+            /// </summary>
+            public InputAction @ShowIdleConstructionYards => m_Wrapper.m_Strategy_ShowIdleConstructionYards;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowTroopers".
+            /// </summary>
+            public InputAction @ShowTroopers => m_Wrapper.m_Strategy_ShowTroopers;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowFighterSquadrons".
+            /// </summary>
+            public InputAction @ShowFighterSquadrons => m_Wrapper.m_Strategy_ShowFighterSquadrons;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowDeathStarShields".
+            /// </summary>
+            public InputAction @ShowDeathStarShields => m_Wrapper.m_Strategy_ShowDeathStarShields;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowPlanetaryShieldGenerators".
+            /// </summary>
+            public InputAction @ShowPlanetaryShieldGenerators => m_Wrapper.m_Strategy_ShowPlanetaryShieldGenerators;
+            /// <summary>
+            /// Provides access to the underlying input action "Strategy/ShowPlanetaryDefenseBatteries".
+            /// </summary>
+            public InputAction @ShowPlanetaryDefenseBatteries => m_Wrapper.m_Strategy_ShowPlanetaryDefenseBatteries;
             /// <summary>
             /// Provides access to the underlying input action map instance.
             /// </summary>
@@ -1341,6 +2183,12 @@ namespace Rebellion.Input
             {
                 if (instance == null || m_Wrapper.m_StrategyActionsCallbackInterfaces.Contains(instance)) return;
                 m_Wrapper.m_StrategyActionsCallbackInterfaces.Add(instance);
+                @DecreaseGameSpeed.started += instance.OnDecreaseGameSpeed;
+                @DecreaseGameSpeed.performed += instance.OnDecreaseGameSpeed;
+                @DecreaseGameSpeed.canceled += instance.OnDecreaseGameSpeed;
+                @IncreaseGameSpeed.started += instance.OnIncreaseGameSpeed;
+                @IncreaseGameSpeed.performed += instance.OnIncreaseGameSpeed;
+                @IncreaseGameSpeed.canceled += instance.OnIncreaseGameSpeed;
                 @MultiSelectModifier.started += instance.OnMultiSelectModifier;
                 @MultiSelectModifier.performed += instance.OnMultiSelectModifier;
                 @MultiSelectModifier.canceled += instance.OnMultiSelectModifier;
@@ -1350,6 +2198,135 @@ namespace Rebellion.Input
                 @AlternateSelectModifier.started += instance.OnAlternateSelectModifier;
                 @AlternateSelectModifier.performed += instance.OnAlternateSelectModifier;
                 @AlternateSelectModifier.canceled += instance.OnAlternateSelectModifier;
+                @BookmarkSlot1.started += instance.OnBookmarkSlot1;
+                @BookmarkSlot1.performed += instance.OnBookmarkSlot1;
+                @BookmarkSlot1.canceled += instance.OnBookmarkSlot1;
+                @BookmarkSlot2.started += instance.OnBookmarkSlot2;
+                @BookmarkSlot2.performed += instance.OnBookmarkSlot2;
+                @BookmarkSlot2.canceled += instance.OnBookmarkSlot2;
+                @BookmarkSlot3.started += instance.OnBookmarkSlot3;
+                @BookmarkSlot3.performed += instance.OnBookmarkSlot3;
+                @BookmarkSlot3.canceled += instance.OnBookmarkSlot3;
+                @BookmarkSlot4.started += instance.OnBookmarkSlot4;
+                @BookmarkSlot4.performed += instance.OnBookmarkSlot4;
+                @BookmarkSlot4.canceled += instance.OnBookmarkSlot4;
+                @BookmarkSlot5.started += instance.OnBookmarkSlot5;
+                @BookmarkSlot5.performed += instance.OnBookmarkSlot5;
+                @BookmarkSlot5.canceled += instance.OnBookmarkSlot5;
+                @BookmarkSlot6.started += instance.OnBookmarkSlot6;
+                @BookmarkSlot6.performed += instance.OnBookmarkSlot6;
+                @BookmarkSlot6.canceled += instance.OnBookmarkSlot6;
+                @BookmarkSlot7.started += instance.OnBookmarkSlot7;
+                @BookmarkSlot7.performed += instance.OnBookmarkSlot7;
+                @BookmarkSlot7.canceled += instance.OnBookmarkSlot7;
+                @BookmarkSlot8.started += instance.OnBookmarkSlot8;
+                @BookmarkSlot8.performed += instance.OnBookmarkSlot8;
+                @BookmarkSlot8.canceled += instance.OnBookmarkSlot8;
+                @BookmarkSlot9.started += instance.OnBookmarkSlot9;
+                @BookmarkSlot9.performed += instance.OnBookmarkSlot9;
+                @BookmarkSlot9.canceled += instance.OnBookmarkSlot9;
+                @BookmarkSlot10.started += instance.OnBookmarkSlot10;
+                @BookmarkSlot10.performed += instance.OnBookmarkSlot10;
+                @BookmarkSlot10.canceled += instance.OnBookmarkSlot10;
+                @BookmarkSlot11.started += instance.OnBookmarkSlot11;
+                @BookmarkSlot11.performed += instance.OnBookmarkSlot11;
+                @BookmarkSlot11.canceled += instance.OnBookmarkSlot11;
+                @BookmarkSlot12.started += instance.OnBookmarkSlot12;
+                @BookmarkSlot12.performed += instance.OnBookmarkSlot12;
+                @BookmarkSlot12.canceled += instance.OnBookmarkSlot12;
+                @OpenSystemFinder.started += instance.OnOpenSystemFinder;
+                @OpenSystemFinder.performed += instance.OnOpenSystemFinder;
+                @OpenSystemFinder.canceled += instance.OnOpenSystemFinder;
+                @OpenFleetFinder.started += instance.OnOpenFleetFinder;
+                @OpenFleetFinder.performed += instance.OnOpenFleetFinder;
+                @OpenFleetFinder.canceled += instance.OnOpenFleetFinder;
+                @OpenPersonnelFinder.started += instance.OnOpenPersonnelFinder;
+                @OpenPersonnelFinder.performed += instance.OnOpenPersonnelFinder;
+                @OpenPersonnelFinder.canceled += instance.OnOpenPersonnelFinder;
+                @OpenPlanetFinder.started += instance.OnOpenPlanetFinder;
+                @OpenPlanetFinder.performed += instance.OnOpenPlanetFinder;
+                @OpenPlanetFinder.canceled += instance.OnOpenPlanetFinder;
+                @OpenEncyclopedia.started += instance.OnOpenEncyclopedia;
+                @OpenEncyclopedia.performed += instance.OnOpenEncyclopedia;
+                @OpenEncyclopedia.canceled += instance.OnOpenEncyclopedia;
+                @OpenAllMessages.started += instance.OnOpenAllMessages;
+                @OpenAllMessages.performed += instance.OnOpenAllMessages;
+                @OpenAllMessages.canceled += instance.OnOpenAllMessages;
+                @DestroySelectedUnits.started += instance.OnDestroySelectedUnits;
+                @DestroySelectedUnits.performed += instance.OnDestroySelectedUnits;
+                @DestroySelectedUnits.canceled += instance.OnDestroySelectedUnits;
+                @OpenMissionSetup.started += instance.OnOpenMissionSetup;
+                @OpenMissionSetup.performed += instance.OnOpenMissionSetup;
+                @OpenMissionSetup.canceled += instance.OnOpenMissionSetup;
+                @IssueMoveOrder.started += instance.OnIssueMoveOrder;
+                @IssueMoveOrder.performed += instance.OnIssueMoveOrder;
+                @IssueMoveOrder.canceled += instance.OnIssueMoveOrder;
+                @ConfirmMoveOrder.started += instance.OnConfirmMoveOrder;
+                @ConfirmMoveOrder.performed += instance.OnConfirmMoveOrder;
+                @ConfirmMoveOrder.canceled += instance.OnConfirmMoveOrder;
+                @ShowPopularSupport.started += instance.OnShowPopularSupport;
+                @ShowPopularSupport.performed += instance.OnShowPopularSupport;
+                @ShowPopularSupport.canceled += instance.OnShowPopularSupport;
+                @ShowUprisings.started += instance.OnShowUprisings;
+                @ShowUprisings.performed += instance.OnShowUprisings;
+                @ShowUprisings.canceled += instance.OnShowUprisings;
+                @ShowIdleFleets.started += instance.OnShowIdleFleets;
+                @ShowIdleFleets.performed += instance.OnShowIdleFleets;
+                @ShowIdleFleets.canceled += instance.OnShowIdleFleets;
+                @ShowFleetsEnroute.started += instance.OnShowFleetsEnroute;
+                @ShowFleetsEnroute.performed += instance.OnShowFleetsEnroute;
+                @ShowFleetsEnroute.canceled += instance.OnShowFleetsEnroute;
+                @ShowIdlePersonnel.started += instance.OnShowIdlePersonnel;
+                @ShowIdlePersonnel.performed += instance.OnShowIdlePersonnel;
+                @ShowIdlePersonnel.canceled += instance.OnShowIdlePersonnel;
+                @ShowActivePersonnel.started += instance.OnShowActivePersonnel;
+                @ShowActivePersonnel.performed += instance.OnShowActivePersonnel;
+                @ShowActivePersonnel.canceled += instance.OnShowActivePersonnel;
+                @ShowAvailableEnergy.started += instance.OnShowAvailableEnergy;
+                @ShowAvailableEnergy.performed += instance.OnShowAvailableEnergy;
+                @ShowAvailableEnergy.canceled += instance.OnShowAvailableEnergy;
+                @ShowAvailableRawMaterial.started += instance.OnShowAvailableRawMaterial;
+                @ShowAvailableRawMaterial.performed += instance.OnShowAvailableRawMaterial;
+                @ShowAvailableRawMaterial.canceled += instance.OnShowAvailableRawMaterial;
+                @ShowMines.started += instance.OnShowMines;
+                @ShowMines.performed += instance.OnShowMines;
+                @ShowMines.canceled += instance.OnShowMines;
+                @ShowRefineries.started += instance.OnShowRefineries;
+                @ShowRefineries.performed += instance.OnShowRefineries;
+                @ShowRefineries.canceled += instance.OnShowRefineries;
+                @ShowShipyards.started += instance.OnShowShipyards;
+                @ShowShipyards.performed += instance.OnShowShipyards;
+                @ShowShipyards.canceled += instance.OnShowShipyards;
+                @ShowTrainingFacilities.started += instance.OnShowTrainingFacilities;
+                @ShowTrainingFacilities.performed += instance.OnShowTrainingFacilities;
+                @ShowTrainingFacilities.canceled += instance.OnShowTrainingFacilities;
+                @ShowConstructionYards.started += instance.OnShowConstructionYards;
+                @ShowConstructionYards.performed += instance.OnShowConstructionYards;
+                @ShowConstructionYards.canceled += instance.OnShowConstructionYards;
+                @ShowIdleShipyards.started += instance.OnShowIdleShipyards;
+                @ShowIdleShipyards.performed += instance.OnShowIdleShipyards;
+                @ShowIdleShipyards.canceled += instance.OnShowIdleShipyards;
+                @ShowIdleTrainingFacilities.started += instance.OnShowIdleTrainingFacilities;
+                @ShowIdleTrainingFacilities.performed += instance.OnShowIdleTrainingFacilities;
+                @ShowIdleTrainingFacilities.canceled += instance.OnShowIdleTrainingFacilities;
+                @ShowIdleConstructionYards.started += instance.OnShowIdleConstructionYards;
+                @ShowIdleConstructionYards.performed += instance.OnShowIdleConstructionYards;
+                @ShowIdleConstructionYards.canceled += instance.OnShowIdleConstructionYards;
+                @ShowTroopers.started += instance.OnShowTroopers;
+                @ShowTroopers.performed += instance.OnShowTroopers;
+                @ShowTroopers.canceled += instance.OnShowTroopers;
+                @ShowFighterSquadrons.started += instance.OnShowFighterSquadrons;
+                @ShowFighterSquadrons.performed += instance.OnShowFighterSquadrons;
+                @ShowFighterSquadrons.canceled += instance.OnShowFighterSquadrons;
+                @ShowDeathStarShields.started += instance.OnShowDeathStarShields;
+                @ShowDeathStarShields.performed += instance.OnShowDeathStarShields;
+                @ShowDeathStarShields.canceled += instance.OnShowDeathStarShields;
+                @ShowPlanetaryShieldGenerators.started += instance.OnShowPlanetaryShieldGenerators;
+                @ShowPlanetaryShieldGenerators.performed += instance.OnShowPlanetaryShieldGenerators;
+                @ShowPlanetaryShieldGenerators.canceled += instance.OnShowPlanetaryShieldGenerators;
+                @ShowPlanetaryDefenseBatteries.started += instance.OnShowPlanetaryDefenseBatteries;
+                @ShowPlanetaryDefenseBatteries.performed += instance.OnShowPlanetaryDefenseBatteries;
+                @ShowPlanetaryDefenseBatteries.canceled += instance.OnShowPlanetaryDefenseBatteries;
             }
 
             /// <summary>
@@ -1361,6 +2338,12 @@ namespace Rebellion.Input
             /// <seealso cref="StrategyActions" />
             private void UnregisterCallbacks(IStrategyActions instance)
             {
+                @DecreaseGameSpeed.started -= instance.OnDecreaseGameSpeed;
+                @DecreaseGameSpeed.performed -= instance.OnDecreaseGameSpeed;
+                @DecreaseGameSpeed.canceled -= instance.OnDecreaseGameSpeed;
+                @IncreaseGameSpeed.started -= instance.OnIncreaseGameSpeed;
+                @IncreaseGameSpeed.performed -= instance.OnIncreaseGameSpeed;
+                @IncreaseGameSpeed.canceled -= instance.OnIncreaseGameSpeed;
                 @MultiSelectModifier.started -= instance.OnMultiSelectModifier;
                 @MultiSelectModifier.performed -= instance.OnMultiSelectModifier;
                 @MultiSelectModifier.canceled -= instance.OnMultiSelectModifier;
@@ -1370,6 +2353,135 @@ namespace Rebellion.Input
                 @AlternateSelectModifier.started -= instance.OnAlternateSelectModifier;
                 @AlternateSelectModifier.performed -= instance.OnAlternateSelectModifier;
                 @AlternateSelectModifier.canceled -= instance.OnAlternateSelectModifier;
+                @BookmarkSlot1.started -= instance.OnBookmarkSlot1;
+                @BookmarkSlot1.performed -= instance.OnBookmarkSlot1;
+                @BookmarkSlot1.canceled -= instance.OnBookmarkSlot1;
+                @BookmarkSlot2.started -= instance.OnBookmarkSlot2;
+                @BookmarkSlot2.performed -= instance.OnBookmarkSlot2;
+                @BookmarkSlot2.canceled -= instance.OnBookmarkSlot2;
+                @BookmarkSlot3.started -= instance.OnBookmarkSlot3;
+                @BookmarkSlot3.performed -= instance.OnBookmarkSlot3;
+                @BookmarkSlot3.canceled -= instance.OnBookmarkSlot3;
+                @BookmarkSlot4.started -= instance.OnBookmarkSlot4;
+                @BookmarkSlot4.performed -= instance.OnBookmarkSlot4;
+                @BookmarkSlot4.canceled -= instance.OnBookmarkSlot4;
+                @BookmarkSlot5.started -= instance.OnBookmarkSlot5;
+                @BookmarkSlot5.performed -= instance.OnBookmarkSlot5;
+                @BookmarkSlot5.canceled -= instance.OnBookmarkSlot5;
+                @BookmarkSlot6.started -= instance.OnBookmarkSlot6;
+                @BookmarkSlot6.performed -= instance.OnBookmarkSlot6;
+                @BookmarkSlot6.canceled -= instance.OnBookmarkSlot6;
+                @BookmarkSlot7.started -= instance.OnBookmarkSlot7;
+                @BookmarkSlot7.performed -= instance.OnBookmarkSlot7;
+                @BookmarkSlot7.canceled -= instance.OnBookmarkSlot7;
+                @BookmarkSlot8.started -= instance.OnBookmarkSlot8;
+                @BookmarkSlot8.performed -= instance.OnBookmarkSlot8;
+                @BookmarkSlot8.canceled -= instance.OnBookmarkSlot8;
+                @BookmarkSlot9.started -= instance.OnBookmarkSlot9;
+                @BookmarkSlot9.performed -= instance.OnBookmarkSlot9;
+                @BookmarkSlot9.canceled -= instance.OnBookmarkSlot9;
+                @BookmarkSlot10.started -= instance.OnBookmarkSlot10;
+                @BookmarkSlot10.performed -= instance.OnBookmarkSlot10;
+                @BookmarkSlot10.canceled -= instance.OnBookmarkSlot10;
+                @BookmarkSlot11.started -= instance.OnBookmarkSlot11;
+                @BookmarkSlot11.performed -= instance.OnBookmarkSlot11;
+                @BookmarkSlot11.canceled -= instance.OnBookmarkSlot11;
+                @BookmarkSlot12.started -= instance.OnBookmarkSlot12;
+                @BookmarkSlot12.performed -= instance.OnBookmarkSlot12;
+                @BookmarkSlot12.canceled -= instance.OnBookmarkSlot12;
+                @OpenSystemFinder.started -= instance.OnOpenSystemFinder;
+                @OpenSystemFinder.performed -= instance.OnOpenSystemFinder;
+                @OpenSystemFinder.canceled -= instance.OnOpenSystemFinder;
+                @OpenFleetFinder.started -= instance.OnOpenFleetFinder;
+                @OpenFleetFinder.performed -= instance.OnOpenFleetFinder;
+                @OpenFleetFinder.canceled -= instance.OnOpenFleetFinder;
+                @OpenPersonnelFinder.started -= instance.OnOpenPersonnelFinder;
+                @OpenPersonnelFinder.performed -= instance.OnOpenPersonnelFinder;
+                @OpenPersonnelFinder.canceled -= instance.OnOpenPersonnelFinder;
+                @OpenPlanetFinder.started -= instance.OnOpenPlanetFinder;
+                @OpenPlanetFinder.performed -= instance.OnOpenPlanetFinder;
+                @OpenPlanetFinder.canceled -= instance.OnOpenPlanetFinder;
+                @OpenEncyclopedia.started -= instance.OnOpenEncyclopedia;
+                @OpenEncyclopedia.performed -= instance.OnOpenEncyclopedia;
+                @OpenEncyclopedia.canceled -= instance.OnOpenEncyclopedia;
+                @OpenAllMessages.started -= instance.OnOpenAllMessages;
+                @OpenAllMessages.performed -= instance.OnOpenAllMessages;
+                @OpenAllMessages.canceled -= instance.OnOpenAllMessages;
+                @DestroySelectedUnits.started -= instance.OnDestroySelectedUnits;
+                @DestroySelectedUnits.performed -= instance.OnDestroySelectedUnits;
+                @DestroySelectedUnits.canceled -= instance.OnDestroySelectedUnits;
+                @OpenMissionSetup.started -= instance.OnOpenMissionSetup;
+                @OpenMissionSetup.performed -= instance.OnOpenMissionSetup;
+                @OpenMissionSetup.canceled -= instance.OnOpenMissionSetup;
+                @IssueMoveOrder.started -= instance.OnIssueMoveOrder;
+                @IssueMoveOrder.performed -= instance.OnIssueMoveOrder;
+                @IssueMoveOrder.canceled -= instance.OnIssueMoveOrder;
+                @ConfirmMoveOrder.started -= instance.OnConfirmMoveOrder;
+                @ConfirmMoveOrder.performed -= instance.OnConfirmMoveOrder;
+                @ConfirmMoveOrder.canceled -= instance.OnConfirmMoveOrder;
+                @ShowPopularSupport.started -= instance.OnShowPopularSupport;
+                @ShowPopularSupport.performed -= instance.OnShowPopularSupport;
+                @ShowPopularSupport.canceled -= instance.OnShowPopularSupport;
+                @ShowUprisings.started -= instance.OnShowUprisings;
+                @ShowUprisings.performed -= instance.OnShowUprisings;
+                @ShowUprisings.canceled -= instance.OnShowUprisings;
+                @ShowIdleFleets.started -= instance.OnShowIdleFleets;
+                @ShowIdleFleets.performed -= instance.OnShowIdleFleets;
+                @ShowIdleFleets.canceled -= instance.OnShowIdleFleets;
+                @ShowFleetsEnroute.started -= instance.OnShowFleetsEnroute;
+                @ShowFleetsEnroute.performed -= instance.OnShowFleetsEnroute;
+                @ShowFleetsEnroute.canceled -= instance.OnShowFleetsEnroute;
+                @ShowIdlePersonnel.started -= instance.OnShowIdlePersonnel;
+                @ShowIdlePersonnel.performed -= instance.OnShowIdlePersonnel;
+                @ShowIdlePersonnel.canceled -= instance.OnShowIdlePersonnel;
+                @ShowActivePersonnel.started -= instance.OnShowActivePersonnel;
+                @ShowActivePersonnel.performed -= instance.OnShowActivePersonnel;
+                @ShowActivePersonnel.canceled -= instance.OnShowActivePersonnel;
+                @ShowAvailableEnergy.started -= instance.OnShowAvailableEnergy;
+                @ShowAvailableEnergy.performed -= instance.OnShowAvailableEnergy;
+                @ShowAvailableEnergy.canceled -= instance.OnShowAvailableEnergy;
+                @ShowAvailableRawMaterial.started -= instance.OnShowAvailableRawMaterial;
+                @ShowAvailableRawMaterial.performed -= instance.OnShowAvailableRawMaterial;
+                @ShowAvailableRawMaterial.canceled -= instance.OnShowAvailableRawMaterial;
+                @ShowMines.started -= instance.OnShowMines;
+                @ShowMines.performed -= instance.OnShowMines;
+                @ShowMines.canceled -= instance.OnShowMines;
+                @ShowRefineries.started -= instance.OnShowRefineries;
+                @ShowRefineries.performed -= instance.OnShowRefineries;
+                @ShowRefineries.canceled -= instance.OnShowRefineries;
+                @ShowShipyards.started -= instance.OnShowShipyards;
+                @ShowShipyards.performed -= instance.OnShowShipyards;
+                @ShowShipyards.canceled -= instance.OnShowShipyards;
+                @ShowTrainingFacilities.started -= instance.OnShowTrainingFacilities;
+                @ShowTrainingFacilities.performed -= instance.OnShowTrainingFacilities;
+                @ShowTrainingFacilities.canceled -= instance.OnShowTrainingFacilities;
+                @ShowConstructionYards.started -= instance.OnShowConstructionYards;
+                @ShowConstructionYards.performed -= instance.OnShowConstructionYards;
+                @ShowConstructionYards.canceled -= instance.OnShowConstructionYards;
+                @ShowIdleShipyards.started -= instance.OnShowIdleShipyards;
+                @ShowIdleShipyards.performed -= instance.OnShowIdleShipyards;
+                @ShowIdleShipyards.canceled -= instance.OnShowIdleShipyards;
+                @ShowIdleTrainingFacilities.started -= instance.OnShowIdleTrainingFacilities;
+                @ShowIdleTrainingFacilities.performed -= instance.OnShowIdleTrainingFacilities;
+                @ShowIdleTrainingFacilities.canceled -= instance.OnShowIdleTrainingFacilities;
+                @ShowIdleConstructionYards.started -= instance.OnShowIdleConstructionYards;
+                @ShowIdleConstructionYards.performed -= instance.OnShowIdleConstructionYards;
+                @ShowIdleConstructionYards.canceled -= instance.OnShowIdleConstructionYards;
+                @ShowTroopers.started -= instance.OnShowTroopers;
+                @ShowTroopers.performed -= instance.OnShowTroopers;
+                @ShowTroopers.canceled -= instance.OnShowTroopers;
+                @ShowFighterSquadrons.started -= instance.OnShowFighterSquadrons;
+                @ShowFighterSquadrons.performed -= instance.OnShowFighterSquadrons;
+                @ShowFighterSquadrons.canceled -= instance.OnShowFighterSquadrons;
+                @ShowDeathStarShields.started -= instance.OnShowDeathStarShields;
+                @ShowDeathStarShields.performed -= instance.OnShowDeathStarShields;
+                @ShowDeathStarShields.canceled -= instance.OnShowDeathStarShields;
+                @ShowPlanetaryShieldGenerators.started -= instance.OnShowPlanetaryShieldGenerators;
+                @ShowPlanetaryShieldGenerators.performed -= instance.OnShowPlanetaryShieldGenerators;
+                @ShowPlanetaryShieldGenerators.canceled -= instance.OnShowPlanetaryShieldGenerators;
+                @ShowPlanetaryDefenseBatteries.started -= instance.OnShowPlanetaryDefenseBatteries;
+                @ShowPlanetaryDefenseBatteries.performed -= instance.OnShowPlanetaryDefenseBatteries;
+                @ShowPlanetaryDefenseBatteries.canceled -= instance.OnShowPlanetaryDefenseBatteries;
             }
 
             /// <summary>
@@ -1820,6 +2932,14 @@ namespace Rebellion.Input
             /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnQuickLoad(InputAction.CallbackContext context);
+        }
+        /// <summary>
+        /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "Strategy" which allows adding and removing callbacks.
+        /// </summary>
+        /// <seealso cref="StrategyActions.AddCallbacks(IStrategyActions)" />
+        /// <seealso cref="StrategyActions.RemoveCallbacks(IStrategyActions)" />
+        public interface IStrategyActions
+        {
             /// <summary>
             /// Method invoked when associated input action "DecreaseGameSpeed" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
             /// </summary>
@@ -1834,14 +2954,6 @@ namespace Rebellion.Input
             /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnIncreaseGameSpeed(InputAction.CallbackContext context);
-        }
-        /// <summary>
-        /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "Strategy" which allows adding and removing callbacks.
-        /// </summary>
-        /// <seealso cref="StrategyActions.AddCallbacks(IStrategyActions)" />
-        /// <seealso cref="StrategyActions.RemoveCallbacks(IStrategyActions)" />
-        public interface IStrategyActions
-        {
             /// <summary>
             /// Method invoked when associated input action "MultiSelectModifier" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
             /// </summary>
@@ -1863,6 +2975,307 @@ namespace Rebellion.Input
             /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
             /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnAlternateSelectModifier(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot1" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot1(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot2" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot2(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot3" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot3(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot4" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot4(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot5" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot5(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot6" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot6(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot7" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot7(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot8" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot8(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot9" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot9(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot10" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot10(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot11" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot11(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "BookmarkSlot12" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnBookmarkSlot12(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "OpenSystemFinder" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnOpenSystemFinder(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "OpenFleetFinder" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnOpenFleetFinder(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "OpenPersonnelFinder" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnOpenPersonnelFinder(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "OpenPlanetFinder" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnOpenPlanetFinder(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "OpenEncyclopedia" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnOpenEncyclopedia(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "OpenAllMessages" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnOpenAllMessages(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "DestroySelectedUnits" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnDestroySelectedUnits(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "OpenMissionSetup" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnOpenMissionSetup(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "IssueMoveOrder" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnIssueMoveOrder(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ConfirmMoveOrder" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnConfirmMoveOrder(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowPopularSupport" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowPopularSupport(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowUprisings" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowUprisings(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowIdleFleets" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowIdleFleets(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowFleetsEnroute" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowFleetsEnroute(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowIdlePersonnel" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowIdlePersonnel(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowActivePersonnel" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowActivePersonnel(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowAvailableEnergy" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowAvailableEnergy(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowAvailableRawMaterial" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowAvailableRawMaterial(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowMines" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowMines(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowRefineries" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowRefineries(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowShipyards" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowShipyards(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowTrainingFacilities" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowTrainingFacilities(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowConstructionYards" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowConstructionYards(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowIdleShipyards" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowIdleShipyards(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowIdleTrainingFacilities" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowIdleTrainingFacilities(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowIdleConstructionYards" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowIdleConstructionYards(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowTroopers" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowTroopers(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowFighterSquadrons" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowFighterSquadrons(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowDeathStarShields" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowDeathStarShields(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowPlanetaryShieldGenerators" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowPlanetaryShieldGenerators(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "ShowPlanetaryDefenseBatteries" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+            void OnShowPlanetaryDefenseBatteries(InputAction.CallbackContext context);
         }
         /// <summary>
         /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "Window" which allows adding and removing callbacks.

--- a/Assets/Scripts/App/AppBootstrap.cs
+++ b/Assets/Scripts/App/AppBootstrap.cs
@@ -326,6 +326,15 @@ public sealed class AppBootstrap : MonoBehaviour
     }
 
     /// <summary>
+    /// Returns the input context controller.
+    /// </summary>
+    /// <returns>The active application input controller.</returns>
+    public AppInputController GetInputController()
+    {
+        return inputController;
+    }
+
+    /// <summary>
     /// Returns the application cancel stack.
     /// </summary>
     /// <returns>The active cancel stack.</returns>

--- a/Assets/Scripts/App/GameRuntime.cs
+++ b/Assets/Scripts/App/GameRuntime.cs
@@ -174,7 +174,7 @@ public sealed class GameRuntime
         GameLaunchContext.IsLoadGame = true;
         GameLaunchContext.SaveFileName = fileName;
         GameLaunchContext.PlayIntroCutscene = false;
-        _loadScene(SaveMenuLaunchContext.StrategyViewSceneName);
+        _loadScene(SceneNames.StrategyView);
     }
 
     /// <summary>

--- a/Assets/Scripts/App/SceneLoader.cs
+++ b/Assets/Scripts/App/SceneLoader.cs
@@ -74,9 +74,7 @@ public sealed class SceneLoader : MonoBehaviour
     private static Task GetSceneInitializationAsync(string sceneName)
     {
         AppBootstrap bootstrap = AppBootstrap.Instance;
-        if (sceneName == SaveMenuLaunchContext.SaveMenuSceneName)
-            return bootstrap.InitializeSaveMenuContentAsync();
-        if (sceneName == SaveMenuLaunchContext.StrategyViewSceneName)
+        if (sceneName == SceneNames.StrategyView)
             return bootstrap.InitializeStrategyContentAsync();
 
         return bootstrap.InitializeMainMenuSceneAsync();

--- a/Assets/Scripts/App/SceneNames.cs
+++ b/Assets/Scripts/App/SceneNames.cs
@@ -1,0 +1,9 @@
+/// <summary>
+/// Defines the names of the game scenes.
+/// </summary>
+public static class SceneNames
+{
+    // Scene Names.
+    public const string MainMenu = "MainMenu";
+    public const string StrategyView = "StrategyView";
+}

--- a/Assets/Scripts/Managers/InputBindingStore.cs
+++ b/Assets/Scripts/Managers/InputBindingStore.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Saves and loads input binding overrides.
+/// </summary>
+internal sealed class InputBindingStore
+{
+    private const int _editableSlotCount = 2;
+    private readonly InputActionAsset _asset;
+
+    internal InputBindingStore(InputActionAsset asset)
+    {
+        _asset = asset ?? throw new ArgumentNullException(nameof(asset));
+        EnsureEditableSlots();
+    }
+
+    internal string SaveOverrides()
+    {
+        return _asset.SaveBindingOverridesAsJson();
+    }
+
+    internal void LoadOverrides(string serializedOverrides)
+    {
+        _asset.RemoveAllBindingOverrides();
+        if (string.IsNullOrWhiteSpace(serializedOverrides))
+            return;
+
+        _asset.LoadBindingOverridesFromJson(serializedOverrides);
+        MigrateLegacyRuntimeOverrides(serializedOverrides);
+    }
+
+    internal Guid GetSlotId(string actionPath, int slot)
+    {
+        InputAction action = _asset.FindAction(actionPath, true);
+        return action.bindings[GetTopLevelBindingIndex(action, slot)].id;
+    }
+
+    internal void ApplySlotOverride(string actionPath, int slot, string path)
+    {
+        InputAction action = _asset.FindAction(actionPath, true);
+        action.ApplyBindingOverride(GetTopLevelBindingIndex(action, slot), path);
+    }
+
+    internal string GetEffectiveSlotPath(string actionPath, int slot)
+    {
+        InputAction action = _asset.FindAction(actionPath, true);
+        return action.bindings[GetTopLevelBindingIndex(action, slot)].effectivePath;
+    }
+
+    private void EnsureEditableSlots()
+    {
+        foreach (InputActionMap map in _asset.actionMaps)
+        {
+            if (map.name is not ("Global" or "Strategy"))
+                continue;
+
+            bool wasEnabled = map.enabled;
+            map.Disable();
+            foreach (InputAction action in map.actions)
+            {
+                if (action.name == "CancelOrSettings")
+                    continue;
+
+                int topLevelCount = CountTopLevelBindings(action);
+                for (int slot = topLevelCount; slot < _editableSlotCount; slot++)
+                {
+                    action.AddBinding(
+                        new InputBinding
+                        {
+                            id = CreateStableSlotId(map.name, action.name, slot),
+                            path = string.Empty,
+                            groups = "Keyboard&Mouse",
+                        }
+                    );
+                }
+            }
+
+            if (wasEnabled)
+                map.Enable();
+        }
+    }
+
+    private void MigrateLegacyRuntimeOverrides(string serializedOverrides)
+    {
+        BindingOverrideList saved = JsonUtility.FromJson<BindingOverrideList>(serializedOverrides);
+        if (saved?.bindings == null)
+            return;
+
+        HashSet<string> migratedSlots = new HashSet<string>();
+        foreach (BindingOverrideEntry entry in saved.bindings)
+        {
+            if (entry == null || BindingIdExists(entry.id))
+                continue;
+
+            InputAction action = _asset.FindAction(entry.action, false);
+            if (action == null)
+                continue;
+
+            for (int slot = 0; slot < _editableSlotCount; slot++)
+            {
+                int bindingIndex = GetTopLevelBindingIndex(action, slot);
+                string slotKey = $"{entry.action}/{slot}";
+                InputBinding binding = action.bindings[bindingIndex];
+                if (migratedSlots.Contains(slotKey) || !string.IsNullOrEmpty(binding.effectivePath))
+                    continue;
+
+                action.ApplyBindingOverride(
+                    bindingIndex,
+                    new InputBinding
+                    {
+                        overridePath = DeserializeNullable(entry.path),
+                        overrideInteractions = DeserializeNullable(entry.interactions),
+                        overrideProcessors = DeserializeNullable(entry.processors),
+                    }
+                );
+                migratedSlots.Add(slotKey);
+                break;
+            }
+        }
+    }
+
+    private bool BindingIdExists(string id)
+    {
+        if (!Guid.TryParse(id, out Guid bindingId))
+            return false;
+
+        foreach (InputBinding binding in _asset.bindings)
+        {
+            if (binding.id == bindingId)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static int CountTopLevelBindings(InputAction action)
+    {
+        int count = 0;
+        foreach (InputBinding binding in action.bindings)
+        {
+            if (!binding.isPartOfComposite)
+                count++;
+        }
+
+        return count;
+    }
+
+    private static Guid CreateStableSlotId(string mapName, string actionName, int slot)
+    {
+        using MD5 md5 = MD5.Create();
+        byte[] hash = md5.ComputeHash(
+            Encoding.UTF8.GetBytes($"rebellion2/{mapName}/{actionName}/binding/{slot}")
+        );
+        return new Guid(hash);
+    }
+
+    internal static int GetTopLevelBindingIndex(InputAction action, int slot)
+    {
+        if (slot < 0)
+            throw new ArgumentOutOfRangeException(nameof(slot));
+
+        int topLevelSlot = 0;
+        for (int bindingIndex = 0; bindingIndex < action.bindings.Count; bindingIndex++)
+        {
+            if (action.bindings[bindingIndex].isPartOfComposite)
+                continue;
+            if (topLevelSlot == slot)
+                return bindingIndex;
+            topLevelSlot++;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(slot));
+    }
+
+    private static string DeserializeNullable(string value)
+    {
+        return value == "null" ? null : value;
+    }
+
+    [Serializable]
+    private sealed class BindingOverrideList
+    {
+        public BindingOverrideEntry[] bindings;
+    }
+
+    [Serializable]
+    private sealed class BindingOverrideEntry
+    {
+        public string action;
+        public string id;
+        public string path;
+        public string interactions;
+        public string processors;
+    }
+}

--- a/Assets/Scripts/Managers/InputManager.cs
+++ b/Assets/Scripts/Managers/InputManager.cs
@@ -1,3 +1,4 @@
+using System;
 using Rebellion.Input;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -8,11 +9,25 @@ using UnityEngine.InputSystem;
 public sealed class InputManager : MonoBehaviour
 {
     private PlayerInputActions _actions;
+    private InputBindingStore _bindingStore;
 
     /// <summary>
     /// Gets the generated input action wrapper.
     /// </summary>
-    public PlayerInputActions Actions => _actions ??= new PlayerInputActions();
+    public PlayerInputActions Actions
+    {
+        get
+        {
+            KeyboardChordProcessor.EnsureRegistered();
+            if (_actions == null)
+            {
+                _actions = new PlayerInputActions();
+                _bindingStore = new InputBindingStore(_actions.asset);
+            }
+
+            return _actions;
+        }
+    }
 
     /// <summary>
     /// Gets the generated input action asset.
@@ -58,7 +73,8 @@ public sealed class InputManager : MonoBehaviour
     /// <returns>The serialized binding override data.</returns>
     public string SaveBindingOverrides()
     {
-        return InputActionRebindingExtensions.SaveBindingOverridesAsJson(Actions.asset);
+        _ = Actions;
+        return _bindingStore.SaveOverrides();
     }
 
     /// <summary>
@@ -67,14 +83,42 @@ public sealed class InputManager : MonoBehaviour
     /// <param name="bindingOverrides">The serialized binding override data.</param>
     public void LoadBindingOverrides(string bindingOverrides)
     {
-        InputActionRebindingExtensions.RemoveAllBindingOverrides(Actions.asset);
+        _ = Actions;
+        _bindingStore.LoadOverrides(bindingOverrides);
+    }
 
-        if (string.IsNullOrWhiteSpace(bindingOverrides))
-            return;
+    /// <summary>
+    /// Returns the identifier for a binding slot.
+    /// </summary>
+    internal Guid GetBindingSlotId(string actionPath, int slot)
+    {
+        _ = Actions;
+        return _bindingStore.GetSlotId(actionPath, slot);
+    }
 
-        InputActionRebindingExtensions.LoadBindingOverridesFromJson(
-            Actions.asset,
-            bindingOverrides
-        );
+    /// <summary>
+    /// Changes the binding assigned to a slot.
+    /// </summary>
+    internal void ApplyBindingSlotOverride(string actionPath, int slot, string path)
+    {
+        _ = Actions;
+        _bindingStore.ApplySlotOverride(actionPath, slot, path);
+    }
+
+    /// <summary>
+    /// Returns the control path assigned to a binding slot.
+    /// </summary>
+    internal string GetEffectiveBindingSlotPath(string actionPath, int slot)
+    {
+        _ = Actions;
+        return _bindingStore.GetEffectiveSlotPath(actionPath, slot);
+    }
+
+    /// <summary>
+    /// Checks whether a control name represents a modifier key.
+    /// </summary>
+    internal static bool IsModifierControlName(string controlName)
+    {
+        return KeyboardChordProcessor.IsModifierControlName(controlName);
     }
 }

--- a/Assets/Scripts/Managers/KeyboardChordProcessor.cs
+++ b/Assets/Scripts/Managers/KeyboardChordProcessor.cs
@@ -1,0 +1,114 @@
+using System;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+
+/// <summary>
+/// Handles modifier keys for keyboard bindings.
+/// </summary>
+internal sealed class KeyboardChordProcessor : InputProcessor<float>
+{
+    internal const int Shift = 1 << 0;
+    internal const int Control = 1 << 1;
+    internal const int Alt = 1 << 2;
+    internal const int Meta = 1 << 3;
+
+    private static bool _registered;
+
+    public int modifiers;
+
+    internal static void EnsureRegistered()
+    {
+        if (_registered)
+            return;
+
+        InputSystem.RegisterProcessor<KeyboardChordProcessor>("keyboardChord");
+        _registered = true;
+    }
+
+    public override float Process(float value, InputControl control)
+    {
+        return value != 0f && ArePressed(Keyboard.current, modifiers) ? value : 0f;
+    }
+
+    internal static int GetPressedModifiers(Keyboard keyboard)
+    {
+        if (keyboard == null)
+            return 0;
+
+        int result = 0;
+        if (keyboard.leftShiftKey.isPressed || keyboard.rightShiftKey.isPressed)
+            result |= Shift;
+        if (keyboard.leftCtrlKey.isPressed || keyboard.rightCtrlKey.isPressed)
+            result |= Control;
+        if (keyboard.leftAltKey.isPressed || keyboard.rightAltKey.isPressed)
+            result |= Alt;
+        if (keyboard.leftMetaKey.isPressed || keyboard.rightMetaKey.isPressed)
+            result |= Meta;
+        return result;
+    }
+
+    internal static bool IsModifier(InputControl control)
+    {
+        if (control?.device is not Keyboard)
+            return false;
+
+        if (control is KeyControl key)
+        {
+            return key.keyCode
+                is Key.LeftShift
+                    or Key.RightShift
+                    or Key.LeftCtrl
+                    or Key.RightCtrl
+                    or Key.LeftAlt
+                    or Key.RightAlt
+                    or Key.LeftMeta
+                    or Key.RightMeta;
+        }
+
+        return IsModifierControlName(control.name);
+    }
+
+    internal static bool IsModifierControlName(string controlName)
+    {
+        return controlName is "ctrl" or "shift" or "alt" or "leftMeta" or "rightMeta";
+    }
+
+    internal static string GetProcessorOverride(int modifierMask)
+    {
+        return modifierMask == 0 ? string.Empty : $"keyboardChord(modifiers={modifierMask})";
+    }
+
+    internal static string GetDisplayPrefix(int modifierMask)
+    {
+        string result = string.Empty;
+        if ((modifierMask & Control) != 0)
+            result += "CTRL+";
+        if ((modifierMask & Shift) != 0)
+            result += "SHIFT+";
+        if ((modifierMask & Alt) != 0)
+            result += "ALT+";
+        if ((modifierMask & Meta) != 0)
+            result += "META+";
+        return result;
+    }
+
+    internal static int ParseModifierMask(string processors)
+    {
+        const string marker = "keyboardChord(modifiers=";
+        int start = processors?.IndexOf(marker, StringComparison.OrdinalIgnoreCase) ?? -1;
+        if (start < 0)
+            return 0;
+
+        start += marker.Length;
+        int end = processors.IndexOf(')', start);
+        return end > start && int.TryParse(processors.Substring(start, end - start), out int mask)
+            ? mask
+            : 0;
+    }
+
+    private static bool ArePressed(Keyboard keyboard, int required)
+    {
+        return required == 0
+            || keyboard != null && (GetPressedModifiers(keyboard) & required) == required;
+    }
+}

--- a/Assets/Scripts/Managers/SaveGameManager.cs
+++ b/Assets/Scripts/Managers/SaveGameManager.cs
@@ -30,6 +30,7 @@ public sealed class SaveGameEntry
 /// </summary>
 public class SaveGameManager
 {
+    public const int MaxDisplayNameLength = 64;
     public const string QuickSaveFileName = "quicksave";
     private const int _saveSlotCount = 6;
     private const string _quickSaveDisplayName = "Quicksave";
@@ -198,6 +199,43 @@ public class SaveGameManager
     }
 
     /// <summary>
+    /// Deletes a save file and its metadata sidecar, if present.
+    /// </summary>
+    /// <param name="fileName">The save file name without its extension.</param>
+    public void DeleteSave(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return;
+
+        string savePath = GetSaveFilePath(fileName);
+        if (File.Exists(savePath))
+            File.Delete(savePath);
+
+        string metadataPath = GetSaveMetadataFilePath(fileName);
+        if (File.Exists(metadataPath))
+            File.Delete(metadataPath);
+    }
+
+    /// <summary>
+    /// Renames a save's stored display name, rewriting its metadata sidecar.
+    /// </summary>
+    /// <param name="fileName">The save file name without its extension.</param>
+    /// <param name="displayName">The new display name.</param>
+    public void SetSaveDisplayName(string fileName, string displayName)
+    {
+        string normalizedDisplayName = NormalizeDisplayName(displayName);
+        if (string.IsNullOrWhiteSpace(fileName) || normalizedDisplayName.Length == 0)
+            return;
+
+        SaveGameEntry entry = TryReadSaveEntry(fileName);
+        if (entry?.Metadata == null)
+            return;
+
+        entry.Metadata.SaveDisplayName = normalizedDisplayName;
+        TryWriteSaveMetadata(fileName, entry.Metadata);
+    }
+
+    /// <summary>
     /// Save game data to file using XML serialization.
     /// Stamps the current schema version and save timestamp onto the metadata.
     /// </summary>
@@ -223,8 +261,9 @@ public class SaveGameManager
         game.Metadata.PackID = game.Summary?.PackID;
         game.Metadata.PackVersion = game.Summary?.PackVersion;
         game.Metadata.ScenarioID = game.Summary?.ScenarioID;
-        if (!string.IsNullOrEmpty(displayName))
-            game.Metadata.SaveDisplayName = displayName;
+        string normalizedDisplayName = NormalizeDisplayName(displayName);
+        if (normalizedDisplayName.Length > 0)
+            game.Metadata.SaveDisplayName = normalizedDisplayName;
         else if (fileName == QuickSaveFileName)
             game.Metadata.SaveDisplayName = _quickSaveDisplayName;
 
@@ -303,6 +342,22 @@ public class SaveGameManager
             ? GetSaveSlotDisplayName(slot)
             : displayName.Trim();
         SaveGameData(game, GetSaveSlotFileName(slot), resolvedDisplayName);
+    }
+
+    /// <summary>
+    /// Trims a save display name and constrains it to the supported length.
+    /// </summary>
+    /// <param name="displayName">The display name to normalize.</param>
+    /// <returns>The normalized display name, or an empty string when no name was supplied.</returns>
+    public static string NormalizeDisplayName(string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+            return string.Empty;
+
+        string normalized = displayName.Trim();
+        return normalized.Length <= MaxDisplayNameLength
+            ? normalized
+            : normalized.Substring(0, MaxDisplayNameLength).TrimEnd();
     }
 
     /// <summary>

--- a/Assets/Scripts/Managers/UserSettingsManager.cs
+++ b/Assets/Scripts/Managers/UserSettingsManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
@@ -11,6 +12,7 @@ public sealed class UserSettingsManager
 
     private readonly AudioManager _audioManager;
     private readonly InputManager _inputManager;
+    private readonly string _settingsFilePathOverride;
 
     /// <summary>
     /// Gets the active user settings.
@@ -23,9 +25,23 @@ public sealed class UserSettingsManager
     /// <param name="audioManager">The audio manager that receives audio settings.</param>
     /// <param name="inputManager">The input manager that receives binding overrides.</param>
     public UserSettingsManager(AudioManager audioManager, InputManager inputManager)
+        : this(audioManager, inputManager, null) { }
+
+    /// <summary>
+    /// Creates a user settings manager that uses the given file path.
+    /// </summary>
+    /// <param name="audioManager">The audio manager that receives audio settings.</param>
+    /// <param name="inputManager">The input manager that receives binding overrides.</param>
+    /// <param name="settingsFilePath">The exact settings file path.</param>
+    internal UserSettingsManager(
+        AudioManager audioManager,
+        InputManager inputManager,
+        string settingsFilePath
+    )
     {
         _audioManager = audioManager;
         _inputManager = inputManager;
+        _settingsFilePathOverride = settingsFilePath;
     }
 
     /// <summary>
@@ -34,7 +50,8 @@ public sealed class UserSettingsManager
     /// <returns>The absolute user settings file path.</returns>
     public string GetSettingsFilePath()
     {
-        return Path.Combine(Application.persistentDataPath, _settingsFileName);
+        return _settingsFilePathOverride
+            ?? Path.Combine(Application.persistentDataPath, _settingsFileName);
     }
 
     /// <summary>
@@ -108,7 +125,12 @@ public sealed class UserSettingsManager
 
         string path = GetSettingsFilePath();
         Directory.CreateDirectory(Path.GetDirectoryName(path));
-        File.WriteAllText(path, JsonUtility.ToJson(settings, true));
+        string temporaryPath = path + ".tmp";
+        File.WriteAllText(temporaryPath, JsonUtility.ToJson(settings, true));
+        if (File.Exists(path))
+            File.Replace(temporaryPath, path, null);
+        else
+            File.Move(temporaryPath, path);
     }
 
     /// <summary>
@@ -126,19 +148,26 @@ public sealed class UserSettingsManager
     }
 
     /// <summary>
-    /// Applies the saved display mode once during startup. Zero dimensions select the
-    /// current display's native resolution.
+    /// Applies the saved display settings when the game starts.
     /// </summary>
     /// <param name="video">The normalized video settings.</param>
     private static void ApplyVideoSettings(UserVideoSettings video)
     {
+        List<Vector2Int> supported = DisplayResolutionPolicy.GetSupportedResolutions();
+        Vector2Int resolution = DisplayResolutionPolicy.Resolve(
+            supported,
+            video.ResolutionWidth,
+            video.ResolutionHeight,
+            Display.main.systemWidth,
+            Display.main.systemHeight
+        );
+        video.ResolutionWidth = resolution.x;
+        video.ResolutionHeight = resolution.y;
+
         if (Application.isEditor)
             return;
 
-        int width = video.ResolutionWidth > 0 ? video.ResolutionWidth : Display.main.systemWidth;
-        int height =
-            video.ResolutionHeight > 0 ? video.ResolutionHeight : Display.main.systemHeight;
-        Screen.SetResolution(width, height, (FullScreenMode)video.FullScreenMode);
+        Screen.SetResolution(resolution.x, resolution.y, (FullScreenMode)video.FullScreenMode);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/Boot/BootController.cs
+++ b/Assets/Scripts/UI/SceneUI/Boot/BootController.cs
@@ -44,7 +44,7 @@ public sealed class BootController : MonoBehaviour
     {
         if (currentVideoIndex >= _bootVideoPaths.Length)
         {
-            AppBootstrap.Instance.LoadScene(SaveMenuLaunchContext.MainMenuSceneName);
+            AppBootstrap.Instance.LoadScene(SceneNames.MainMenu);
             return;
         }
 

--- a/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
@@ -15,11 +15,16 @@ public sealed class MainMenuController : MonoBehaviour
     private MainMenuView view;
 
     [SerializeField]
+    private OptionsMenuView _optionsMenuPrefab;
+
+    [SerializeField]
     [Min(0f)]
     private float creditsMusicFadeDuration = 0.5f;
 
     private GameVictoryCondition currentVictoryCondition;
     private Canvas mainMenuCanvas;
+    private MainMenuOptionsHost _optionsHost;
+    private GameRuntime _settingsRuntime;
 
     /// <summary>
     /// Resets launch state and renders the authored initial selections.
@@ -57,6 +62,8 @@ public sealed class MainMenuController : MonoBehaviour
         if (view == null)
             return;
 
+        AppBootstrap.EnsureExists().GetInputController()?.SetContext(InputContext.Menu);
+
         view.GalaxySizeSelected += SelectGalaxySize;
         view.DifficultySelected += SelectGameDifficulty;
         view.StartGameRequested += HandleStartGameRequested;
@@ -65,6 +72,11 @@ public sealed class MainMenuController : MonoBehaviour
         view.ExitRequested += ExitApplication;
         view.CreditsRequested += ShowCredits;
         view.AudioCueRequested += PlayAudioCue;
+
+        // Options Menu.
+        _settingsRuntime = AppBootstrap.EnsureExists().GetRuntime();
+        if (_settingsRuntime != null)
+            _settingsRuntime.ToggleSettingsMenuRequested += HandleToggleSettingsMenu;
     }
 
     /// <summary>
@@ -119,6 +131,28 @@ public sealed class MainMenuController : MonoBehaviour
         view.ExitRequested -= ExitApplication;
         view.CreditsRequested -= ShowCredits;
         view.AudioCueRequested -= PlayAudioCue;
+
+        if (_settingsRuntime != null)
+            _settingsRuntime.ToggleSettingsMenuRequested -= HandleToggleSettingsMenu;
+    }
+
+    /// <summary>
+    /// Destroys the Options menu.
+    /// </summary>
+    private void OnDestroy()
+    {
+        _optionsHost?.Dispose();
+        _optionsHost = null;
+    }
+
+    /// <summary>
+    /// Opens the Options menu from its keyboard shortcut.
+    /// </summary>
+    private void HandleToggleSettingsMenu()
+    {
+        EnsureOptionsHost();
+        if (_optionsHost?.IsOpen == false)
+            _optionsHost.Open();
     }
 
     /// <summary>
@@ -200,12 +234,51 @@ public sealed class MainMenuController : MonoBehaviour
     }
 
     /// <summary>
-    /// Opens the save-menu scene in load mode.
+    /// Opens the Options menu.
     /// </summary>
     private void OpenLoadGameMenu()
     {
-        SaveMenuLaunchContext.OpenFromMainMenu();
-        AppBootstrap.Instance.LoadScene(SaveMenuLaunchContext.SaveMenuSceneName);
+        EnsureOptionsHost();
+        _optionsHost?.Open();
+    }
+
+    /// <summary>
+    /// Updates the Options menu.
+    /// </summary>
+    private void Update()
+    {
+        _optionsHost?.Tick();
+    }
+
+    /// <summary>
+    /// Creates the Options menu when it is first opened.
+    /// </summary>
+    private void EnsureOptionsHost()
+    {
+        if (_optionsHost != null)
+            return;
+        if (_optionsMenuPrefab == null)
+        {
+            Debug.LogWarning(
+                "MainMenu options prefab is not assigned; run Build Main Menu UI to wire it."
+            );
+            return;
+        }
+
+        AppBootstrap bootstrap = AppBootstrap.EnsureExists();
+        FactionThemeLibrary themeLibrary = new FactionThemeLibrary(
+            bootstrap.GetContentPack().GameData.FactionThemes
+        );
+        _optionsHost = new MainMenuOptionsHost(
+            mainMenuCanvas.transform,
+            _optionsMenuPrefab,
+            bootstrap.GetContentAssets(),
+            themeLibrary,
+            bootstrap.GetUserSettingsManager(),
+            AudioManager.EnsureExists(),
+            bootstrap.GetInputManager(),
+            bootstrap.GetCancelStack()
+        );
     }
 
     /// <summary>
@@ -237,7 +310,10 @@ public sealed class MainMenuController : MonoBehaviour
         GameLaunchContext.SaveFileName = null;
         GameLaunchContext.PlayIntroCutscene = true;
 
+        // Start a new game session.
+        AppBootstrap.Instance.GetRuntime()?.EndGame();
+
         AudioManager.EnsureExists().StopMusic();
-        AppBootstrap.Instance.LoadScene(SaveMenuLaunchContext.StrategyViewSceneName);
+        AppBootstrap.Instance.LoadScene(SceneNames.StrategyView);
     }
 }

--- a/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuOptionsHost.cs
+++ b/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuOptionsHost.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Displays the Options menu from the Main Menu.
+/// </summary>
+public sealed class MainMenuOptionsHost : IOptionsMenuHostActions, IOptionsSaveStore, IDisposable
+{
+    // Source Resolution.
+    private const float _surfaceWidth = 853.33f;
+    private const float _surfaceHeight = 480f;
+
+    // Menu Controls.
+    private readonly OptionsMenuController _controller;
+    private readonly UIWindowManager _windowManager;
+    private readonly CancelStack _cancelStack;
+
+    // Content.
+    private readonly FactionThemeLibrary _themeLibrary;
+    private readonly ContentAssets _contentAssets;
+
+    // Menu Objects.
+    private readonly Vector2Int _windowSize;
+    private readonly GameObject _canvasObject;
+    private readonly GameObject _dimmerObject;
+
+    // Menu State.
+    private bool _dirty;
+
+    /// <summary>
+    /// Builds the overlay canvas and controller under the supplied menu canvas.
+    /// </summary>
+    /// <param name="canvasParent">The Main Menu canvas transform.</param>
+    /// <param name="prefab">The authored Options overlay prefab.</param>
+    /// <param name="contentAssets">The active content asset source.</param>
+    /// <param name="themeLibrary">The faction-theme source for save icons.</param>
+    /// <param name="userSettings">The user-settings store.</param>
+    /// <param name="audioManager">The audio manager for live volume changes.</param>
+    /// <param name="inputManager">The input manager exposing key bindings.</param>
+    /// <param name="cancelStack">The cancel stack so Escape closes the overlay.</param>
+    public MainMenuOptionsHost(
+        Transform canvasParent,
+        OptionsMenuView prefab,
+        ContentAssets contentAssets,
+        FactionThemeLibrary themeLibrary,
+        UserSettingsManager userSettings,
+        AudioManager audioManager,
+        InputManager inputManager,
+        CancelStack cancelStack
+    )
+    {
+        if (prefab == null)
+            throw new ArgumentNullException(nameof(prefab));
+        if (canvasParent == null)
+            throw new ArgumentNullException(nameof(canvasParent));
+
+        _contentAssets = contentAssets;
+        _themeLibrary = themeLibrary;
+        _cancelStack = cancelStack;
+
+        RectTransform prefabRect = (RectTransform)prefab.transform;
+        _windowSize = new Vector2Int(
+            Mathf.RoundToInt(prefabRect.sizeDelta.x),
+            Mathf.RoundToInt(prefabRect.sizeDelta.y)
+        );
+
+        // Options Menu Canvas.
+        _canvasObject = new GameObject(
+            "OptionsOverlayCanvas",
+            typeof(RectTransform),
+            typeof(Canvas),
+            typeof(CanvasScaler),
+            typeof(GraphicRaycaster)
+        );
+        Canvas canvas = _canvasObject.GetComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvas.sortingOrder = 1000;
+        CanvasScaler scaler = _canvasObject.GetComponent<CanvasScaler>();
+        scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+        scaler.referenceResolution = new Vector2(_surfaceWidth, _surfaceHeight);
+        scaler.screenMatchMode = CanvasScaler.ScreenMatchMode.Expand;
+
+        RectTransform modalLayer = new GameObject(
+            "ModalLayer",
+            typeof(RectTransform)
+        ).GetComponent<RectTransform>();
+        modalLayer.SetParent(_canvasObject.transform, false);
+        modalLayer.anchorMin = Vector2.zero;
+        modalLayer.anchorMax = Vector2.one;
+        modalLayer.offsetMin = Vector2.zero;
+        modalLayer.offsetMax = Vector2.zero;
+
+        // Background Dimmer.
+        _dimmerObject = new GameObject(
+            "Dimmer",
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image)
+        );
+        RectTransform dimmer = _dimmerObject.GetComponent<RectTransform>();
+        dimmer.SetParent(canvasParent, false);
+        dimmer.anchorMin = Vector2.zero;
+        dimmer.anchorMax = Vector2.one;
+        dimmer.offsetMin = Vector2.zero;
+        dimmer.offsetMax = Vector2.zero;
+        dimmer.SetAsLastSibling();
+        Image dimmerImage = _dimmerObject.GetComponent<Image>();
+        dimmerImage.color = new Color(0f, 0f, 0f, 0.8f);
+        dimmerImage.raycastTarget = true;
+        _dimmerObject.SetActive(false);
+
+        _windowManager = _canvasObject.AddComponent<UIWindowManager>();
+        _windowManager.SetContentSource(contentAssets);
+
+        _controller = new OptionsMenuController(
+            prefab,
+            modalLayer,
+            _windowManager,
+            GetOverlayPosition,
+            _windowManager.DestroyWindow,
+            userSettings,
+            audioManager,
+            inputManager,
+            MarkDirty
+        );
+        _controller.Initialize(this, this);
+        cancelStack?.Register(_controller);
+    }
+
+    /// <summary>
+    /// Gets whether the overlay is currently open.
+    /// </summary>
+    public bool IsOpen => _controller.IsOpen;
+
+    /// <summary>
+    /// Opens the Options menu over the Main Menu.
+    /// </summary>
+    public void Open()
+    {
+        _controller.Open();
+        _dimmerObject.SetActive(_controller.IsOpen);
+        _controller.RenderWindows();
+        _dirty = false;
+    }
+
+    /// <summary>
+    /// Updates the Options menu and background dimmer.
+    /// </summary>
+    public void Tick()
+    {
+        if (_dimmerObject.activeSelf != _controller.IsOpen)
+            _dimmerObject.SetActive(_controller.IsOpen);
+        if (!_dirty)
+            return;
+
+        _dirty = false;
+        _controller.RenderWindows();
+    }
+
+    /// <summary>
+    /// Destroys the Options menu objects.
+    /// </summary>
+    public void Dispose()
+    {
+        _cancelStack?.Unregister(_controller);
+        _controller.Dispose();
+        if (_dimmerObject != null)
+            UnityEngine.Object.Destroy(_dimmerObject);
+        if (_canvasObject != null)
+            UnityEngine.Object.Destroy(_canvasObject);
+    }
+
+    /// <summary>
+    /// Gets whether the Options menu can return to a running game.
+    /// </summary>
+    public bool CanReturnToGame => false;
+
+    /// <summary>
+    /// Gets whether the Options menu can return to the Main Menu.
+    /// </summary>
+    public bool CanReturnToMainMenu => false;
+
+    /// <summary>
+    /// Does nothing because there is no running game to pause.
+    /// </summary>
+    public void PauseForOptions() { }
+
+    /// <summary>
+    /// Does nothing because there is no running game to resume.
+    /// </summary>
+    public void ResumeFromOptions() { }
+
+    /// <summary>
+    /// Returns the existing save games.
+    /// </summary>
+    /// <returns>The existing saves, newest first.</returns>
+    public IReadOnlyList<OptionsSaveSlot> GetSaveSlots()
+    {
+        List<OptionsSaveSlot> rows = new List<OptionsSaveSlot>();
+        foreach (SaveGameEntry entry in SaveGameManager.Instance.GetSavedGames())
+        {
+            string name = string.IsNullOrEmpty(entry.Metadata?.SaveDisplayName)
+                ? entry.FileName
+                : entry.Metadata.SaveDisplayName;
+            string date =
+                entry.Metadata != null
+                    ? entry.Metadata.LastSavedUtc.ToLocalTime().ToString("g")
+                    : string.Empty;
+            rows.Add(
+                new OptionsSaveSlot(
+                    name,
+                    date,
+                    ResolveFactionIcon(entry.Metadata?.PlayerFactionID),
+                    false,
+                    entry.FileName
+                )
+            );
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Loads the selected save game.
+    /// </summary>
+    /// <param name="fileName">The save file to load.</param>
+    /// <returns>True when a game load started.</returns>
+    public bool LoadSave(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName))
+            return false;
+
+        GameRuntime runtime = AppBootstrap.Instance?.GetRuntime();
+        if (runtime == null)
+            return false;
+
+        // Start the saved game in a new session.
+        runtime.EndGame();
+        return runtime.LoadGame(fileName);
+    }
+
+    /// <summary>
+    /// Deletes a save game.
+    /// </summary>
+    /// <param name="fileName">The save file to delete.</param>
+    public void DeleteSave(string fileName)
+    {
+        SaveGameManager.Instance.DeleteSave(fileName);
+    }
+
+    /// <summary>
+    /// Renames a save game.
+    /// </summary>
+    /// <param name="fileName">The save file to rename.</param>
+    /// <param name="displayName">The new display name.</param>
+    public void RenameSave(string fileName, string displayName)
+    {
+        SaveGameManager.Instance.SetSaveDisplayName(fileName, displayName);
+    }
+
+    /// <summary>
+    /// Closes the Options menu.
+    /// </summary>
+    public void ReturnToMainMenu()
+    {
+        _controller.Close();
+    }
+
+    /// <summary>
+    /// Quits the game.
+    /// </summary>
+    public void QuitApplication()
+    {
+#if UNITY_EDITOR
+        UnityEditor.EditorApplication.isPlaying = false;
+#else
+        Application.Quit();
+#endif
+    }
+
+    /// <summary>
+    /// Centers the overlay window on the source-space surface.
+    /// </summary>
+    /// <returns>The source-space overlay position.</returns>
+    private Vector2Int GetOverlayPosition()
+    {
+        return new Vector2Int(
+            Mathf.RoundToInt(_surfaceWidth / 2f - _windowSize.x / 2f),
+            Mathf.RoundToInt(_surfaceHeight / 2f - _windowSize.y / 2f)
+        );
+    }
+
+    /// <summary>
+    /// Resolves a save's faction icon texture from its stored faction id.
+    /// </summary>
+    /// <param name="factionId">The saved faction id, or null.</param>
+    /// <returns>The faction icon texture, or null.</returns>
+    private Texture2D ResolveFactionIcon(string factionId)
+    {
+        if (string.IsNullOrEmpty(factionId) || _themeLibrary == null || _contentAssets == null)
+            return null;
+
+        string path = _themeLibrary.GetTheme(factionId)?.SaveMenuSlotIconImagePath;
+        return string.IsNullOrEmpty(path) ? null : _contentAssets.GetTexture(path);
+    }
+
+    /// <summary>
+    /// Re-renders the open overlay in response to a state change.
+    /// </summary>
+    private void MarkDirty()
+    {
+        _dirty = true;
+    }
+}

--- a/Assets/Scripts/UI/SceneUI/SaveMenu/Presentation/SaveMenuConfirmDialogView.cs
+++ b/Assets/Scripts/UI/SceneUI/SaveMenu/Presentation/SaveMenuConfirmDialogView.cs
@@ -95,12 +95,30 @@ public sealed class SaveMenuConfirmDialogView : MonoBehaviour, IContentInitializ
     {
         VerifyReferences();
         BindControls();
+        Image inputBlocker = transform.Find("InputBlocker")?.GetComponent<Image>();
+        if (inputBlocker != null)
+        {
+            StretchToDialog(inputBlocker.rectTransform);
+            inputBlocker.color = new Color(0f, 0f, 0f, 0.8f);
+        }
         backgroundImage.enabled = backgroundImage.texture != null;
         backgroundImage.raycastTarget = false;
         confirmButtonPressVisual.SetTextures(confirmButtonUpTexture, confirmButtonDownTexture);
         cancelButtonPressVisual.SetTextures(cancelButtonUpTexture, cancelButtonDownTexture);
         UILayout.SetTextContent(messageTextField, message ?? string.Empty, messageTextColor);
         gameObject.SetActive(true);
+    }
+
+    /// <summary>
+    /// Stretches the input blocker across the dialog.
+    /// </summary>
+    private static void StretchToDialog(RectTransform blocker)
+    {
+        blocker.anchorMin = Vector2.zero;
+        blocker.anchorMax = Vector2.one;
+        blocker.pivot = new Vector2(0.5f, 0.5f);
+        blocker.anchoredPosition = Vector2.zero;
+        blocker.sizeDelta = Vector2.zero;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/SaveMenu/Presentation/SaveMenuSlotRowView.cs
+++ b/Assets/Scripts/UI/SceneUI/SaveMenu/Presentation/SaveMenuSlotRowView.cs
@@ -81,12 +81,53 @@ public sealed class SaveMenuSlotRowView : MonoBehaviour, IContentInitializable
             throw new ArgumentNullException(nameof(data));
 
         VerifyReferences();
+        AlignNameInput();
         BindControls();
         bool slotChanged = slot != data.Slot;
         slot = data.Slot;
         RenderFaction(data.FactionIconTexture);
         RenderButtons(data.CanSave, data.CanLoad);
         RenderName(data.Label, data.CanSave, slotChanged);
+    }
+
+    /// <summary>
+    /// Aligns the save name and cursor in the input field.
+    /// </summary>
+    private void AlignNameInput()
+    {
+        if (nameInputField.textComponent is TextMeshProUGUI text)
+        {
+            text.alignment = TextAlignmentOptions.MidlineLeft;
+            StretchInputText(text.rectTransform);
+        }
+
+        if (nameInputField.placeholder is TextMeshProUGUI placeholder)
+        {
+            placeholder.alignment = TextAlignmentOptions.MidlineLeft;
+            StretchInputText(placeholder.rectTransform);
+        }
+
+        nameInputField.textViewport = nameInputField.transform as RectTransform;
+        nameInputField.customCaretColor = true;
+        nameInputField.caretColor = Color.white;
+        nameInputField.caretWidth = 2;
+        nameInputField.caretBlinkRate = 0.85f;
+        nameInputField.characterLimit = SaveGameManager.MaxDisplayNameLength;
+        nameInputField.onFocusSelectAll = false;
+        nameInputField.ForceLabelUpdate();
+    }
+
+    /// <summary>
+    /// Positions the save name inside the input field.
+    /// </summary>
+    /// <param name="rect">The label rectangle.</param>
+    private static void StretchInputText(RectTransform rect)
+    {
+        rect.anchorMin = Vector2.zero;
+        rect.anchorMax = Vector2.one;
+        rect.pivot = new Vector2(0.5f, 0.5f);
+        rect.offsetMin = new Vector2(2f, 0f);
+        rect.offsetMax = new Vector2(-2f, 0f);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyContextMenuRouter.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyContextMenuRouter.cs
@@ -76,6 +76,59 @@ public sealed class StrategyContextMenuRouter : ICancelable
     }
 
     /// <summary>
+    /// Runs a context menu action at the pointer position.
+    /// </summary>
+    /// <param name="eventData">The current pointer raycast.</param>
+    /// <param name="x">The source-space horizontal pointer position.</param>
+    /// <param name="y">The source-space vertical pointer position.</param>
+    /// <param name="action">The shortcut action.</param>
+    /// <returns>True when a provider accepted and executed the command.</returns>
+    public bool TryExecuteShortcut(
+        PointerEventData eventData,
+        int x,
+        int y,
+        StrategyMenuAction action
+    )
+    {
+        contextMenuController.Cancel();
+        contextMenuPresenter.Reset();
+
+        UIWindow window = windowManager.GetWindow(eventData);
+        if (window == null)
+            return false;
+
+        StrategyContextMenuProviderContext context = new StrategyContextMenuProviderContext(
+            window,
+            contextMenuPresenter.Layout,
+            eventData,
+            x,
+            y
+        );
+        foreach (IStrategyContextMenuProvider provider in providers)
+        {
+            if (!provider.TryCreateContextMenu(context, out ContextMenuRequest request, out _))
+                continue;
+
+            for (int index = 0; index < request.Commands.Count; index++)
+            {
+                if (
+                    request.Commands[index] is StrategyMenuCommand command
+                    && command.Action == action
+                    && command.Enabled
+                )
+                {
+                    contextMenuController.Open(request);
+                    return contextMenuController.TrySelectCommand(command);
+                }
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Completes a selection owned by the runtime context-menu controller.
     /// </summary>
     /// <param name="command">The selected semantic command.</param>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayController.cs
@@ -156,6 +156,18 @@ public sealed class GalacticInformationDisplayController : ICancelable
     }
 
     /// <summary>
+    /// Selects an information filter from a keyboard shortcut.
+    /// </summary>
+    /// <param name="mode">The selected filter mode.</param>
+    internal void SelectFilterFromShortcut(GalacticInformationFilterMode mode)
+    {
+        if (filterMode != mode)
+            playSfx(StrategyUISoundPaths.GalacticInformationControl);
+
+        SelectFilter(mode);
+    }
+
+    /// <summary>
     /// Opens one category submenu and clears competing hover state.
     /// </summary>
     /// <param name="categoryIndex">The requested category index.</param>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjector.cs
@@ -63,7 +63,9 @@ public sealed class GalaxyMapProjector
             ProjectActiveFilterLabel(
                 playerTheme?.GalacticInformationDisplay,
                 filter,
-                briefing?.Label
+                briefing == null ? null
+                    : string.IsNullOrWhiteSpace(briefing.Label) ? "Briefing"
+                    : briefing.Label
             ),
             clusters
         );

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsBindingEditor.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsBindingEditor.cs
@@ -1,0 +1,633 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Manages the controls list and keyboard rebinding.
+/// </summary>
+internal sealed class OptionsBindingEditor : IDisposable
+{
+    // Modifier Keys.
+    private static readonly string[] _modifierControlPaths =
+    {
+        "<Keyboard>/ctrl",
+        "<Keyboard>/shift",
+        "<Keyboard>/alt",
+        "<Keyboard>/leftCtrl",
+        "<Keyboard>/rightCtrl",
+        "<Keyboard>/leftShift",
+        "<Keyboard>/rightShift",
+        "<Keyboard>/leftAlt",
+        "<Keyboard>/rightAlt",
+        "<Keyboard>/leftMeta",
+        "<Keyboard>/rightMeta",
+    };
+
+    // Binding List.
+    private readonly InputManager _inputManager;
+    private readonly List<OptionsBindingRow> _rows = new List<OptionsBindingRow>();
+    private readonly List<(InputAction action, int primary, int secondary)> _targets =
+        new List<(InputAction, int, int)>();
+    private readonly Dictionary<InputAction, bool> _suppressedActionStates =
+        new Dictionary<InputAction, bool>();
+
+    // Rebinding State.
+    private InputActionRebindingExtensions.RebindingOperation _operation;
+    private InputAction _listeningAction;
+    private InputAction _reboundAction;
+    private InputBinding[] _previousActionOverrides;
+    private bool _reboundActionWasEnabled;
+    private bool _rebindApplied;
+    private int _capturedModifiers;
+
+    // Binding Conflict.
+    private InputAction _conflictOldAction;
+    private int _conflictOldIndex;
+    private InputAction _conflictNewAction;
+    private int _conflictNewIndex;
+
+    internal event Action Changed;
+
+    internal event Action<string> ConflictRequested;
+
+    internal event Action PresentationChanged;
+
+    internal OptionsBindingEditor(InputManager inputManager)
+    {
+        _inputManager = inputManager ?? throw new ArgumentNullException(nameof(inputManager));
+    }
+
+    internal IReadOnlyList<OptionsBindingRow> Rows => _rows;
+
+    internal int ListeningRow { get; private set; } = -1;
+
+    internal bool ListeningSecondary { get; private set; }
+
+    internal bool HasPendingConflict => _conflictNewAction != null;
+
+    internal void Rebuild()
+    {
+        _rows.Clear();
+        _targets.Clear();
+        foreach (InputActionMap map in _inputManager.Asset.actionMaps)
+        {
+            if (!IsBindableMap(map.name))
+                continue;
+
+            List<OptionsBindingRow> mapRows = new List<OptionsBindingRow>();
+            List<(InputAction, int, int)> mapTargets = new List<(InputAction, int, int)>();
+            foreach (InputAction action in map.actions)
+            {
+                if (!IsBindableAction(action.name))
+                    continue;
+
+                (int primary, int secondary) = GetTopLevelBindingIndices(action);
+                (string primaryKey, string secondaryKey) = FormatKeys(action);
+                mapRows.Add(new OptionsBindingRow(Humanize(action.name), primaryKey, secondaryKey));
+                mapTargets.Add((action, primary, secondary));
+            }
+
+            if (mapRows.Count == 0)
+                continue;
+
+            _rows.Add(new OptionsBindingRow(Humanize(map.name), string.Empty, string.Empty, true));
+            _targets.Add((null, -1, -1));
+            _rows.AddRange(mapRows);
+            _targets.AddRange(mapTargets);
+        }
+    }
+
+    internal void BeginRebind(int row, bool secondary)
+    {
+        if (_operation != null || HasPendingConflict || row < 0 || row >= _targets.Count)
+            return;
+
+        (InputAction action, int primary, int secondaryIndex) = _targets[row];
+        if (action == null)
+            return;
+
+        int bindingIndex = secondary ? secondaryIndex : primary;
+        if (bindingIndex < 0)
+            throw new InvalidOperationException(
+                $"Bindable action '{action}' has no authored slot."
+            );
+
+        ListeningRow = row;
+        ListeningSecondary = secondary;
+        _previousActionOverrides = CaptureOverrides(action);
+        PresentationChanged?.Invoke();
+        StartRebind(action, bindingIndex);
+    }
+
+    internal void ResolveConflict(bool clearOld)
+    {
+        if (!HasPendingConflict)
+            return;
+
+        if (clearOld)
+        {
+            UnbindTopLevel(_conflictOldAction, _conflictOldIndex);
+            Changed?.Invoke();
+        }
+        else
+        {
+            RestoreOverrides(_conflictNewAction, _previousActionOverrides);
+        }
+
+        ClearConflict();
+        Rebuild();
+        PresentationChanged?.Invoke();
+    }
+
+    internal void SetTextEntryActive(bool active)
+    {
+        InputActionAsset asset = _inputManager.Asset;
+        if (active)
+        {
+            if (_suppressedActionStates.Count > 0)
+                return;
+
+            foreach (InputActionMap map in asset.actionMaps)
+            {
+                if (!IsBindableMap(map.name))
+                    continue;
+                foreach (InputAction action in map.actions)
+                {
+                    if (!IsBindableAction(action.name))
+                        continue;
+                    _suppressedActionStates[action] = action.enabled;
+                    action.Disable();
+                }
+            }
+            return;
+        }
+
+        foreach (KeyValuePair<InputAction, bool> entry in _suppressedActionStates)
+        {
+            if (entry.Key != null && entry.Value)
+                entry.Key.Enable();
+        }
+        _suppressedActionStates.Clear();
+    }
+
+    internal void CancelRebind()
+    {
+        _operation?.Cancel();
+    }
+
+    public void Dispose()
+    {
+        _operation?.Dispose();
+        _operation = null;
+        _listeningAction?.Dispose();
+        _listeningAction = null;
+        RestoreReboundActionState();
+        SetTextEntryActive(false);
+        ClearConflict();
+    }
+
+    private void StartRebind(InputAction action, int bindingIndex)
+    {
+        KeyboardChordProcessor.EnsureRegistered();
+        _capturedModifiers = 0;
+        _rebindApplied = false;
+        _reboundAction = action;
+        _reboundActionWasEnabled = action.enabled;
+        action.Disable();
+
+        bool isComposite = action.bindings[bindingIndex].isComposite;
+        InputAction rebindSource = action;
+        if (isComposite)
+        {
+            // Listen for both parts of a modifier key binding.
+            _listeningAction = new InputAction(type: InputActionType.Button);
+            rebindSource = _listeningAction;
+        }
+
+        InputActionRebindingExtensions.RebindingOperation candidate = (
+            isComposite
+                ? rebindSource.PerformInteractiveRebinding()
+                : rebindSource.PerformInteractiveRebinding(bindingIndex)
+        )
+            .WithCancelingThrough("<Keyboard>/escape")
+            .WithControlsExcluding("<Mouse>")
+            .WithControlsExcluding("<Keyboard>/anyKey");
+        if (!IsModifierAction(action.name))
+        {
+            foreach (string path in _modifierControlPaths)
+                candidate.WithControlsExcluding(path);
+        }
+
+        _operation = candidate
+            .OnPotentialMatch(match => HandlePotentialMatch(match, action))
+            .OnApplyBinding((_, path) => ApplyRebindPath(action, bindingIndex, path))
+            .OnCancel(_ => FinishRebind(action, bindingIndex, false))
+            .OnComplete(_ => FinishRebind(action, bindingIndex, true))
+            .Start();
+    }
+
+    private static void HandlePotentialMatch(
+        InputActionRebindingExtensions.RebindingOperation candidate,
+        InputAction action
+    )
+    {
+        InputControl control = candidate.selectedControl;
+        if (!IsModifierAction(action?.name))
+        {
+            while (KeyboardChordProcessor.IsModifier(control))
+            {
+                candidate.RemoveCandidate(control);
+                control = candidate.selectedControl;
+            }
+
+            if (control == null)
+                return;
+        }
+
+        candidate.Complete();
+    }
+
+    private void ApplyRebindPath(InputAction action, int bindingIndex, string path)
+    {
+        InputControl selectedControl = _operation?.selectedControl;
+        _capturedModifiers = KeyboardChordProcessor.IsModifier(selectedControl)
+            ? 0
+            : KeyboardChordProcessor.GetPressedModifiers(Keyboard.current);
+
+        if (action.bindings[bindingIndex].isComposite)
+        {
+            _rebindApplied = TryApplyCompositeChord(action, bindingIndex, path);
+            if (!_rebindApplied)
+                RestoreOverrides(action, _previousActionOverrides);
+            return;
+        }
+
+        action.ApplyBindingOverride(
+            bindingIndex,
+            new InputBinding
+            {
+                overridePath = path,
+                overrideProcessors = KeyboardChordProcessor.GetProcessorOverride(
+                    _capturedModifiers
+                ),
+            }
+        );
+        _rebindApplied = true;
+    }
+
+    private bool TryApplyCompositeChord(InputAction action, int compositeIndex, string buttonPath)
+    {
+        string modifierPath = GetSingleModifierPath(_capturedModifiers);
+        if (string.IsNullOrEmpty(modifierPath))
+            return false;
+
+        int modifierIndex = -1;
+        int buttonIndex = -1;
+        for (int index = compositeIndex + 1; index < action.bindings.Count; index++)
+        {
+            InputBinding part = action.bindings[index];
+            if (!part.isPartOfComposite)
+                break;
+            if (string.Equals(part.name, "Modifier", StringComparison.OrdinalIgnoreCase))
+                modifierIndex = index;
+            else if (string.Equals(part.name, "Button", StringComparison.OrdinalIgnoreCase))
+                buttonIndex = index;
+        }
+
+        if (modifierIndex < 0 || buttonIndex < 0)
+            return false;
+
+        action.ApplyBindingOverride(modifierIndex, modifierPath);
+        action.ApplyBindingOverride(buttonIndex, buttonPath);
+        return true;
+    }
+
+    private void FinishRebind(InputAction action, int bindingIndex, bool completed)
+    {
+        _operation?.Dispose();
+        _operation = null;
+        _listeningAction?.Dispose();
+        _listeningAction = null;
+        RestoreReboundActionState();
+        ListeningRow = -1;
+        ListeningSecondary = false;
+
+        if (!completed || !_rebindApplied)
+        {
+            RestoreOverrides(action, _previousActionOverrides);
+            _previousActionOverrides = null;
+            Rebuild();
+            PresentationChanged?.Invoke();
+            return;
+        }
+
+        (InputAction other, int otherIndex) = FindConflict(action, bindingIndex);
+        if (other != null)
+        {
+            _conflictOldAction = other;
+            _conflictOldIndex = otherIndex;
+            _conflictNewAction = action;
+            _conflictNewIndex = bindingIndex;
+            ConflictRequested?.Invoke(
+                $"That input is already bound to \"{Humanize(other.name)}\". Move it here and clear the old binding?"
+            );
+            return;
+        }
+
+        Changed?.Invoke();
+        _previousActionOverrides = null;
+        Rebuild();
+        PresentationChanged?.Invoke();
+    }
+
+    private (InputAction action, int index) FindConflict(InputAction rebound, int reboundIndex)
+    {
+        string signature = GetBindingSignature(rebound, reboundIndex);
+        if (string.IsNullOrEmpty(signature))
+            return (null, -1);
+
+        foreach (InputActionMap map in _inputManager.Asset.actionMaps)
+        {
+            if (!IsBindableMap(map.name))
+                continue;
+            foreach (InputAction action in map.actions)
+            {
+                for (int index = 0; index < action.bindings.Count; index++)
+                {
+                    if (action.bindings[index].isPartOfComposite)
+                        continue;
+                    if (action == rebound && index == reboundIndex)
+                        continue;
+                    if (
+                        string.Equals(
+                            GetBindingSignature(action, index),
+                            signature,
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    )
+                        return (action, index);
+                }
+            }
+        }
+
+        return (null, -1);
+    }
+
+    private static InputBinding[] CaptureOverrides(InputAction action)
+    {
+        InputBinding[] result = new InputBinding[action.bindings.Count];
+        for (int index = 0; index < action.bindings.Count; index++)
+        {
+            InputBinding binding = action.bindings[index];
+            result[index] = new InputBinding
+            {
+                overridePath = binding.overridePath,
+                overrideInteractions = binding.overrideInteractions,
+                overrideProcessors = binding.overrideProcessors,
+            };
+        }
+        return result;
+    }
+
+    private static void RestoreOverrides(InputAction action, IReadOnlyList<InputBinding> overrides)
+    {
+        if (action == null || overrides == null)
+            return;
+
+        action.RemoveAllBindingOverrides();
+        int count = Math.Min(action.bindings.Count, overrides.Count);
+        for (int index = 0; index < count; index++)
+        {
+            InputBinding binding = overrides[index];
+            if (
+                binding.overridePath != null
+                || binding.overrideInteractions != null
+                || binding.overrideProcessors != null
+            )
+                action.ApplyBindingOverride(index, binding);
+        }
+    }
+
+    private static void UnbindTopLevel(InputAction action, int index)
+    {
+        if (action == null || index < 0 || index >= action.bindings.Count)
+            return;
+
+        action.ApplyBindingOverride(index, string.Empty);
+        if (!action.bindings[index].isComposite)
+            return;
+
+        for (int partIndex = index + 1; partIndex < action.bindings.Count; partIndex++)
+        {
+            if (!action.bindings[partIndex].isPartOfComposite)
+                break;
+            action.ApplyBindingOverride(partIndex, string.Empty);
+        }
+    }
+
+    private void ClearConflict()
+    {
+        _conflictOldAction = null;
+        _conflictNewAction = null;
+        _conflictOldIndex = -1;
+        _conflictNewIndex = -1;
+        _previousActionOverrides = null;
+    }
+
+    private void RestoreReboundActionState()
+    {
+        if (_reboundActionWasEnabled)
+            _reboundAction?.Enable();
+        _reboundAction = null;
+        _reboundActionWasEnabled = false;
+    }
+
+    internal static string GetBindingSignature(InputAction action, int bindingIndex)
+    {
+        InputBinding binding = action.bindings[bindingIndex];
+        if (binding.isComposite)
+        {
+            string modifierPath = null;
+            string buttonPath = null;
+            for (int index = bindingIndex + 1; index < action.bindings.Count; index++)
+            {
+                InputBinding part = action.bindings[index];
+                if (!part.isPartOfComposite)
+                    break;
+                if (string.Equals(part.name, "Modifier", StringComparison.OrdinalIgnoreCase))
+                    modifierPath = part.effectivePath;
+                else if (string.Equals(part.name, "Button", StringComparison.OrdinalIgnoreCase))
+                    buttonPath = part.effectivePath;
+            }
+            int modifierMask = GetModifierMask(modifierPath);
+            return modifierMask == 0 || string.IsNullOrEmpty(buttonPath)
+                ? string.Empty
+                : $"{buttonPath}|{modifierMask}";
+        }
+
+        if (string.IsNullOrEmpty(binding.effectivePath))
+            return string.Empty;
+        int modifiers = KeyboardChordProcessor.ParseModifierMask(binding.effectiveProcessors);
+        return $"{binding.effectivePath}|{modifiers}";
+    }
+
+    private static int GetModifierMask(string modifierPath)
+    {
+        if (string.IsNullOrEmpty(modifierPath))
+            return 0;
+        if (modifierPath.IndexOf("shift", StringComparison.OrdinalIgnoreCase) >= 0)
+            return KeyboardChordProcessor.Shift;
+        if (
+            modifierPath.IndexOf("ctrl", StringComparison.OrdinalIgnoreCase) >= 0
+            || modifierPath.IndexOf("control", StringComparison.OrdinalIgnoreCase) >= 0
+        )
+            return KeyboardChordProcessor.Control;
+        if (modifierPath.IndexOf("alt", StringComparison.OrdinalIgnoreCase) >= 0)
+            return KeyboardChordProcessor.Alt;
+        if (modifierPath.IndexOf("meta", StringComparison.OrdinalIgnoreCase) >= 0)
+            return KeyboardChordProcessor.Meta;
+        return 0;
+    }
+
+    private static string GetSingleModifierPath(int modifiers)
+    {
+        return modifiers switch
+        {
+            KeyboardChordProcessor.Shift => "<Keyboard>/shift",
+            KeyboardChordProcessor.Control => "<Keyboard>/ctrl",
+            KeyboardChordProcessor.Alt => "<Keyboard>/alt",
+            KeyboardChordProcessor.Meta => "<Keyboard>/leftMeta",
+            _ => null,
+        };
+    }
+
+    private static bool IsModifierAction(string actionName)
+    {
+        return actionName
+            is "MultiSelectModifier"
+                or "RangeSelectModifier"
+                or "AlternateSelectModifier";
+    }
+
+    private static (int primary, int secondary) GetTopLevelBindingIndices(InputAction action)
+    {
+        int primary = -1;
+        int secondary = -1;
+        for (int index = 0; index < action.bindings.Count; index++)
+        {
+            if (action.bindings[index].isPartOfComposite)
+                continue;
+            if (primary < 0)
+                primary = index;
+            else
+            {
+                secondary = index;
+                break;
+            }
+        }
+        return (primary, secondary);
+    }
+
+    private static bool IsBindableMap(string map)
+    {
+        return map is "Global" or "Strategy";
+    }
+
+    private static bool IsBindableAction(string action)
+    {
+        return action != "CancelOrSettings";
+    }
+
+    private static (string primary, string secondary) FormatKeys(InputAction action)
+    {
+        List<string> keys = new List<string>();
+        for (int index = 0; index < action.bindings.Count; index++)
+        {
+            InputBinding binding = action.bindings[index];
+            if (binding.isPartOfComposite)
+                continue;
+
+            string display = binding.isComposite
+                ? GetCompositeDisplayString(action, index)
+                : action.GetBindingDisplayString(index);
+            if (string.IsNullOrWhiteSpace(display) && string.IsNullOrEmpty(binding.effectivePath))
+                display = "UNBOUND";
+            int modifiers = binding.isComposite
+                ? 0
+                : KeyboardChordProcessor.ParseModifierMask(binding.effectiveProcessors);
+            keys.Add(KeyboardChordProcessor.GetDisplayPrefix(modifiers) + ShortenKey(display));
+            if (keys.Count == 2)
+                break;
+        }
+
+        return (keys.Count > 0 ? keys[0] : "UNBOUND", keys.Count > 1 ? keys[1] : "UNBOUND");
+    }
+
+    private static string GetCompositeDisplayString(InputAction action, int compositeIndex)
+    {
+        string modifier = null;
+        string button = null;
+        for (int index = compositeIndex + 1; index < action.bindings.Count; index++)
+        {
+            InputBinding part = action.bindings[index];
+            if (!part.isPartOfComposite)
+                break;
+
+            string display = string.IsNullOrEmpty(part.effectivePath)
+                ? string.Empty
+                : InputControlPath.ToHumanReadableString(
+                    part.effectivePath,
+                    InputControlPath.HumanReadableStringOptions.OmitDevice
+                );
+            if (string.Equals(part.name, "Modifier", StringComparison.OrdinalIgnoreCase))
+                modifier = display;
+            else if (string.Equals(part.name, "Button", StringComparison.OrdinalIgnoreCase))
+                button = display;
+        }
+
+        return string.IsNullOrEmpty(modifier) || string.IsNullOrEmpty(button)
+            ? string.Empty
+            : $"{ShortenKey(modifier)}+{ShortenKey(button)}";
+    }
+
+    private static string ShortenKey(string display)
+    {
+        if (string.IsNullOrWhiteSpace(display))
+            return "UNBOUND";
+        return display
+            .ToUpperInvariant()
+            .Replace("LEFT ", "L ")
+            .Replace("RIGHT ", "R ")
+            .Replace("CONTROL", "CTRL")
+            .Replace("DELETE", "DEL")
+            .Replace("INSERT", "INS")
+            .Replace("BACKSPACE", "BKSP")
+            .Replace("PAGE UP", "PG UP")
+            .Replace("PAGE DOWN", "PG DN")
+            .Replace("NUMPAD ", "NUM ");
+    }
+
+    private static string Humanize(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return string.Empty;
+
+        System.Text.StringBuilder builder = new System.Text.StringBuilder(name.Length + 8);
+        for (int index = 0; index < name.Length; index++)
+        {
+            char value = name[index];
+            char previous = index > 0 ? name[index - 1] : '\0';
+            bool boundary =
+                index > 0
+                && (
+                    (char.IsUpper(value) && !char.IsUpper(previous))
+                    || (char.IsDigit(value) && !char.IsDigit(previous))
+                    || (char.IsLetter(value) && char.IsDigit(previous))
+                );
+            if (boundary)
+                builder.Append(' ');
+            builder.Append(value);
+        }
+        return builder.ToString();
+    }
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuContracts.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuContracts.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+/// <summary>
+/// Defines the game actions used by the Options menu.
+/// </summary>
+public interface IOptionsMenuHostActions
+{
+    bool CanReturnToGame { get; }
+
+    bool CanReturnToMainMenu { get; }
+
+    void PauseForOptions();
+
+    void ResumeFromOptions();
+
+    void ReturnToMainMenu();
+
+    void QuitApplication();
+}
+
+/// <summary>
+/// Defines the save game actions used by the Options menu.
+/// </summary>
+public interface IOptionsSaveStore
+{
+    IReadOnlyList<OptionsSaveSlot> GetSaveSlots();
+
+    bool LoadSave(string fileName);
+
+    void DeleteSave(string fileName);
+
+    void RenameSave(string fileName, string displayName);
+}
+
+/// <summary>
+/// Defines the save writing actions used by the Options menu.
+/// </summary>
+public interface IOptionsSaveWriter
+{
+    void CreateNamedSave(string displayName);
+
+    void OverwriteSave(string fileName, string displayName);
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuController.cs
@@ -1,0 +1,724 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Manages the Options menu.
+/// </summary>
+public sealed class OptionsMenuController : ICancelable, IDisposable
+{
+    // Window.
+    private readonly OptionsMenuView _prefab;
+    private readonly Transform _windowParent;
+    private readonly UIWindowManager _windowManager;
+    private readonly Func<Vector2Int> _getWindowPosition;
+    private readonly Action<UIWindow> _closeWindow;
+    private readonly Action _markDirty;
+
+    // Settings.
+    private readonly OptionsSettingsSession _settingsSession;
+    private readonly OptionsBindingEditor _bindingEditor;
+
+    // Save Games.
+    private readonly List<OptionsSaveSlot> _saveSlots = new List<OptionsSaveSlot>();
+    private IOptionsSaveStore _saveStore;
+    private IOptionsSaveWriter _saveWriter;
+    private int _selectedSlot = -1;
+    private bool _saveSlotsLoaded;
+
+    // Menu State.
+    private IOptionsMenuHostActions _hostActions;
+    private Action _pendingConfirmAction;
+    private bool _pendingConfirmKeepsVisible;
+    private OptionsMenuView _view;
+    private UIWindow _window;
+    private OptionsMenuTab _activeTab = OptionsMenuTab.Graphics;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates an Options menu controller.
+    /// </summary>
+    /// <param name="prefab">The Options menu prefab.</param>
+    /// <param name="windowParent">The parent for the Options menu.</param>
+    /// <param name="windowManager">The window manager.</param>
+    /// <param name="getWindowPosition">Returns the Options menu position.</param>
+    /// <param name="closeWindow">Closes a registered window.</param>
+    /// <param name="userSettings">The user-settings store.</param>
+    /// <param name="audioManager">The audio manager.</param>
+    /// <param name="inputManager">The input manager.</param>
+    /// <param name="markDirty">Marks the menu data as changed.</param>
+    public OptionsMenuController(
+        OptionsMenuView prefab,
+        Transform windowParent,
+        UIWindowManager windowManager,
+        Func<Vector2Int> getWindowPosition,
+        Action<UIWindow> closeWindow,
+        UserSettingsManager userSettings,
+        AudioManager audioManager,
+        InputManager inputManager,
+        Action markDirty
+    )
+    {
+        _prefab = prefab;
+        _windowParent = windowParent ?? throw new ArgumentNullException(nameof(windowParent));
+        _windowManager = windowManager ?? throw new ArgumentNullException(nameof(windowManager));
+        _getWindowPosition =
+            getWindowPosition ?? throw new ArgumentNullException(nameof(getWindowPosition));
+        _closeWindow = closeWindow ?? throw new ArgumentNullException(nameof(closeWindow));
+        _markDirty = markDirty ?? throw new ArgumentNullException(nameof(markDirty));
+        InputManager bindings =
+            inputManager ?? throw new ArgumentNullException(nameof(inputManager));
+        _settingsSession = new OptionsSettingsSession(userSettings, audioManager, bindings);
+        _bindingEditor = new OptionsBindingEditor(bindings);
+        _bindingEditor.Changed += _settingsSession.MarkInputChanged;
+        _bindingEditor.PresentationChanged += _markDirty;
+        _bindingEditor.ConflictRequested += HandleBindingConflictRequested;
+    }
+
+    /// <summary>
+    /// Returns whether the Options menu is open.
+    /// </summary>
+    public bool IsOpen => _window != null;
+
+    /// <summary>
+    /// Sets the game and save actions used by the Options menu.
+    /// </summary>
+    /// <param name="menuActions">The game actions.</param>
+    /// <param name="optionsSaveStore">The save game actions.</param>
+    /// <param name="optionsSaveWriter">The save writing actions.</param>
+    public void Initialize(
+        IOptionsMenuHostActions menuActions,
+        IOptionsSaveStore optionsSaveStore,
+        IOptionsSaveWriter optionsSaveWriter = null
+    )
+    {
+        _hostActions = menuActions ?? throw new ArgumentNullException(nameof(menuActions));
+        _saveStore = optionsSaveStore ?? throw new ArgumentNullException(nameof(optionsSaveStore));
+        _saveWriter = optionsSaveWriter;
+    }
+
+    /// <summary>
+    /// Opens or focuses the Options menu.
+    /// </summary>
+    public void Open()
+    {
+        EnsureInitialized();
+        if (_window != null)
+        {
+            _windowManager.Focus(_window);
+            return;
+        }
+
+        if (_prefab == null)
+        {
+            Debug.LogWarning(
+                "OptionsMenu prefab is not assigned; run Build Options Menu UI to generate it."
+            );
+            return;
+        }
+
+        _settingsSession.Begin();
+        _bindingEditor.Rebuild();
+        _activeTab = OptionsMenuTab.Graphics;
+        _selectedSlot = -1;
+        _saveSlotsLoaded = false;
+
+        Vector2Int position = _getWindowPosition();
+        _window = _windowManager.CreateWindow(
+            _prefab,
+            _windowParent,
+            "OptionsMenu",
+            position.x,
+            position.y,
+            GetPrefabSize(),
+            true,
+            true,
+            false,
+            false,
+            out _view
+        );
+        BindView(_view);
+        _hostActions.PauseForOptions();
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Closes the Options menu.
+    /// </summary>
+    public void Close()
+    {
+        if (_window == null)
+            return;
+
+        _pendingConfirmAction = null;
+        _pendingConfirmKeepsVisible = false;
+        _bindingEditor.CancelRebind();
+        if (_bindingEditor.HasPendingConflict)
+            _bindingEditor.ResolveConflict(false);
+        _bindingEditor.SetTextEntryActive(false);
+        UIWindow closing = _window;
+        _window = null;
+        _view = null;
+        _hostActions.ResumeFromOptions();
+        _closeWindow(closing);
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Closes the Options menu and restores unapplied settings.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        if (_settingsSession.IsDirty)
+            _settingsSession.Revert();
+        Close();
+        _bindingEditor.Changed -= _settingsSession.MarkInputChanged;
+        _bindingEditor.PresentationChanged -= _markDirty;
+        _bindingEditor.ConflictRequested -= HandleBindingConflictRequested;
+        _bindingEditor.Dispose();
+        _disposed = true;
+    }
+
+    /// <summary>
+    /// Updates the open Options menu.
+    /// </summary>
+    public void RenderWindows()
+    {
+        if (_window == null || _view == null)
+            return;
+
+        _view.Render(BuildRenderData(_window));
+    }
+
+    /// <summary>
+    /// Closes the Options menu from a cancel request.
+    /// </summary>
+    /// <returns>True when the overlay was open and closed.</returns>
+    public bool TryCancel()
+    {
+        if (_window == null)
+            return false;
+
+        // Close the confirmation dialog first.
+        if (_pendingConfirmAction != null || _bindingEditor.HasPendingConflict)
+        {
+            HandleConfirmDeclined();
+            return true;
+        }
+
+        HandleBackToGame();
+        return true;
+    }
+
+    /// <summary>
+    /// Creates the data displayed by the Options menu.
+    /// </summary>
+    /// <param name="shell">The Options menu window.</param>
+    /// <returns>The Options menu data.</returns>
+    private OptionsMenuRenderData BuildRenderData(UIWindow shell)
+    {
+        return new OptionsMenuRenderData(
+            shell.X,
+            shell.Y,
+            _activeTab,
+            _settingsSession.ResolutionLabel,
+            _settingsSession.FullScreenLabel,
+            _settingsSession.GetTacticalStates(),
+            _settingsSession.GetVolumes(),
+            _bindingEditor.Rows,
+            _saveSlots,
+            _selectedSlot,
+            _saveWriter != null,
+            _saveStore != null,
+            _hostActions.CanReturnToGame,
+            _hostActions.CanReturnToMainMenu,
+            _bindingEditor.ListeningRow,
+            _bindingEditor.ListeningSecondary
+        );
+    }
+
+    /// <summary>
+    /// Adds the Options menu listeners.
+    /// </summary>
+    /// <param name="target">The view to bind.</param>
+    private void BindView(OptionsMenuView target)
+    {
+        target.TabSelected += HandleTabSelected;
+        target.ResumeRequested += HandleBackToGame;
+        target.SaveRequested += HandleSaveRequested;
+        target.LoadRequested += HandleLoadRequested;
+        target.SlotSelected += HandleSlotSelected;
+        target.SlotRenamed += HandleSlotRenamed;
+        target.SlotDeleteRequested += HandleSlotDeleteRequested;
+        target.RenameEditingChanged += HandleRenameEditingChanged;
+        target.ApplyRequested += HandleApply;
+        target.DefaultsRequested += HandleDefaults;
+        target.ConfirmAccepted += HandleConfirmAccepted;
+        target.ConfirmDeclined += HandleConfirmDeclined;
+        target.RebindRequested += HandleRebindRequested;
+        target.MainMenuRequested += HandleMainMenuRequested;
+        target.QuitRequested += HandleQuitRequested;
+        target.TacticalToggleRequested += HandleTacticalToggle;
+        target.ResolutionStepRequested += HandleResolutionStep;
+        target.FullScreenStepRequested += HandleFullScreenStep;
+        target.VolumeChanged += HandleVolumeChanged;
+        target.Destroyed += HandleViewDestroyed;
+    }
+
+    /// <summary>
+    /// Selects an Options menu page.
+    /// </summary>
+    /// <param name="tab">The selected page.</param>
+    private void HandleTabSelected(OptionsMenuTab tab)
+    {
+        if (tab == _activeTab)
+            return;
+
+        if (_settingsSession.IsDirty)
+        {
+            RequestConfirm(
+                "Discard unsaved changes?",
+                () =>
+                {
+                    _settingsSession.Revert();
+                    _bindingEditor.Rebuild();
+                    SwitchTab(tab);
+                }
+            );
+            return;
+        }
+
+        SwitchTab(tab);
+    }
+
+    /// <summary>
+    /// Activates a page and lazily loads its data.
+    /// </summary>
+    /// <param name="tab">The page to show.</param>
+    private void SwitchTab(OptionsMenuTab tab)
+    {
+        _activeTab = tab;
+        if (tab == OptionsMenuTab.SaveLoad && !_saveSlotsLoaded)
+        {
+            RefreshSaveSlots();
+            _saveSlotsLoaded = true;
+        }
+
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Selects a save game row.
+    /// </summary>
+    /// <param name="slot">The clicked row index.</param>
+    private void HandleSlotSelected(int slot)
+    {
+        if (slot < 0 || slot >= _saveSlots.Count)
+            return;
+
+        _selectedSlot = _saveSlots[slot].IsCreateNew ? -1 : slot;
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Saves a change to a save game name.
+    /// </summary>
+    /// <param name="slot">The edited row index.</param>
+    /// <param name="newName">The typed name.</param>
+    /// <param name="submitted">Whether Return submitted the edit.</param>
+    private void HandleSlotRenamed(int slot, string newName, bool submitted)
+    {
+        if (slot < 0 || slot >= _saveSlots.Count || string.IsNullOrWhiteSpace(newName))
+            return;
+
+        if (_saveSlots[slot].IsCreateNew)
+        {
+            _saveWriter?.CreateNamedSave(newName.Trim());
+            _selectedSlot = -1;
+        }
+        else
+        {
+            string displayName = newName.Trim();
+            string fileName = _saveSlots[slot].FileName;
+            if (submitted && _saveWriter != null)
+                _saveWriter.OverwriteSave(fileName, displayName);
+            else
+                _saveStore.RenameSave(fileName, displayName);
+            RefreshSaveSlots(fileName);
+            _markDirty();
+            return;
+        }
+
+        RefreshSaveSlots();
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Confirms and deletes an existing save.
+    /// </summary>
+    /// <param name="slot">The row index to delete.</param>
+    private void HandleSlotDeleteRequested(int slot)
+    {
+        if (slot < 0 || slot >= _saveSlots.Count || _saveSlots[slot].IsCreateNew)
+            return;
+
+        string fileName = _saveSlots[slot].FileName;
+        string label = _saveSlots[slot].Name;
+        RequestConfirm(
+            $"Delete \"{label}\"?",
+            () =>
+            {
+                _saveStore.DeleteSave(fileName);
+                _selectedSlot = -1;
+                RefreshSaveSlots();
+                _markDirty();
+            }
+        );
+    }
+
+    /// <summary>
+    /// Overwrites the selected existing save with the running game.
+    /// </summary>
+    private void HandleSaveRequested()
+    {
+        if (_saveWriter == null || !IsSelectedExistingSave())
+            return;
+
+        string fileName = _saveSlots[_selectedSlot].FileName;
+        _saveWriter.OverwriteSave(fileName, _saveSlots[_selectedSlot].Name);
+        RefreshSaveSlots(fileName);
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Loads the selected existing save, then closes the overlay on success.
+    /// </summary>
+    private void HandleLoadRequested()
+    {
+        if (_saveStore == null || !IsSelectedExistingSave())
+            return;
+
+        if (_saveStore.LoadSave(_saveSlots[_selectedSlot].FileName))
+            Close();
+    }
+
+    /// <summary>
+    /// Gets whether an existing save game is selected.
+    /// </summary>
+    /// <returns>True when an existing save is selected.</returns>
+    private bool IsSelectedExistingSave()
+    {
+        return _selectedSlot >= 0
+            && _selectedSlot < _saveSlots.Count
+            && !_saveSlots[_selectedSlot].IsCreateNew;
+    }
+
+    /// <summary>
+    /// Disables game shortcuts while a save name is being edited.
+    /// </summary>
+    /// <param name="editing">True while a text field is focused for editing.</param>
+    private void HandleRenameEditingChanged(bool editing)
+    {
+        _bindingEditor.SetTextEntryActive(editing);
+    }
+
+    /// <summary>
+    /// Rebuilds the cached save-slot list from the host.
+    /// </summary>
+    private void RefreshSaveSlots(string selectedFileName = null)
+    {
+        _saveSlots.Clear();
+        _saveSlots.AddRange(_saveStore.GetSaveSlots());
+        _selectedSlot = -1;
+        if (string.IsNullOrEmpty(selectedFileName))
+            return;
+
+        for (int index = 0; index < _saveSlots.Count; index++)
+        {
+            if (
+                string.Equals(
+                    _saveSlots[index].FileName,
+                    selectedFileName,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                _selectedSlot = index;
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Persists the currently previewed settings to disk.
+    /// </summary>
+    private void HandleApply()
+    {
+        _settingsSession.Commit();
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Confirms before restoring the current page to its default settings.
+    /// </summary>
+    private void HandleDefaults()
+    {
+        switch (_activeTab)
+        {
+            case OptionsMenuTab.Graphics:
+                RequestConfirm("Reset display settings to their defaults?", ApplyActiveDefaults);
+                break;
+            case OptionsMenuTab.Audio:
+                RequestConfirm("Reset volume to defaults?", ApplyActiveDefaults);
+                break;
+            case OptionsMenuTab.Controls:
+                RequestConfirm("Reset all key bindings to their defaults?", ApplyActiveDefaults);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Restores the default settings for the current page.
+    /// </summary>
+    private void ApplyActiveDefaults()
+    {
+        _settingsSession.RestoreDefaults(_activeTab);
+        _bindingEditor.Rebuild();
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Returns to the game after resolving any unsaved settings.
+    /// </summary>
+    private void HandleBackToGame()
+    {
+        if (!_settingsSession.IsDirty)
+        {
+            Close();
+            return;
+        }
+
+        RequestConfirm(
+            "Discard unsaved settings and return to the game?",
+            () =>
+            {
+                _settingsSession.Revert();
+                _bindingEditor.Rebuild();
+                Close();
+            }
+        );
+    }
+
+    /// <summary>
+    /// Confirms returning to the main menu, warning when settings are unsaved.
+    /// </summary>
+    private void HandleMainMenuRequested()
+    {
+        RequestConfirm(
+            _settingsSession.IsDirty
+                ? "Return to the Main Menu? Unsaved settings will be lost."
+                : "Return to the Main Menu?",
+            () => ExitWithoutSaving(_hostActions.ReturnToMainMenu),
+            true
+        );
+    }
+
+    /// <summary>
+    /// Confirms quitting to desktop, warning when settings are unsaved.
+    /// </summary>
+    private void HandleQuitRequested()
+    {
+        RequestConfirm(
+            _settingsSession.IsDirty
+                ? "Quit to desktop? Unsaved settings will be lost."
+                : "Quit to desktop?",
+            () => ExitWithoutSaving(_hostActions.QuitApplication),
+            true
+        );
+    }
+
+    private void ExitWithoutSaving(Action exit)
+    {
+        if (_settingsSession.IsDirty)
+            _settingsSession.Revert();
+        exit?.Invoke();
+    }
+
+    /// <summary>
+    /// Opens a confirmation dialog for an action.
+    /// </summary>
+    /// <param name="message">The prompt text.</param>
+    /// <param name="onConfirmed">The action to run on acceptance.</param>
+    /// <param name="keepVisibleWhileExecuting">Whether the prompt remains during a scene exit.</param>
+    private void RequestConfirm(
+        string message,
+        Action onConfirmed,
+        bool keepVisibleWhileExecuting = false
+    )
+    {
+        _pendingConfirmAction = onConfirmed;
+        _pendingConfirmKeepsVisible = keepVisibleWhileExecuting;
+        _view?.ShowConfirm(message);
+    }
+
+    /// <summary>
+    /// Runs and clears the pending confirmed action.
+    /// </summary>
+    private void HandleConfirmAccepted()
+    {
+        if (_bindingEditor.HasPendingConflict)
+        {
+            _view?.HideConfirm();
+            _bindingEditor.ResolveConflict(true);
+            return;
+        }
+
+        Action confirmed = _pendingConfirmAction;
+        bool keepVisible = _pendingConfirmKeepsVisible;
+        _pendingConfirmAction = null;
+        _pendingConfirmKeepsVisible = false;
+        if (!keepVisible)
+            _view?.HideConfirm();
+        confirmed?.Invoke();
+    }
+
+    /// <summary>
+    /// Dismisses the confirmation prompt without acting.
+    /// </summary>
+    private void HandleConfirmDeclined()
+    {
+        _view?.HideConfirm();
+        if (_bindingEditor.HasPendingConflict)
+        {
+            _bindingEditor.ResolveConflict(false);
+            return;
+        }
+
+        _pendingConfirmAction = null;
+        _pendingConfirmKeepsVisible = false;
+    }
+
+    /// <summary>
+    /// Starts changing a key binding.
+    /// </summary>
+    /// <param name="row">The binding row index.</param>
+    /// <param name="secondary">Whether the secondary column was clicked.</param>
+    private void HandleRebindRequested(int row, bool secondary)
+    {
+        _bindingEditor.BeginRebind(row, secondary);
+    }
+
+    private void HandleBindingConflictRequested(string message)
+    {
+        _view?.ShowConfirm(message);
+    }
+
+    /// <summary>
+    /// Toggles a detail option and marks settings dirty.
+    /// </summary>
+    /// <param name="option">The toggled option.</param>
+    private void HandleTacticalToggle(UserTacticalOption option)
+    {
+        _settingsSession.ToggleTactical(option);
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Steps the selected resolution and applies it immediately.
+    /// </summary>
+    /// <param name="delta">The step direction.</param>
+    private void HandleResolutionStep(int delta)
+    {
+        _settingsSession.StepResolution(delta);
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Steps the display mode and applies it immediately.
+    /// </summary>
+    /// <param name="delta">The step direction.</param>
+    private void HandleFullScreenStep(int delta)
+    {
+        _settingsSession.StepFullScreen(delta);
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Applies a live volume change for one channel.
+    /// </summary>
+    /// <param name="channel">The channel index (0..4).</param>
+    /// <param name="value">The normalized volume.</param>
+    private void HandleVolumeChanged(int channel, float value)
+    {
+        _settingsSession.SetVolume(channel, value);
+        _markDirty();
+    }
+
+    /// <summary>
+    /// Clears the destroyed Options menu view.
+    /// </summary>
+    /// <param name="destroyed">The destroyed view.</param>
+    private void HandleViewDestroyed(OptionsMenuView destroyed)
+    {
+        if (destroyed == null)
+            return;
+
+        destroyed.TabSelected -= HandleTabSelected;
+        destroyed.ResumeRequested -= HandleBackToGame;
+        destroyed.SaveRequested -= HandleSaveRequested;
+        destroyed.LoadRequested -= HandleLoadRequested;
+        destroyed.SlotSelected -= HandleSlotSelected;
+        destroyed.SlotRenamed -= HandleSlotRenamed;
+        destroyed.SlotDeleteRequested -= HandleSlotDeleteRequested;
+        destroyed.RenameEditingChanged -= HandleRenameEditingChanged;
+        destroyed.ApplyRequested -= HandleApply;
+        destroyed.DefaultsRequested -= HandleDefaults;
+        destroyed.ConfirmAccepted -= HandleConfirmAccepted;
+        destroyed.ConfirmDeclined -= HandleConfirmDeclined;
+        destroyed.RebindRequested -= HandleRebindRequested;
+        destroyed.MainMenuRequested -= HandleMainMenuRequested;
+        destroyed.QuitRequested -= HandleQuitRequested;
+        destroyed.TacticalToggleRequested -= HandleTacticalToggle;
+        destroyed.ResolutionStepRequested -= HandleResolutionStep;
+        destroyed.FullScreenStepRequested -= HandleFullScreenStep;
+        destroyed.VolumeChanged -= HandleVolumeChanged;
+        destroyed.Destroyed -= HandleViewDestroyed;
+        if (ReferenceEquals(destroyed, _view))
+        {
+            bool wasOpen = _window != null;
+            _view = null;
+            _window = null;
+            if (wasOpen)
+                _hostActions?.ResumeFromOptions();
+        }
+    }
+
+    /// <summary>
+    /// Returns the size of the Options menu prefab.
+    /// </summary>
+    /// <returns>The Options menu size.</returns>
+    private Vector2Int GetPrefabSize()
+    {
+        RectTransform rect = (RectTransform)_prefab.transform;
+        return new Vector2Int(
+            Mathf.RoundToInt(rect.sizeDelta.x),
+            Mathf.RoundToInt(rect.sizeDelta.y)
+        );
+    }
+
+    /// <summary>
+    /// Checks that the Options menu has been initialized.
+    /// </summary>
+    private void EnsureInitialized()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(OptionsMenuController));
+        if (_hostActions == null || _saveStore == null)
+            throw new InvalidOperationException(
+                $"{nameof(OptionsMenuController)} must be initialized before use."
+            );
+    }
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuRenderData.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuRenderData.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Represents one binding row in the Controls menu.
+/// </summary>
+public sealed class OptionsBindingRow
+{
+    /// <summary>
+    /// Creates a binding row.
+    /// </summary>
+    /// <param name="action">The human-readable action name.</param>
+    /// <param name="primary">The primary bound keys.</param>
+    /// <param name="secondary">The secondary bound keys, if any.</param>
+    /// <param name="isHeader">Whether this row is a group header rather than a bindable action.</param>
+    public OptionsBindingRow(
+        string action,
+        string primary,
+        string secondary = "",
+        bool isHeader = false
+    )
+    {
+        Action = action ?? string.Empty;
+        Primary = primary ?? string.Empty;
+        Secondary = secondary ?? string.Empty;
+        IsHeader = isHeader;
+    }
+
+    // Binding Info.
+    public string Action { get; }
+    public string Primary { get; }
+    public string Secondary { get; }
+    public bool IsHeader { get; }
+}
+
+/// <summary>
+/// Represents one row in the Save/Load menu.
+/// </summary>
+public sealed class OptionsSaveSlot
+{
+    /// <summary>
+    /// Creates a save row.
+    /// </summary>
+    /// <param name="name">The row display name.</param>
+    /// <param name="date">The save date line (empty for the create-new row).</param>
+    /// <param name="factionIcon">The saved faction's icon, or null.</param>
+    /// <param name="isCreateNew">Whether this row creates a new save.</param>
+    /// <param name="fileName">The save file name, or null for the create-new row.</param>
+    public OptionsSaveSlot(
+        string name,
+        string date,
+        Texture2D factionIcon,
+        bool isCreateNew,
+        string fileName
+    )
+    {
+        Name = SaveGameManager.NormalizeDisplayName(name);
+        Date = date ?? string.Empty;
+        FactionIcon = factionIcon;
+        IsCreateNew = isCreateNew;
+        FileName = fileName ?? string.Empty;
+    }
+
+    // Save Info.
+    public string Name { get; }
+    public string Date { get; }
+    public Texture2D FactionIcon { get; }
+    public bool IsCreateNew { get; }
+    public string FileName { get; }
+}
+
+/// <summary>
+/// Contains the data displayed by the Options menu.
+/// </summary>
+public sealed class OptionsMenuRenderData
+{
+    /// <summary>
+    /// Creates the Options menu data.
+    /// </summary>
+    /// <param name="x">The source-space horizontal window position.</param>
+    /// <param name="y">The source-space vertical window position.</param>
+    /// <param name="activeTab">The currently visible page.</param>
+    /// <param name="resolutionLabel">The current resolution value text.</param>
+    /// <param name="fullScreenLabel">The current display-mode value text.</param>
+    /// <param name="tacticalStates">The current detail-toggle states keyed by option.</param>
+    /// <param name="volumes">The five normalized volume values in channel order.</param>
+    /// <param name="bindings">The read-only key-binding rows.</param>
+    /// <param name="saveSlots">The save-slot rows.</param>
+    /// <param name="selectedSlot">The selected save-slot index, or -1.</param>
+    /// <param name="canSave">Whether saving is currently available.</param>
+    /// <param name="canLoad">Whether loading is currently available.</param>
+    /// <param name="canReturnToGame">Whether a running game exists to return to.</param>
+    /// <param name="canReturnToMainMenu">Whether returning to the Main Menu is possible.</param>
+    /// <param name="listeningRow">The binding row awaiting a key press, or -1.</param>
+    /// <param name="listeningSecondary">Whether the secondary column is awaiting a key press.</param>
+    public OptionsMenuRenderData(
+        int x,
+        int y,
+        OptionsMenuTab activeTab,
+        string resolutionLabel,
+        string fullScreenLabel,
+        IReadOnlyDictionary<UserTacticalOption, bool> tacticalStates,
+        IReadOnlyList<float> volumes,
+        IReadOnlyList<OptionsBindingRow> bindings,
+        IReadOnlyList<OptionsSaveSlot> saveSlots,
+        int selectedSlot,
+        bool canSave,
+        bool canLoad,
+        bool canReturnToGame,
+        bool canReturnToMainMenu,
+        int listeningRow,
+        bool listeningSecondary
+    )
+    {
+        X = x;
+        Y = y;
+        ActiveTab = activeTab;
+        ResolutionLabel = resolutionLabel ?? string.Empty;
+        FullScreenLabel = fullScreenLabel ?? string.Empty;
+        TacticalStates = tacticalStates ?? new Dictionary<UserTacticalOption, bool>();
+        Volumes = volumes ?? Array.Empty<float>();
+        Bindings = bindings ?? Array.Empty<OptionsBindingRow>();
+        SaveSlots = saveSlots ?? Array.Empty<OptionsSaveSlot>();
+        SelectedSlot = selectedSlot;
+        CanSave = canSave;
+        CanLoad = canLoad;
+        CanReturnToGame = canReturnToGame;
+        CanReturnToMainMenu = canReturnToMainMenu;
+        ListeningRow = listeningRow;
+        ListeningSecondary = listeningSecondary;
+    }
+
+    // Window Position.
+    public int X { get; }
+    public int Y { get; }
+
+    // Menu Selection.
+    public OptionsMenuTab ActiveTab { get; }
+    public int SelectedSlot { get; }
+    public int ListeningRow { get; }
+    public bool ListeningSecondary { get; }
+
+    // Display Settings.
+    public string ResolutionLabel { get; }
+    public string FullScreenLabel { get; }
+    public IReadOnlyDictionary<UserTacticalOption, bool> TacticalStates { get; }
+
+    // Audio Settings.
+    public IReadOnlyList<float> Volumes { get; }
+
+    // Menu Rows.
+    public IReadOnlyList<OptionsBindingRow> Bindings { get; }
+    public IReadOnlyList<OptionsSaveSlot> SaveSlots { get; }
+
+    // Available Actions.
+    public bool CanSave { get; }
+    public bool CanLoad { get; }
+    public bool CanReturnToGame { get; }
+    public bool CanReturnToMainMenu { get; }
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuTab.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuTab.cs
@@ -1,0 +1,10 @@
+/// <summary>
+/// Identifies an Options menu page.
+/// </summary>
+public enum OptionsMenuTab
+{
+    Graphics = 0,
+    Audio = 1,
+    SaveLoad = 2,
+    Controls = 3,
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsMenuView.cs
@@ -1,0 +1,824 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Displays the Options menu.
+/// </summary>
+public sealed class OptionsMenuView : MonoBehaviour
+{
+    // Colors.
+    private static readonly Color _activeTabColor = new Color(0.875f, 0.910f, 0.941f);
+    private static readonly Color _inactiveTabColor = new Color(0.573f, 0.635f, 0.706f);
+    private static readonly Color _accentColor = new Color(0.373f, 0.659f, 0.925f);
+    private static readonly Color _metaColor = new Color(0.573f, 0.635f, 0.706f);
+    private static readonly Color _textColor = new Color(0.875f, 0.910f, 0.941f);
+    private static readonly Color _badgeColor = new Color(0.204f, 0.243f, 0.302f);
+    private static readonly Color _badgeListeningColor = new Color(0.373f, 0.659f, 0.925f);
+
+    // Binding Rows.
+    private readonly List<TextMeshProUGUI> _bindingHeaderFields = new List<TextMeshProUGUI>();
+    private readonly List<TextMeshProUGUI> _bindingActionFields = new List<TextMeshProUGUI>();
+    private readonly List<TextMeshProUGUI> _bindingKeyFields = new List<TextMeshProUGUI>();
+    private readonly List<TextMeshProUGUI> _bindingSecondaryKeyFields = new List<TextMeshProUGUI>();
+    private readonly List<Image> _bindingRowImages = new List<Image>();
+    private readonly List<Image> _bindingBadgeImages = new List<Image>();
+    private readonly List<Image> _bindingSecondaryBadgeImages = new List<Image>();
+    private readonly HashSet<Button> _wiredBadges = new HashSet<Button>();
+
+    [Header("Frame")]
+    [SerializeField]
+    private RawImage _backgroundImage;
+
+    [SerializeField]
+    private TextMeshProUGUI _headerTextField;
+
+    [SerializeField]
+    private TextMeshProUGUI _pageTitleTextField;
+
+    [Header("Navigation")]
+    [SerializeField]
+    private Sprite _rowIdleSprite;
+
+    [SerializeField]
+    private Sprite _rowActiveSprite;
+
+    [SerializeField]
+    private Button[] _tabButtons = Array.Empty<Button>();
+
+    [SerializeField]
+    private TextMeshProUGUI[] _tabLabelFields = Array.Empty<TextMeshProUGUI>();
+
+    [SerializeField]
+    private GameObject _graphicsPage;
+
+    [SerializeField]
+    private GameObject _audioPage;
+
+    [SerializeField]
+    private GameObject _saveLoadPage;
+
+    [SerializeField]
+    private GameObject _controlsPage;
+
+    [Header("Footer")]
+    [SerializeField]
+    private Button _backToGameButton;
+
+    [SerializeField]
+    private Button _mainMenuButton;
+
+    [SerializeField]
+    private Button _quitButton;
+
+    [Header("Settings actions")]
+    [SerializeField]
+    private GameObject _settingsActions;
+
+    [SerializeField]
+    private Button _applyButton;
+
+    [SerializeField]
+    private Button _defaultsButton;
+
+    [SerializeField]
+    private SaveMenuConfirmDialogView _confirmDialog;
+
+    [Header("Graphics page")]
+    [SerializeField]
+    private OptionsToggleRowView[] _tacticalRows = Array.Empty<OptionsToggleRowView>();
+
+    [SerializeField]
+    private TextMeshProUGUI _resolutionValueField;
+
+    [SerializeField]
+    private Button _resolutionPrevButton;
+
+    [SerializeField]
+    private Button _resolutionNextButton;
+
+    [SerializeField]
+    private TextMeshProUGUI _fullScreenValueField;
+
+    [SerializeField]
+    private Button _fullScreenPrevButton;
+
+    [SerializeField]
+    private Button _fullScreenNextButton;
+
+    [Header("Audio page")]
+    [SerializeField]
+    private SaveMenuSliderView[] _volumeSliders = Array.Empty<SaveMenuSliderView>();
+
+    [SerializeField]
+    private TextMeshProUGUI[] _volumeValueFields = Array.Empty<TextMeshProUGUI>();
+
+    [Header("Save/Load page")]
+    [SerializeField]
+    private Button _saveButton;
+
+    [SerializeField]
+    private Button _loadButton;
+
+    [SerializeField]
+    private RawImage _saveDisabledImage;
+
+    [SerializeField]
+    private RawImage _loadDisabledImage;
+
+    [SerializeField]
+    private ScrollAreaView _saveSlotScrollArea;
+
+    [SerializeField]
+    private Image _slotRowTemplate;
+
+    [SerializeField]
+    private RawImage _slotIconTemplate;
+
+    [SerializeField]
+    private TextMeshProUGUI _slotNameTemplate;
+
+    [SerializeField]
+    private TextMeshProUGUI _slotMetaTemplate;
+
+    [SerializeField]
+    private Button _slotDeleteTemplate;
+
+    [SerializeField]
+    private TMP_InputField _slotRenameField;
+
+    [Header("Controls page")]
+    [SerializeField]
+    private ScrollAreaView _controlsScrollArea;
+
+    [SerializeField]
+    private Image _bindingRowTemplate;
+
+    [SerializeField]
+    private TextMeshProUGUI _bindingHeaderTemplate;
+
+    [SerializeField]
+    private TextMeshProUGUI _bindingActionTemplate;
+
+    [SerializeField]
+    private Image _bindingKeyBadgeTemplate;
+
+    [SerializeField]
+    private TextMeshProUGUI _bindingKeyTemplate;
+
+    // Menu State.
+    private OptionsSaveListPresenter _saveListPresenter;
+    private bool _bound;
+
+    // Events.
+    public event Action<OptionsMenuTab> TabSelected;
+    public event Action ResumeRequested;
+    public event Action SaveRequested;
+    public event Action LoadRequested;
+    public event Action<int> SlotSelected;
+    public event Action<int, string, bool> SlotRenamed;
+    public event Action<int> SlotDeleteRequested;
+    public event Action<bool> RenameEditingChanged;
+    public event Action ApplyRequested;
+    public event Action DefaultsRequested;
+    public event Action ConfirmAccepted;
+    public event Action ConfirmDeclined;
+    public event Action<int, bool> RebindRequested;
+    public event Action MainMenuRequested;
+    public event Action QuitRequested;
+    public event Action<UserTacticalOption> TacticalToggleRequested;
+    public event Action<int> ResolutionStepRequested;
+    public event Action<int> FullScreenStepRequested;
+    public event Action<int, float> VolumeChanged;
+    public event Action<OptionsMenuView> Destroyed;
+
+    /// <summary>
+    /// Checks the menu references and adds its listeners.
+    /// </summary>
+    private void Awake()
+    {
+        VerifyReferences();
+        _saveListPresenter = new OptionsSaveListPresenter(
+            _saveButton,
+            _loadButton,
+            _saveDisabledImage,
+            _loadDisabledImage,
+            _saveSlotScrollArea,
+            _slotRowTemplate,
+            _slotIconTemplate,
+            _slotNameTemplate,
+            _slotMetaTemplate,
+            _slotDeleteTemplate,
+            _slotRenameField,
+            _rowIdleSprite,
+            _rowActiveSprite,
+            index => SlotSelected?.Invoke(index),
+            (index, value, submitted) => SlotRenamed?.Invoke(index, value, submitted),
+            index => SlotDeleteRequested?.Invoke(index),
+            editing => RenameEditingChanged?.Invoke(editing)
+        );
+        BindControls();
+    }
+
+    /// <summary>
+    /// Removes the menu listeners.
+    /// </summary>
+    private void OnDestroy()
+    {
+        UnbindControls();
+        _saveListPresenter?.Dispose();
+        Destroyed?.Invoke(this);
+    }
+
+    /// <summary>
+    /// Displays the Options menu data.
+    /// </summary>
+    /// <param name="data">The Options menu data.</param>
+    public void Render(OptionsMenuRenderData data)
+    {
+        if (data == null)
+            throw new ArgumentNullException(nameof(data));
+
+        UILayout.SetSourcePosition(transform as RectTransform, data.X, data.Y);
+        UILayout.SetTextContent(_headerTextField, "OPTIONS");
+        UILayout.SetTextContent(_pageTitleTextField, GetTabTitle(data.ActiveTab));
+        if (data.ActiveTab != OptionsMenuTab.SaveLoad)
+            _saveListPresenter.CancelRename();
+        RenderTabs(data.ActiveTab);
+        RenderFooter(data);
+        switch (data.ActiveTab)
+        {
+            case OptionsMenuTab.Graphics:
+                RenderGraphicsPage(data);
+                break;
+            case OptionsMenuTab.Audio:
+                RenderAudioPage(data);
+                break;
+            case OptionsMenuTab.SaveLoad:
+                RenderSaveLoadPage(data);
+                break;
+            case OptionsMenuTab.Controls:
+                RenderControlsPage(data);
+                break;
+        }
+        gameObject.SetActive(true);
+    }
+
+    /// <summary>
+    /// Highlights the active tab and shows only its page.
+    /// </summary>
+    /// <param name="activeTab">The currently visible page.</param>
+    private void RenderTabs(OptionsMenuTab activeTab)
+    {
+        for (int i = 0; i < _tabLabelFields.Length; i++)
+        {
+            bool active = i == (int)activeTab;
+            if (_tabLabelFields[i] != null)
+                _tabLabelFields[i].color = active ? _activeTabColor : _inactiveTabColor;
+            if (i < _tabButtons.Length && _tabButtons[i]?.targetGraphic is Image tabImage)
+            {
+                tabImage.sprite = active ? _rowActiveSprite : _rowIdleSprite;
+            }
+        }
+
+        SetPageActive(_graphicsPage, activeTab == OptionsMenuTab.Graphics);
+        SetPageActive(_audioPage, activeTab == OptionsMenuTab.Audio);
+        SetPageActive(_saveLoadPage, activeTab == OptionsMenuTab.SaveLoad);
+        SetPageActive(_controlsPage, activeTab == OptionsMenuTab.Controls);
+        _settingsActions?.SetActive(activeTab != OptionsMenuTab.SaveLoad);
+    }
+
+    /// <summary>
+    /// Applies footer action availability.
+    /// </summary>
+    /// <param name="data">The Options menu data.</param>
+    private void RenderFooter(OptionsMenuRenderData data)
+    {
+        bool layoutChanged =
+            _backToGameButton.gameObject.activeSelf != data.CanReturnToGame
+            || _mainMenuButton.gameObject.activeSelf != data.CanReturnToMainMenu;
+        _backToGameButton.gameObject.SetActive(data.CanReturnToGame);
+        _mainMenuButton.gameObject.SetActive(data.CanReturnToMainMenu);
+        if (layoutChanged && _backToGameButton.transform.parent is RectTransform navigationRoot)
+            LayoutRebuilder.ForceRebuildLayoutImmediate(navigationRoot);
+    }
+
+    /// <summary>
+    /// Applies detail-toggle and display values to the Graphics page.
+    /// </summary>
+    /// <param name="data">The Options menu data.</param>
+    private void RenderGraphicsPage(OptionsMenuRenderData data)
+    {
+        foreach (OptionsToggleRowView row in _tacticalRows)
+        {
+            if (row == null)
+                continue;
+
+            bool enabled = data.TacticalStates.TryGetValue(row.Option, out bool value) && value;
+            row.Render(enabled);
+        }
+
+        UILayout.SetTextContent(_resolutionValueField, data.ResolutionLabel);
+        UILayout.SetTextContent(_fullScreenValueField, data.FullScreenLabel);
+    }
+
+    /// <summary>
+    /// Applies normalized volumes to the Audio page sliders and labels.
+    /// </summary>
+    /// <param name="data">The Options menu data.</param>
+    private void RenderAudioPage(OptionsMenuRenderData data)
+    {
+        for (int i = 0; i < _volumeSliders.Length; i++)
+        {
+            float value = i < data.Volumes.Count ? data.Volumes[i] : 0f;
+            _volumeSliders[i]?.Render(value);
+            if (i < _volumeValueFields.Length && _volumeValueFields[i] != null)
+                UILayout.SetTextContent(
+                    _volumeValueFields[i],
+                    Mathf.RoundToInt(Mathf.Clamp01(value) * 100f).ToString()
+                );
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds the save-slot list and applies action availability.
+    /// </summary>
+    /// <param name="data">The Options menu data.</param>
+    private void RenderSaveLoadPage(OptionsMenuRenderData data)
+    {
+        _saveListPresenter.Render(data);
+    }
+
+    /// <summary>
+    /// Rebuilds the read-only key-binding list: accent group headers followed by
+    /// backed rows with badged key captions.
+    /// </summary>
+    /// <param name="data">The Options menu data.</param>
+    private void RenderControlsPage(OptionsMenuRenderData data)
+    {
+        RectInt rowTemplate = UILayout.GetSourceRect(_bindingRowTemplate.rectTransform);
+        RectInt headerTemplate = UILayout.GetSourceRect(_bindingHeaderTemplate.rectTransform);
+        RectInt actionTemplate = UILayout.GetSourceRect(_bindingActionTemplate.rectTransform);
+        RectInt badgeTemplate = UILayout.GetSourceRect(_bindingKeyBadgeTemplate.rectTransform);
+        RectInt keyTemplate = UILayout.GetSourceRect(_bindingKeyTemplate.rectTransform);
+        int contentHeight = 0;
+        int headerCount = 0;
+        int rowCount = 0;
+        for (int i = 0; i < data.Bindings.Count; i++)
+        {
+            OptionsBindingRow binding = data.Bindings[i];
+            if (binding.IsHeader)
+            {
+                if (i > 0)
+                    contentHeight += 6;
+                UILayout.SetTemplateText(
+                    GetBindingField(
+                        _bindingHeaderFields,
+                        _bindingHeaderTemplate,
+                        "BindingHeader",
+                        headerCount++
+                    ),
+                    _bindingHeaderTemplate,
+                    binding.Action,
+                    _accentColor,
+                    new RectInt(
+                        headerTemplate.x,
+                        contentHeight,
+                        headerTemplate.width,
+                        headerTemplate.height
+                    )
+                );
+                contentHeight += headerTemplate.height + 4;
+                continue;
+            }
+
+            Image rowImage = GetBindingImage(
+                _bindingRowImages,
+                _bindingRowTemplate,
+                "BindingRow",
+                rowCount
+            );
+            UILayout.SetSourceRect(
+                rowImage.rectTransform,
+                rowTemplate.x,
+                contentHeight,
+                rowTemplate.width,
+                rowTemplate.height
+            );
+            UILayout.SetTemplateText(
+                GetBindingField(
+                    _bindingActionFields,
+                    _bindingActionTemplate,
+                    "BindingAction",
+                    rowCount
+                ),
+                _bindingActionTemplate,
+                binding.Action,
+                _metaColor,
+                new RectInt(
+                    actionTemplate.x,
+                    contentHeight + actionTemplate.y,
+                    180,
+                    actionTemplate.height
+                )
+            );
+            RenderBindingKey(
+                _bindingBadgeImages,
+                _bindingKeyFields,
+                "BindingPrimary",
+                rowCount,
+                i,
+                badgeTemplate.x - 67,
+                contentHeight,
+                binding.Primary,
+                badgeTemplate,
+                keyTemplate,
+                false,
+                i == data.ListeningRow && !data.ListeningSecondary
+            );
+            RenderBindingKey(
+                _bindingSecondaryBadgeImages,
+                _bindingSecondaryKeyFields,
+                "BindingSecondary",
+                rowCount,
+                i,
+                badgeTemplate.x,
+                contentHeight,
+                binding.Secondary,
+                badgeTemplate,
+                keyTemplate,
+                true,
+                i == data.ListeningRow && data.ListeningSecondary
+            );
+            rowCount++;
+            contentHeight += rowTemplate.height + 5;
+        }
+
+        _controlsScrollArea.SetContentHeight(contentHeight, rowTemplate.height + 5, false);
+        HideFieldsFrom(_bindingHeaderFields, headerCount);
+        HideFieldsFrom(_bindingActionFields, rowCount);
+        HideFieldsFrom(_bindingKeyFields, rowCount);
+        HideFieldsFrom(_bindingSecondaryKeyFields, rowCount);
+        HideImagesFrom(_bindingRowImages, rowCount);
+        HideImagesFrom(_bindingBadgeImages, rowCount);
+        HideImagesFrom(_bindingSecondaryBadgeImages, rowCount);
+    }
+
+    /// <summary>
+    /// Displays a key binding.
+    /// </summary>
+    /// <param name="badges">The badge cache for this column.</param>
+    /// <param name="keys">The key-field cache for this column.</param>
+    /// <param name="prefix">The instance-name prefix.</param>
+    /// <param name="index">The row index.</param>
+    /// <param name="bindingIndex">The source binding index, including group headers.</param>
+    /// <param name="x">The left position.</param>
+    /// <param name="top">The top position.</param>
+    /// <param name="text">The key caption.</param>
+    /// <param name="badgeTemplate">The badge template rect.</param>
+    /// <param name="keyTemplate">The key template rect.</param>
+    /// <param name="isSecondary">Whether this is the secondary column.</param>
+    /// <param name="listening">Whether this cell is awaiting a key press.</param>
+    private void RenderBindingKey(
+        List<Image> badges,
+        List<TextMeshProUGUI> keys,
+        string prefix,
+        int index,
+        int bindingIndex,
+        int x,
+        int top,
+        string text,
+        RectInt badgeTemplate,
+        RectInt keyTemplate,
+        bool isSecondary,
+        bool listening
+    )
+    {
+        Image badge = GetBindingImage(badges, _bindingKeyBadgeTemplate, prefix + "Badge", index);
+        if (badge.TryGetComponent(out Button badgeButton) && _wiredBadges.Add(badgeButton))
+        {
+            badgeButton.onClick.AddListener(() => HandleBadgeClick(bindingIndex, isSecondary));
+        }
+
+        // Binding Key.
+        badge.gameObject.SetActive(true);
+        badge.color = listening ? _badgeListeningColor : _badgeColor;
+        UILayout.SetSourceRect(
+            badge.rectTransform,
+            x,
+            top + badgeTemplate.y,
+            badgeTemplate.width,
+            badgeTemplate.height
+        );
+        UILayout.SetTemplateText(
+            GetBindingField(keys, _bindingKeyTemplate, prefix + "Key", index),
+            _bindingKeyTemplate,
+            listening ? "..." : text,
+            _textColor,
+            new RectInt(x, top + keyTemplate.y, keyTemplate.width, keyTemplate.height)
+        );
+    }
+
+    /// <summary>
+    /// Raises a rebind request when a binding badge is clicked.
+    /// </summary>
+    /// <param name="row">The binding row index.</param>
+    /// <param name="secondary">Whether the secondary column was clicked.</param>
+    private void HandleBadgeClick(int row, bool secondary)
+    {
+        RebindRequested?.Invoke(row, secondary);
+    }
+
+    /// <summary>
+    /// Gets or creates a reusable controls-page image cloned from a template.
+    /// </summary>
+    /// <param name="images">The image cache.</param>
+    /// <param name="template">The template image.</param>
+    /// <param name="namePrefix">The instance-name prefix.</param>
+    /// <param name="index">The required row index.</param>
+    /// <returns>The reusable image.</returns>
+    private Image GetBindingImage(List<Image> images, Image template, string namePrefix, int index)
+    {
+        while (images.Count <= index)
+        {
+            Image image = Instantiate(template, _controlsScrollArea.ContentRoot);
+            image.name = $"{namePrefix}{images.Count}";
+            image.gameObject.SetActive(true);
+            images.Add(image);
+        }
+
+        return images[index];
+    }
+
+    /// <summary>
+    /// Aligns the save name field and caret.
+    /// </summary>
+    internal void AlignRenameInput()
+    {
+        _saveListPresenter.AlignRenameInput();
+    }
+
+    /// <summary>
+    /// Focuses the save name field after a row click.
+    /// </summary>
+    private void Update()
+    {
+        _saveListPresenter?.UpdateFocus();
+    }
+
+    /// <summary>
+    /// Gets or creates a reusable binding field cloned from a template.
+    /// </summary>
+    /// <param name="fields">The field cache.</param>
+    /// <param name="template">The template field.</param>
+    /// <param name="namePrefix">The instance-name prefix.</param>
+    /// <param name="index">The required row index.</param>
+    /// <returns>The reusable binding field.</returns>
+    private TextMeshProUGUI GetBindingField(
+        List<TextMeshProUGUI> fields,
+        TextMeshProUGUI template,
+        string namePrefix,
+        int index
+    )
+    {
+        while (fields.Count <= index)
+        {
+            TextMeshProUGUI field = Instantiate(template, _controlsScrollArea.ContentRoot);
+            field.name = $"{namePrefix}{fields.Count}";
+            field.gameObject.SetActive(true);
+            fields.Add(field);
+        }
+
+        return fields[index];
+    }
+
+    /// <summary>
+    /// Hides cached images beginning at the supplied index.
+    /// </summary>
+    /// <param name="images">The image cache.</param>
+    /// <param name="firstHiddenIndex">The first image to hide.</param>
+    private static void HideImagesFrom(List<Image> images, int firstHiddenIndex)
+    {
+        for (int i = firstHiddenIndex; i < images.Count; i++)
+            images[i].gameObject.SetActive(false);
+    }
+
+    /// <summary>
+    /// Hides cached text fields beginning at the supplied index.
+    /// </summary>
+    /// <param name="fields">The field cache to update.</param>
+    /// <param name="firstHiddenIndex">The first field to hide.</param>
+    private static void HideFieldsFrom(List<TextMeshProUGUI> fields, int firstHiddenIndex)
+    {
+        for (int i = firstHiddenIndex; i < fields.Count; i++)
+            fields[i].gameObject.SetActive(false);
+    }
+
+    /// <summary>
+    /// Shows or hides a menu page.
+    /// </summary>
+    /// <param name="page">The menu page.</param>
+    /// <param name="active">Whether the page should be visible.</param>
+    private static void SetPageActive(GameObject page, bool active)
+    {
+        if (page != null && page.activeSelf != active)
+            page.SetActive(active);
+    }
+
+    /// <summary>
+    /// Resolves the display title for a page.
+    /// </summary>
+    /// <param name="tab">The page whose title is requested.</param>
+    /// <returns>The page title.</returns>
+    private static string GetTabTitle(OptionsMenuTab tab)
+    {
+        return tab switch
+        {
+            OptionsMenuTab.Graphics => "GRAPHICS",
+            OptionsMenuTab.Audio => "AUDIO",
+            OptionsMenuTab.SaveLoad => "SAVE / LOAD",
+            OptionsMenuTab.Controls => "CONTROLS",
+            _ => string.Empty,
+        };
+    }
+
+    /// <summary>
+    /// Adds the Options menu listeners.
+    /// </summary>
+    private void BindControls()
+    {
+        if (_bound)
+            return;
+
+        for (int i = 0; i < _tabButtons.Length; i++)
+        {
+            OptionsMenuTab tab = (OptionsMenuTab)i;
+            if (_tabButtons[i] != null)
+                _tabButtons[i].onClick.AddListener(() => TabSelected?.Invoke(tab));
+        }
+
+        _backToGameButton.onClick.AddListener(() => ResumeRequested?.Invoke());
+        _mainMenuButton.onClick.AddListener(() => MainMenuRequested?.Invoke());
+        _quitButton.onClick.AddListener(() => QuitRequested?.Invoke());
+        _saveButton.onClick.AddListener(() => SaveRequested?.Invoke());
+        _loadButton.onClick.AddListener(() => LoadRequested?.Invoke());
+        _applyButton.onClick.AddListener(() => ApplyRequested?.Invoke());
+        _defaultsButton.onClick.AddListener(() => DefaultsRequested?.Invoke());
+        _confirmDialog.Confirmed += HandleConfirmAccepted;
+        _confirmDialog.Canceled += HandleConfirmDeclined;
+
+        foreach (OptionsToggleRowView row in _tacticalRows)
+        {
+            if (row != null)
+                row.ToggleRequested += HandleTacticalToggle;
+        }
+
+        _resolutionPrevButton.onClick.AddListener(() => ResolutionStepRequested?.Invoke(-1));
+        _resolutionNextButton.onClick.AddListener(() => ResolutionStepRequested?.Invoke(1));
+        _fullScreenPrevButton.onClick.AddListener(() => FullScreenStepRequested?.Invoke(-1));
+        _fullScreenNextButton.onClick.AddListener(() => FullScreenStepRequested?.Invoke(1));
+
+        for (int i = 0; i < _volumeSliders.Length; i++)
+        {
+            int channel = i;
+            if (_volumeSliders[i] != null)
+                _volumeSliders[i].ValueChanged += value =>
+                {
+                    if (channel < _volumeValueFields.Length && _volumeValueFields[channel] != null)
+                        UILayout.SetTextContent(
+                            _volumeValueFields[channel],
+                            Mathf.RoundToInt(Mathf.Clamp01(value) * 100f).ToString()
+                        );
+                    VolumeChanged?.Invoke(channel, value);
+                };
+        }
+
+        _bound = true;
+    }
+
+    /// <summary>
+    /// Removes tactical-row listeners that outlive the Unity button lifetime.
+    /// </summary>
+    private void UnbindControls()
+    {
+        foreach (OptionsToggleRowView row in _tacticalRows)
+        {
+            if (row != null)
+                row.ToggleRequested -= HandleTacticalToggle;
+        }
+    }
+
+    /// <summary>
+    /// Forwards a detail-toggle request to subscribers.
+    /// </summary>
+    /// <param name="option">The toggled option.</param>
+    private void HandleTacticalToggle(UserTacticalOption option)
+    {
+        TacticalToggleRequested?.Invoke(option);
+    }
+
+    /// <summary>
+    /// Shows the confirmation prompt with a message.
+    /// </summary>
+    /// <param name="message">The prompt text.</param>
+    public void ShowConfirm(string message)
+    {
+        _confirmDialog.Show(message);
+    }
+
+    /// <summary>
+    /// Hides the confirmation prompt.
+    /// </summary>
+    public void HideConfirm()
+    {
+        _confirmDialog?.Hide();
+    }
+
+    /// <summary>
+    /// Forwards the dialog's confirm response to subscribers.
+    /// </summary>
+    private void HandleConfirmAccepted()
+    {
+        ConfirmAccepted?.Invoke();
+    }
+
+    /// <summary>
+    /// Forwards the dialog's decline response to subscribers.
+    /// </summary>
+    private void HandleConfirmDeclined()
+    {
+        ConfirmDeclined?.Invoke();
+    }
+
+    /// <summary>
+    /// Checks the Options menu references.
+    /// </summary>
+    private void VerifyReferences()
+    {
+        if (_backgroundImage == null)
+            throw new MissingReferenceException($"{name}/BackgroundImage is missing.");
+        if (_headerTextField == null || _pageTitleTextField == null)
+            throw new MissingReferenceException($"{name} is missing a title field.");
+        if (_rowIdleSprite == null || _rowActiveSprite == null)
+            throw new MissingReferenceException($"{name} is missing a row sprite.");
+        if (_tabButtons.Length != 4 || _tabLabelFields.Length != 4)
+            throw new MissingReferenceException($"{name} expects four tabs.");
+        if (
+            _graphicsPage == null
+            || _audioPage == null
+            || _saveLoadPage == null
+            || _controlsPage == null
+        )
+            throw new MissingReferenceException($"{name} is missing a page container.");
+        if (_backToGameButton == null || _mainMenuButton == null || _quitButton == null)
+            throw new MissingReferenceException($"{name} is missing a footer button.");
+        if (_settingsActions == null || _applyButton == null || _defaultsButton == null)
+            throw new MissingReferenceException($"{name} is missing a settings-action button.");
+        if (_confirmDialog == null)
+            throw new MissingReferenceException($"{name} is missing the confirm dialog.");
+        if (_resolutionValueField == null || _fullScreenValueField == null)
+            throw new MissingReferenceException($"{name} is missing a Graphics value field.");
+        if (
+            _resolutionPrevButton == null
+            || _resolutionNextButton == null
+            || _fullScreenPrevButton == null
+            || _fullScreenNextButton == null
+        )
+            throw new MissingReferenceException($"{name} is missing a Graphics step button.");
+        if (_saveButton == null || _loadButton == null)
+            throw new MissingReferenceException($"{name} is missing a Save/Load button.");
+        if (
+            _saveSlotScrollArea == null
+            || _slotRowTemplate == null
+            || _slotIconTemplate == null
+            || _slotNameTemplate == null
+            || _slotMetaTemplate == null
+            || _slotDeleteTemplate == null
+            || _slotRenameField == null
+        )
+            throw new MissingReferenceException($"{name} is missing a save-slot template.");
+        if (
+            _controlsScrollArea == null
+            || _bindingRowTemplate == null
+            || _bindingHeaderTemplate == null
+            || _bindingActionTemplate == null
+            || _bindingKeyBadgeTemplate == null
+            || _bindingKeyTemplate == null
+        )
+            throw new MissingReferenceException($"{name} is missing a binding template.");
+
+        _slotRowTemplate.gameObject.SetActive(false);
+        _slotIconTemplate.gameObject.SetActive(false);
+        _slotNameTemplate.gameObject.SetActive(false);
+        _slotMetaTemplate.gameObject.SetActive(false);
+        _slotDeleteTemplate.gameObject.SetActive(false);
+        // The rename field is controlled by the save list.
+        _bindingRowTemplate.gameObject.SetActive(false);
+        _bindingHeaderTemplate.gameObject.SetActive(false);
+        _bindingActionTemplate.gameObject.SetActive(false);
+        _bindingKeyBadgeTemplate.gameObject.SetActive(false);
+        _bindingKeyTemplate.gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsSaveListPresenter.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsSaveListPresenter.cs
@@ -1,0 +1,447 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Manages the save list in the Options menu.
+/// </summary>
+internal sealed class OptionsSaveListPresenter : IDisposable
+{
+    // Colors.
+    private static readonly Color _accentColor = new Color(0.373f, 0.659f, 0.925f);
+    private static readonly Color _metaColor = new Color(0.573f, 0.635f, 0.706f);
+    private static readonly Color _textColor = new Color(0.875f, 0.910f, 0.941f);
+
+    // Controls.
+    private readonly Button _saveButton;
+    private readonly Button _loadButton;
+    private readonly RawImage _saveDisabledImage;
+    private readonly RawImage _loadDisabledImage;
+    private readonly ScrollAreaView _scrollArea;
+    private readonly Image _rowTemplate;
+    private readonly RawImage _iconTemplate;
+    private readonly TextMeshProUGUI _nameTemplate;
+    private readonly TextMeshProUGUI _metaTemplate;
+    private readonly Button _deleteTemplate;
+    private readonly TMP_InputField _renameField;
+    private readonly Sprite _rowIdleSprite;
+    private readonly Sprite _rowActiveSprite;
+
+    // Events.
+    private readonly Action<int> _slotSelected;
+    private readonly Action<int, string, bool> _slotRenamed;
+    private readonly Action<int> _slotDeleteRequested;
+    private readonly Action<bool> _renameEditingChanged;
+
+    // Save Rows.
+    private readonly List<Image> _rowImages = new List<Image>();
+    private readonly List<RawImage> _iconImages = new List<RawImage>();
+    private readonly List<TextMeshProUGUI> _nameFields = new List<TextMeshProUGUI>();
+    private readonly List<TextMeshProUGUI> _metaFields = new List<TextMeshProUGUI>();
+    private readonly List<Button> _deleteButtons = new List<Button>();
+    private readonly Dictionary<Button, float> _lastClickTimes = new Dictionary<Button, float>();
+    private readonly List<int> _rowTops = new List<int>();
+    private readonly List<OptionsSaveSlot> _slots = new List<OptionsSaveSlot>();
+
+    // Editing State.
+    private int _rowWidth;
+    private int _rowHeight;
+    private int _renameRow = -1;
+    private bool _suppressRenameCommit;
+    private bool _pendingRenameFocus;
+
+    internal OptionsSaveListPresenter(
+        Button saveButton,
+        Button loadButton,
+        RawImage saveDisabledImage,
+        RawImage loadDisabledImage,
+        ScrollAreaView scrollArea,
+        Image rowTemplate,
+        RawImage iconTemplate,
+        TextMeshProUGUI nameTemplate,
+        TextMeshProUGUI metaTemplate,
+        Button deleteTemplate,
+        TMP_InputField renameField,
+        Sprite rowIdleSprite,
+        Sprite rowActiveSprite,
+        Action<int> slotSelected,
+        Action<int, string, bool> slotRenamed,
+        Action<int> slotDeleteRequested,
+        Action<bool> renameEditingChanged
+    )
+    {
+        _saveButton = saveButton;
+        _loadButton = loadButton;
+        _saveDisabledImage = saveDisabledImage;
+        _loadDisabledImage = loadDisabledImage;
+        _scrollArea = scrollArea;
+        _rowTemplate = rowTemplate;
+        _iconTemplate = iconTemplate;
+        _nameTemplate = nameTemplate;
+        _metaTemplate = metaTemplate;
+        _deleteTemplate = deleteTemplate;
+        _renameField = renameField;
+        _rowIdleSprite = rowIdleSprite;
+        _rowActiveSprite = rowActiveSprite;
+        _slotSelected = slotSelected;
+        _slotRenamed = slotRenamed;
+        _slotDeleteRequested = slotDeleteRequested;
+        _renameEditingChanged = renameEditingChanged;
+
+        renameField.onEndEdit.AddListener(HandleRenameEndEdit);
+        renameField.onSubmit.AddListener(HandleRenameSubmitted);
+    }
+
+    internal void Render(OptionsMenuRenderData data)
+    {
+        int selected = data.SelectedSlot;
+        bool existingSelected =
+            selected >= 0
+            && selected < data.SaveSlots.Count
+            && !data.SaveSlots[selected].IsCreateNew;
+        bool canSave = data.CanSave && existingSelected;
+        bool canLoad = data.CanLoad && existingSelected;
+        _saveButton.interactable = canSave;
+        _loadButton.interactable = canLoad;
+        SetButtonDisabledVisual(_saveButton, _saveDisabledImage, canSave);
+        SetButtonDisabledVisual(_loadButton, _loadDisabledImage, canLoad);
+
+        RectInt rowRect = UILayout.GetSourceRect(_rowTemplate.rectTransform);
+        RectInt iconRect = UILayout.GetSourceRect(_iconTemplate.rectTransform);
+        RectInt nameRect = UILayout.GetSourceRect(_nameTemplate.rectTransform);
+        RectInt metaRect = UILayout.GetSourceRect(_metaTemplate.rectTransform);
+        _rowWidth = rowRect.width;
+        _rowHeight = rowRect.height;
+        _slots.Clear();
+        _rowTops.Clear();
+        const int gap = 6;
+        int contentHeight = 0;
+        for (int index = 0; index < data.SaveSlots.Count; index++)
+        {
+            OptionsSaveSlot slot = data.SaveSlots[index];
+            int top = contentHeight;
+            _slots.Add(slot);
+            _rowTops.Add(top);
+
+            Image row = GetRow(index);
+            UILayout.SetSourceRect(
+                row.rectTransform,
+                rowRect.x,
+                top,
+                rowRect.width,
+                rowRect.height
+            );
+            row.sprite = index == selected ? _rowActiveSprite : _rowIdleSprite;
+            row.color = Color.white;
+
+            RawImage icon = GetIcon(index);
+            icon.texture = slot.FactionIcon;
+            icon.enabled = !slot.IsCreateNew && slot.FactionIcon != null;
+            RectInt fittedIcon = FitPreservingAspect(slot.FactionIcon, iconRect);
+            UILayout.SetSourceRect(
+                icon.rectTransform,
+                fittedIcon.x,
+                top + fittedIcon.y,
+                fittedIcon.width,
+                fittedIcon.height
+            );
+
+            TextMeshProUGUI name = GetField(_nameFields, _nameTemplate, "SlotName", index);
+            RectInt renderedNameRect = slot.IsCreateNew
+                ? new RectInt(0, top, rowRect.width, rowRect.height)
+                : new RectInt(nameRect.x, top + nameRect.y, nameRect.width, nameRect.height);
+            UILayout.SetTemplateText(
+                name,
+                _nameTemplate,
+                slot.Name,
+                slot.IsCreateNew ? _accentColor : _textColor,
+                renderedNameRect
+            );
+            if (slot.IsCreateNew)
+                name.alignment = TextAlignmentOptions.Midline;
+
+            UILayout.SetTemplateText(
+                GetField(_metaFields, _metaTemplate, "SlotDate", index),
+                _metaTemplate,
+                slot.IsCreateNew ? string.Empty : slot.Date,
+                _metaColor,
+                new RectInt(metaRect.x, top + metaRect.y, metaRect.width, metaRect.height)
+            );
+
+            Button delete = GetDelete(index);
+            delete.gameObject.SetActive(!slot.IsCreateNew);
+            UILayout.SetSourceRect(
+                (RectTransform)delete.transform,
+                rowRect.width - 24,
+                top + (rowRect.height - 16) / 2,
+                16,
+                16
+            );
+            contentHeight += rowRect.height + gap;
+        }
+
+        _scrollArea.SetContentHeight(contentHeight, rowRect.height + gap, false);
+        HideFrom(_rowImages, data.SaveSlots.Count);
+        HideFrom(_iconImages, data.SaveSlots.Count);
+        HideFrom(_nameFields, data.SaveSlots.Count);
+        HideFrom(_metaFields, data.SaveSlots.Count);
+        HideFrom(_deleteButtons, data.SaveSlots.Count);
+    }
+
+    internal void UpdateFocus()
+    {
+        if (!_pendingRenameFocus)
+            return;
+
+        _pendingRenameFocus = false;
+        if (!_renameField.gameObject.activeInHierarchy)
+            return;
+        _renameField.Select();
+        _renameField.ActivateInputField();
+        _renameField.caretPosition = _renameField.text?.Length ?? 0;
+        _renameField.selectionAnchorPosition = _renameField.caretPosition;
+        _renameField.selectionFocusPosition = _renameField.caretPosition;
+        _renameField.ForceLabelUpdate();
+    }
+
+    internal void CancelRename()
+    {
+        if (_renameRow < 0)
+            return;
+
+        _renameRow = -1;
+        _suppressRenameCommit = true;
+        _pendingRenameFocus = false;
+        _renameField.gameObject.SetActive(false);
+        _renameEditingChanged?.Invoke(false);
+    }
+
+    internal void AlignRenameInput()
+    {
+        if (_renameField.textComponent is TextMeshProUGUI text)
+        {
+            text.alignment = TextAlignmentOptions.MidlineLeft;
+            StretchRenameText(text.rectTransform);
+        }
+        if (_renameField.placeholder is TextMeshProUGUI placeholder)
+        {
+            placeholder.alignment = TextAlignmentOptions.MidlineLeft;
+            StretchRenameText(placeholder.rectTransform);
+        }
+
+        _renameField.textViewport = _renameField.transform as RectTransform;
+        _renameField.customCaretColor = true;
+        _renameField.caretColor = Color.white;
+        _renameField.caretWidth = 2;
+        _renameField.caretBlinkRate = 0.85f;
+        _renameField.characterLimit = SaveGameManager.MaxDisplayNameLength;
+        _renameField.onFocusSelectAll = false;
+        _renameField.ForceLabelUpdate();
+    }
+
+    public void Dispose()
+    {
+        _renameField.onEndEdit.RemoveListener(HandleRenameEndEdit);
+        _renameField.onSubmit.RemoveListener(HandleRenameSubmitted);
+    }
+
+    private Image GetRow(int index)
+    {
+        while (_rowImages.Count <= index)
+        {
+            int slotIndex = _rowImages.Count;
+            Image image = UnityEngine.Object.Instantiate(_rowTemplate, _scrollArea.ContentRoot);
+            image.name = $"SlotRow{slotIndex}";
+            image.gameObject.SetActive(true);
+            if (image.TryGetComponent(out Button rowButton))
+                rowButton.onClick.AddListener(() => HandleSlotClick(rowButton, slotIndex));
+            _rowImages.Add(image);
+        }
+
+        Image row = _rowImages[index];
+        row.gameObject.SetActive(true);
+        return row;
+    }
+
+    private RawImage GetIcon(int index)
+    {
+        while (_iconImages.Count <= index)
+        {
+            RawImage icon = UnityEngine.Object.Instantiate(_iconTemplate, _scrollArea.ContentRoot);
+            icon.name = $"SlotIcon{_iconImages.Count}";
+            icon.gameObject.SetActive(true);
+            _iconImages.Add(icon);
+        }
+
+        RawImage iconImage = _iconImages[index];
+        iconImage.gameObject.SetActive(true);
+        return iconImage;
+    }
+
+    private TextMeshProUGUI GetField(
+        List<TextMeshProUGUI> fields,
+        TextMeshProUGUI template,
+        string prefix,
+        int index
+    )
+    {
+        while (fields.Count <= index)
+        {
+            TextMeshProUGUI field = UnityEngine.Object.Instantiate(
+                template,
+                _scrollArea.ContentRoot
+            );
+            field.name = $"{prefix}{fields.Count}";
+            field.gameObject.SetActive(true);
+            fields.Add(field);
+        }
+
+        TextMeshProUGUI textField = fields[index];
+        textField.gameObject.SetActive(true);
+        return textField;
+    }
+
+    private Button GetDelete(int index)
+    {
+        while (_deleteButtons.Count <= index)
+        {
+            int slotIndex = _deleteButtons.Count;
+            Button button = UnityEngine.Object.Instantiate(
+                _deleteTemplate,
+                _scrollArea.ContentRoot
+            );
+            button.name = $"SlotDelete{slotIndex}";
+            button.gameObject.SetActive(true);
+            button.transform.SetAsLastSibling();
+            button.onClick.AddListener(() => _slotDeleteRequested?.Invoke(slotIndex));
+            _deleteButtons.Add(button);
+        }
+
+        Button deleteButton = _deleteButtons[index];
+        deleteButton.gameObject.SetActive(true);
+        return deleteButton;
+    }
+
+    private void HandleSlotClick(Button button, int index)
+    {
+        if (index < 0 || index >= _slots.Count)
+            return;
+
+        bool existing = !_slots[index].IsCreateNew;
+        float now = Time.unscaledTime;
+        if (existing && _lastClickTimes.TryGetValue(button, out float last) && now - last < 0.35f)
+        {
+            _lastClickTimes[button] = 0f;
+            CancelRename();
+            _slotSelected?.Invoke(index);
+            BeginRename(index);
+            return;
+        }
+
+        _lastClickTimes[button] = now;
+        CancelRename();
+        _slotSelected?.Invoke(index);
+        if (!existing)
+            BeginRename(index);
+    }
+
+    private void BeginRename(int index)
+    {
+        if (index < 0 || index >= _slots.Count)
+            return;
+
+        _renameRow = index;
+        _suppressRenameCommit = false;
+        int width = _slots[index].IsCreateNew ? _rowWidth - 44 : _rowWidth - 62;
+        const int fieldHeight = 18;
+        int fieldTop = _rowTops[index] + (_rowHeight - fieldHeight) / 2;
+        UILayout.SetSourceRect(
+            (RectTransform)_renameField.transform,
+            32,
+            fieldTop,
+            width,
+            fieldHeight
+        );
+        AlignRenameInput();
+        _renameField.transform.SetAsLastSibling();
+        _renameField.gameObject.SetActive(true);
+        _renameField.SetTextWithoutNotify(
+            _slots[index].IsCreateNew ? string.Empty : _slots[index].Name
+        );
+        _pendingRenameFocus = true;
+        _renameEditingChanged?.Invoke(true);
+    }
+
+    private void HandleRenameEndEdit(string value) => CompleteRename(value, false);
+
+    private void HandleRenameSubmitted(string value) => CompleteRename(value, true);
+
+    private void CompleteRename(string value, bool submitted)
+    {
+        if (_renameRow < 0)
+        {
+            _suppressRenameCommit = false;
+            return;
+        }
+
+        int row = _renameRow;
+        _renameRow = -1;
+        _pendingRenameFocus = false;
+        _renameEditingChanged?.Invoke(false);
+        _renameField.gameObject.SetActive(false);
+        if (_suppressRenameCommit)
+        {
+            _suppressRenameCommit = false;
+            return;
+        }
+        _slotRenamed?.Invoke(row, value, submitted);
+    }
+
+    private static void StretchRenameText(RectTransform rect)
+    {
+        rect.anchorMin = Vector2.zero;
+        rect.anchorMax = Vector2.one;
+        rect.pivot = new Vector2(0.5f, 0.5f);
+        rect.offsetMin = new Vector2(6f, 0f);
+        rect.offsetMax = new Vector2(-6f, 0f);
+    }
+
+    private static void SetButtonDisabledVisual(Button button, RawImage disabledImage, bool enabled)
+    {
+        if (disabledImage != null)
+            disabledImage.gameObject.SetActive(!enabled);
+        if (button?.targetGraphic != null)
+            button.targetGraphic.enabled = enabled;
+    }
+
+    private static RectInt FitPreservingAspect(Texture texture, RectInt box)
+    {
+        if (texture == null || texture.width <= 0 || texture.height <= 0)
+            return box;
+
+        float aspect = (float)texture.width / texture.height;
+        int width =
+            aspect >= (float)box.width / box.height
+                ? box.width
+                : Mathf.RoundToInt(box.height * aspect);
+        int height =
+            aspect >= (float)box.width / box.height
+                ? Mathf.RoundToInt(box.width / aspect)
+                : box.height;
+        return new RectInt(
+            box.x + (box.width - width) / 2,
+            box.y + (box.height - height) / 2,
+            width,
+            height
+        );
+    }
+
+    private static void HideFrom<T>(List<T> items, int firstHiddenIndex)
+        where T : Component
+    {
+        for (int index = firstHiddenIndex; index < items.Count; index++)
+            items[index].gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsSettingsSession.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsSettingsSession.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Manages pending changes to graphics, audio, and input settings.
+/// </summary>
+internal sealed class OptionsSettingsSession
+{
+    // Display Modes.
+    private static readonly int[] _fullScreenModes =
+    {
+        (int)FullScreenMode.ExclusiveFullScreen,
+        (int)FullScreenMode.FullScreenWindow,
+        (int)FullScreenMode.Windowed,
+    };
+
+    // Settings.
+    private readonly UserSettingsManager _userSettings;
+    private readonly AudioManager _audioManager;
+    private readonly InputManager _inputManager;
+
+    // Display Settings.
+    private readonly List<Vector2Int> _resolutions = new List<Vector2Int>();
+    private int _resolutionIndex;
+
+    // Original Settings.
+    private readonly Dictionary<UserTacticalOption, bool> _snapshotTactical =
+        new Dictionary<UserTacticalOption, bool>();
+
+    private float[] _snapshotVolumes = Array.Empty<float>();
+    private int _snapshotResolutionWidth;
+    private int _snapshotResolutionHeight;
+    private int _snapshotFullScreenMode;
+    private string _snapshotBindingOverrides = string.Empty;
+
+    internal OptionsSettingsSession(
+        UserSettingsManager userSettings,
+        AudioManager audioManager,
+        InputManager inputManager
+    )
+    {
+        _userSettings = userSettings ?? throw new ArgumentNullException(nameof(userSettings));
+        _audioManager = audioManager ?? throw new ArgumentNullException(nameof(audioManager));
+        _inputManager = inputManager ?? throw new ArgumentNullException(nameof(inputManager));
+    }
+
+    internal bool IsDirty { get; private set; }
+
+    internal UserVideoSettings Video => _userSettings.Settings.Video;
+
+    internal UserAudioSettings Audio => _userSettings.Settings.Audio;
+
+    internal string ResolutionLabel => $"{Video.ResolutionWidth} x {Video.ResolutionHeight}";
+
+    internal string FullScreenLabel => GetFullScreenLabel(Video.FullScreenMode);
+
+    internal void Begin()
+    {
+        RebuildResolutions();
+        CaptureSnapshot();
+        IsDirty = false;
+    }
+
+    internal void Commit()
+    {
+        _userSettings.Save();
+        _userSettings.Apply();
+        RebuildResolutions();
+        CaptureSnapshot();
+        IsDirty = false;
+    }
+
+    internal void Revert()
+    {
+        for (int channel = 0; channel < _snapshotVolumes.Length; channel++)
+            SetVolumeValue(channel, _snapshotVolumes[channel]);
+
+        Video.ResolutionWidth = _snapshotResolutionWidth;
+        Video.ResolutionHeight = _snapshotResolutionHeight;
+        Video.FullScreenMode = _snapshotFullScreenMode;
+        foreach (KeyValuePair<UserTacticalOption, bool> entry in _snapshotTactical)
+            Video.SetEnabled(entry.Key, entry.Value);
+
+        _inputManager.LoadBindingOverrides(_snapshotBindingOverrides);
+        ApplyAllVolumes();
+        ApplyResolution();
+        RebuildResolutions();
+        IsDirty = false;
+    }
+
+    internal void RestoreDefaults(OptionsMenuTab tab)
+    {
+        switch (tab)
+        {
+            case OptionsMenuTab.Graphics:
+                Video.ResolutionWidth = 0;
+                Video.ResolutionHeight = 0;
+                Video.FullScreenMode = (int)FullScreenMode.ExclusiveFullScreen;
+                Video.RestoreTacticalDefaults();
+                ApplyResolution();
+                RebuildResolutions();
+                break;
+            case OptionsMenuTab.Audio:
+                for (int channel = 0; channel < 5; channel++)
+                    SetVolumeValue(channel, 1f);
+                ApplyAllVolumes();
+                break;
+            case OptionsMenuTab.Controls:
+                _inputManager.Asset.RemoveAllBindingOverrides();
+                break;
+            default:
+                return;
+        }
+
+        IsDirty = true;
+    }
+
+    internal Dictionary<UserTacticalOption, bool> GetTacticalStates()
+    {
+        Dictionary<UserTacticalOption, bool> states = new Dictionary<UserTacticalOption, bool>();
+        foreach (UserTacticalOption option in Enum.GetValues(typeof(UserTacticalOption)))
+            states[option] = Video.IsEnabled(option);
+        return states;
+    }
+
+    internal float[] GetVolumes()
+    {
+        return new[]
+        {
+            Audio.MasterVolume,
+            Audio.MusicVolume,
+            Audio.SfxVolume,
+            Audio.AmbienceVolume,
+            Audio.VideoVolume,
+        };
+    }
+
+    internal void ToggleTactical(UserTacticalOption option)
+    {
+        Video.SetEnabled(option, !Video.IsEnabled(option));
+        IsDirty = true;
+    }
+
+    internal void StepResolution(int delta)
+    {
+        if (_resolutions.Count == 0)
+            return;
+
+        _resolutionIndex =
+            ((_resolutionIndex + delta) % _resolutions.Count + _resolutions.Count)
+            % _resolutions.Count;
+        Vector2Int resolution = _resolutions[_resolutionIndex];
+        Video.ResolutionWidth = resolution.x;
+        Video.ResolutionHeight = resolution.y;
+        Screen.SetResolution(resolution.x, resolution.y, (FullScreenMode)Video.FullScreenMode);
+        IsDirty = true;
+    }
+
+    internal void StepFullScreen(int delta)
+    {
+        int current = Array.IndexOf(_fullScreenModes, Video.FullScreenMode);
+        if (current < 0)
+            current = 0;
+        int next =
+            ((current + delta) % _fullScreenModes.Length + _fullScreenModes.Length)
+            % _fullScreenModes.Length;
+        Video.FullScreenMode = _fullScreenModes[next];
+        ApplyResolution();
+        IsDirty = true;
+    }
+
+    internal void SetVolume(int channel, float value)
+    {
+        if (!SetVolumeValue(channel, value))
+            return;
+
+        ApplyVolume(channel, Mathf.Clamp01(value));
+        IsDirty = true;
+    }
+
+    internal void MarkInputChanged()
+    {
+        IsDirty = true;
+    }
+
+    private void CaptureSnapshot()
+    {
+        _snapshotVolumes = GetVolumes();
+        _snapshotResolutionWidth = Video.ResolutionWidth;
+        _snapshotResolutionHeight = Video.ResolutionHeight;
+        _snapshotFullScreenMode = Video.FullScreenMode;
+        _snapshotBindingOverrides = _inputManager.SaveBindingOverrides();
+        _snapshotTactical.Clear();
+        foreach (UserTacticalOption option in Enum.GetValues(typeof(UserTacticalOption)))
+            _snapshotTactical[option] = Video.IsEnabled(option);
+    }
+
+    private void RebuildResolutions()
+    {
+        _resolutions.Clear();
+        _resolutions.AddRange(DisplayResolutionPolicy.GetSupportedResolutions());
+        Vector2Int current = ResolveResolution();
+        Video.ResolutionWidth = current.x;
+        Video.ResolutionHeight = current.y;
+        _resolutionIndex = _resolutions.IndexOf(current);
+    }
+
+    private void ApplyResolution()
+    {
+        Vector2Int resolution = ResolveResolution();
+        Video.ResolutionWidth = resolution.x;
+        Video.ResolutionHeight = resolution.y;
+        Screen.SetResolution(resolution.x, resolution.y, (FullScreenMode)Video.FullScreenMode);
+    }
+
+    private Vector2Int ResolveResolution()
+    {
+        return DisplayResolutionPolicy.Resolve(
+            _resolutions,
+            Video.ResolutionWidth,
+            Video.ResolutionHeight,
+            Display.main.systemWidth,
+            Display.main.systemHeight
+        );
+    }
+
+    private void ApplyAllVolumes()
+    {
+        _audioManager.SetMasterVolume(Audio.MasterVolume);
+        _audioManager.SetMusicVolume(Audio.MusicVolume);
+        _audioManager.SetSfxVolume(Audio.SfxVolume);
+        _audioManager.SetAmbienceVolume(Audio.AmbienceVolume);
+        _audioManager.SetVideoVolume(Audio.VideoVolume);
+    }
+
+    private void ApplyVolume(int channel, float value)
+    {
+        switch (channel)
+        {
+            case 0:
+                _audioManager.SetMasterVolume(value);
+                break;
+            case 1:
+                _audioManager.SetMusicVolume(value);
+                break;
+            case 2:
+                _audioManager.SetSfxVolume(value);
+                break;
+            case 3:
+                _audioManager.SetAmbienceVolume(value);
+                break;
+            case 4:
+                _audioManager.SetVideoVolume(value);
+                break;
+        }
+    }
+
+    private bool SetVolumeValue(int channel, float value)
+    {
+        value = Mathf.Clamp01(value);
+        switch (channel)
+        {
+            case 0:
+                Audio.MasterVolume = value;
+                return true;
+            case 1:
+                Audio.MusicVolume = value;
+                return true;
+            case 2:
+                Audio.SfxVolume = value;
+                return true;
+            case 3:
+                Audio.AmbienceVolume = value;
+                return true;
+            case 4:
+                Audio.VideoVolume = value;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static string GetFullScreenLabel(int mode)
+    {
+        return (FullScreenMode)mode switch
+        {
+            FullScreenMode.ExclusiveFullScreen => "Fullscreen",
+            FullScreenMode.FullScreenWindow => "Borderless",
+            FullScreenMode.MaximizedWindow => "Maximized",
+            FullScreenMode.Windowed => "Windowed",
+            _ => "Fullscreen",
+        };
+    }
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsToggleRowView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Options/OptionsToggleRowView.cs
@@ -1,0 +1,112 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Displays a tactical option in the Options menu.
+/// </summary>
+public sealed class OptionsToggleRowView : MonoBehaviour
+{
+    private static readonly Color _onTextColor = Color.white;
+    private static readonly Color _offTextColor = new Color(0.55f, 0.63f, 0.73f);
+
+    [SerializeField]
+    private UserTacticalOption _option;
+
+    [SerializeField]
+    private Image _toggleImage;
+
+    [SerializeField]
+    private Sprite _offSprite;
+
+    [SerializeField]
+    private Sprite _onSprite;
+
+    [SerializeField]
+    private Button _button;
+
+    [SerializeField]
+    private TextMeshProUGUI _labelTextField;
+
+    [SerializeField]
+    private TextMeshProUGUI _stateTextField;
+
+    private bool _bound;
+
+    // Toggle Info.
+    public UserTacticalOption Option => _option;
+    public event Action<UserTacticalOption> ToggleRequested;
+
+    /// <summary>
+    /// Renders the current option state.
+    /// </summary>
+    /// <param name="enabled">Whether the tactical option is enabled.</param>
+    public void Render(bool enabled)
+    {
+        VerifyReferences();
+        BindControls();
+        _toggleImage.sprite = enabled ? _onSprite : _offSprite;
+        _labelTextField.color = enabled ? _onTextColor : _offTextColor;
+        _stateTextField.text = enabled ? "ON" : "OFF";
+        _stateTextField.color = enabled ? _onTextColor : _offTextColor;
+    }
+
+    /// <summary>
+    /// Checks the toggle row references.
+    /// </summary>
+    public void VerifyReferences()
+    {
+        if (_toggleImage == null)
+            throw new MissingReferenceException("ToggleImage is missing.");
+        if (_offSprite == null || _onSprite == null)
+            throw new MissingReferenceException("Toggle sprites are missing.");
+        if (_button == null)
+            throw new MissingReferenceException("Button is missing.");
+        if (_labelTextField == null)
+            throw new MissingReferenceException("LabelTextField is missing.");
+        if (_stateTextField == null)
+            throw new MissingReferenceException("StateTextField is missing.");
+    }
+
+    /// <summary>
+    /// Adds the toggle button listener.
+    /// </summary>
+    private void OnEnable()
+    {
+        if (_button != null)
+            BindControls();
+    }
+
+    /// <summary>
+    /// Removes the button listener while the row is inactive.
+    /// </summary>
+    private void OnDisable()
+    {
+        if (!_bound)
+            return;
+
+        _button.onClick.RemoveListener(RequestToggle);
+        _bound = false;
+    }
+
+    /// <summary>
+    /// Adds the toggle listener.
+    /// </summary>
+    private void BindControls()
+    {
+        if (_bound)
+            return;
+
+        _button.onClick.AddListener(RequestToggle);
+        _bound = true;
+    }
+
+    /// <summary>
+    /// Requests a change to the tactical option.
+    /// </summary>
+    private void RequestToggle()
+    {
+        ToggleRequested?.Invoke(_option);
+    }
+}

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyBriefingController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyBriefingController.cs
@@ -70,6 +70,19 @@ public sealed class StrategyBriefingController
         activeBriefing = briefing;
         completed = onCompleted;
         segmentIndex = 0;
+        Faction playerFaction = game.GetPlayerFaction();
+        Faction opponentFaction = game.GetFactions()
+            .FirstOrDefault(faction => faction != playerFaction);
+        galaxyMapController.SetBriefingPresentation(
+            new StrategyBriefingMapPresentation(
+                StrategyBriefingMapMode.Default,
+                "Briefing",
+                null,
+                null,
+                playerFaction?.InstanceID,
+                opponentFaction?.InstanceID
+            )
+        );
         PlayCurrentSegment();
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -12,6 +12,7 @@ using Rebellion.SceneGraph;
 using Rebellion.Systems;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 /// <summary>
@@ -37,7 +38,10 @@ public sealed class StrategyController
         IMissionCreateWindowActions,
         IMessagesWindowActions,
         IStatusWindowActions,
-        IBattleAlertWindowActions
+        IBattleAlertWindowActions,
+        IOptionsMenuHostActions,
+        IOptionsSaveStore,
+        IOptionsSaveWriter
 {
     [SerializeField]
     private CanvasGroup contentGroup;
@@ -86,6 +90,11 @@ public sealed class StrategyController
     private EventSystem briefingEventSystem;
     private bool briefingSkipConfirmationOpen;
     private UIContext uiContext;
+    private FactionThemeLibrary _saveFactionThemeLibrary;
+    private readonly List<(
+        InputAction action,
+        Action<InputAction.CallbackContext> callback
+    )> _boundInputActions = new List<(InputAction, Action<InputAction.CallbackContext>)>();
 
     private bool dirty = true;
     private bool contentReady;
@@ -121,6 +130,8 @@ public sealed class StrategyController
     private StrategyWindowPlacementController windowPlacementController;
     private StrategyWindowCommandController windowCommandController;
     private StrategyScreenInputController inputController;
+    private OptionsMenuController _optionsMenuController;
+    private TickSpeed _speedBeforeOptions = TickSpeed.Paused;
 
     private IReadOnlyList<GalaxyMapSector> Sectors =>
         galaxyMapController?.Sectors ?? Array.Empty<GalaxyMapSector>();
@@ -148,6 +159,7 @@ public sealed class StrategyController
             throw new InvalidOperationException("StrategyController.Initialize called twice.");
 
         ValidateAuthoredViews();
+        AppBootstrap.Instance?.GetInputController()?.SetContext(InputContext.Strategy);
         gameManager = manager;
         uiContext = context;
         PreloadStrategySfx();
@@ -374,6 +386,23 @@ public sealed class StrategyController
             CloseWindow,
             MarkDirty
         );
+        _optionsMenuController = new OptionsMenuController(
+            strategyWindowLayerView.OptionsMenuWindowPrefab,
+            strategyWindowLayerView.GetWindowParent(true),
+            strategyWindowManager,
+            windowPlacementController.GetOptionsWindowPosition,
+            CloseWindow,
+            AppBootstrap.Instance.GetUserSettingsManager(),
+            AudioManager.EnsureExists(),
+            AppBootstrap.Instance.GetInputManager(),
+            MarkDirty
+        );
+        _optionsMenuController.Initialize(this, this, this);
+        cancelStack?.Register(_optionsMenuController);
+        GameRuntime settingsRuntime = AppBootstrap.Instance?.GetRuntime();
+        if (settingsRuntime != null)
+            settingsRuntime.ToggleSettingsMenuRequested += HandleToggleOptions;
+        WireStrategyInputActions();
         battleAlertWindowController = new BattleAlertWindowController(
             () =>
                 gameManager.SpaceCombatSystem.TryGetPendingCombat(out PendingCombatResult pending)
@@ -662,8 +691,17 @@ public sealed class StrategyController
     private void OnDestroy()
     {
         SetBriefingInteractionEnabled(true);
+        UnwireStrategyInputActions();
         UnregisterCancelHandlers();
         UnsubscribeViewEvents();
+        if (_optionsMenuController != null)
+        {
+            cancelStack?.Unregister(_optionsMenuController);
+            _optionsMenuController.Dispose();
+        }
+        GameRuntime settingsRuntime = AppBootstrap.Instance?.GetRuntime();
+        if (settingsRuntime != null)
+            settingsRuntime.ToggleSettingsMenuRequested -= HandleToggleOptions;
         if (gameManager != null)
         {
             gameManager.GameSpeedChanged -= MarkDirty;
@@ -765,6 +803,7 @@ public sealed class StrategyController
         AudioManager.EnsureExists().PauseSfx();
         SetBriefingInteractionEnabled(true);
         briefingSkipConfirmation.Show("Do you wish to skip the tutorial?");
+        dirty = true;
     }
 
     /// <summary>
@@ -1101,6 +1140,7 @@ public sealed class StrategyController
         advisorReportWindowController.RenderWindows();
         statusWindowController.RenderWindows();
         encyclopediaWindowController.RenderWindows();
+        _optionsMenuController.RenderWindows();
         finderWindowController.RenderWindows();
         messagesWindowController.RenderWindows();
         battleAlertWindowController.RenderWindows();
@@ -1918,8 +1958,7 @@ public sealed class StrategyController
         switch (action)
         {
             case StrategyHudAction.Options:
-                SaveMenuLaunchContext.OpenFromStrategyView();
-                AppBootstrap.Instance.LoadScene(SaveMenuLaunchContext.SaveMenuSceneName);
+                _optionsMenuController.Open();
                 break;
             case StrategyHudAction.SystemFinder:
                 finderWindowController.Open(FinderMode.Systems);
@@ -2740,6 +2779,428 @@ public sealed class StrategyController
     private void MarkDirty()
     {
         dirty = true;
+    }
+
+    /// <summary>
+    /// Adds the strategy key binding listeners.
+    /// </summary>
+    private void WireStrategyInputActions()
+    {
+        InputActionAsset asset = AppBootstrap.Instance?.GetInputManager()?.Asset;
+        if (asset == null)
+            return;
+
+        asset.FindActionMap("Strategy")?.Enable();
+
+        for (int slot = 0; slot < 12; slot++)
+        {
+            int index = slot;
+            BindInputAction(
+                asset,
+                $"Strategy/BookmarkSlot{slot + 1}",
+                () => HandleBookmarkRequested(index)
+            );
+        }
+
+        BindInputAction(
+            asset,
+            "Strategy/OpenSystemFinder",
+            () => finderWindowController.Open(FinderMode.Systems)
+        );
+        BindInputAction(
+            asset,
+            "Strategy/OpenFleetFinder",
+            () => finderWindowController.Open(FinderMode.Fleets)
+        );
+        BindInputAction(
+            asset,
+            "Strategy/OpenPersonnelFinder",
+            () => finderWindowController.Open(FinderMode.Personnel)
+        );
+        BindInputAction(
+            asset,
+            "Strategy/OpenPlanetFinder",
+            () => finderWindowController.Open(FinderMode.Troops)
+        );
+        BindInputAction(
+            asset,
+            "Strategy/OpenEncyclopedia",
+            () => encyclopediaWindowController.Open()
+        );
+        BindInputAction(
+            asset,
+            "Strategy/OpenAllMessages",
+            () => messagesWindowController.Open(MessagesTab.All)
+        );
+        BindInputAction(
+            asset,
+            "Strategy/OpenMissionSetup",
+            () => inputController.TryExecuteContextShortcut(StrategyMenuAction.CreateMission)
+        );
+        BindInputAction(
+            asset,
+            "Strategy/IssueMoveOrder",
+            () => inputController.TryExecuteContextShortcut(StrategyMenuAction.Move)
+        );
+        BindInputAction(
+            asset,
+            "Strategy/ConfirmMoveOrder",
+            () => inputController.TryExecuteContextShortcut(StrategyMenuAction.MoveConfirm)
+        );
+        BindInputAction(asset, "Strategy/DecreaseGameSpeed", () => StepGameSpeed(false));
+        BindInputAction(asset, "Strategy/IncreaseGameSpeed", () => StepGameSpeed(true));
+
+        BindGalacticInformationAction(
+            asset,
+            "ShowPopularSupport",
+            GalacticInformationFilterMode.PopularSupport
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowUprisings",
+            GalacticInformationFilterMode.Uprisings
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowIdleFleets",
+            GalacticInformationFilterMode.IdleFleets
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowFleetsEnroute",
+            GalacticInformationFilterMode.FleetsEnroute
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowIdlePersonnel",
+            GalacticInformationFilterMode.IdlePersonnel
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowActivePersonnel",
+            GalacticInformationFilterMode.ActivePersonnel
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowAvailableEnergy",
+            GalacticInformationFilterMode.AvailableEnergy
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowAvailableRawMaterial",
+            GalacticInformationFilterMode.AvailableRawMaterial
+        );
+        BindGalacticInformationAction(asset, "ShowMines", GalacticInformationFilterMode.Mines);
+        BindGalacticInformationAction(
+            asset,
+            "ShowRefineries",
+            GalacticInformationFilterMode.Refineries
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowShipyards",
+            GalacticInformationFilterMode.Shipyards
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowTrainingFacilities",
+            GalacticInformationFilterMode.TrainingFacilities
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowConstructionYards",
+            GalacticInformationFilterMode.ConstructionYards
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowIdleShipyards",
+            GalacticInformationFilterMode.IdleShipyards
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowIdleTrainingFacilities",
+            GalacticInformationFilterMode.IdleTrainingFacilities
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowIdleConstructionYards",
+            GalacticInformationFilterMode.IdleConstructionYards
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowTroopers",
+            GalacticInformationFilterMode.Troopers
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowFighterSquadrons",
+            GalacticInformationFilterMode.FighterSquadrons
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowDeathStarShields",
+            GalacticInformationFilterMode.DeathStarShields
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowPlanetaryShieldGenerators",
+            GalacticInformationFilterMode.PlanetaryShieldGenerators
+        );
+        BindGalacticInformationAction(
+            asset,
+            "ShowPlanetaryDefenseBatteries",
+            GalacticInformationFilterMode.PlanetaryDefenseBatteries
+        );
+    }
+
+    /// <summary>
+    /// Applies the information filter selected by a keyboard shortcut.
+    /// </summary>
+    private void BindGalacticInformationAction(
+        InputActionAsset asset,
+        string actionName,
+        GalacticInformationFilterMode mode
+    )
+    {
+        BindInputAction(
+            asset,
+            $"Strategy/{actionName}",
+            () => galacticInformationDisplayController?.SelectFilterFromShortcut(mode)
+        );
+    }
+
+    /// <summary>
+    /// Adds a listener for an input action.
+    /// </summary>
+    /// <param name="asset">The input asset.</param>
+    /// <param name="actionPath">The map/action path.</param>
+    /// <param name="command">The command to run.</param>
+    private void BindInputAction(InputActionAsset asset, string actionPath, Action command)
+    {
+        InputAction action = asset.FindAction(actionPath, false);
+        if (action == null)
+            return;
+
+        void Callback(InputAction.CallbackContext context)
+        {
+            if (context.performed && !briefingActive && _optionsMenuController?.IsOpen != true)
+                command();
+        }
+
+        action.performed += Callback;
+        _boundInputActions.Add((action, Callback));
+    }
+
+    /// <summary>
+    /// Steps the game speed one step faster or slower.
+    /// </summary>
+    /// <param name="faster">Whether to speed up.</param>
+    private void StepGameSpeed(bool faster)
+    {
+        if (gameManager == null)
+            return;
+
+        TickSpeed current = gameManager.GetGameSpeed();
+        gameManager.SetGameSpeed(
+            faster
+                ? AppInputController.GetFasterGameSpeed(current)
+                : AppInputController.GetSlowerGameSpeed(current)
+        );
+    }
+
+    /// <summary>
+    /// Removes the strategy key binding listeners.
+    /// </summary>
+    private void UnwireStrategyInputActions()
+    {
+        foreach (
+            (InputAction action, Action<InputAction.CallbackContext> callback) in _boundInputActions
+        )
+            action.performed -= callback;
+        _boundInputActions.Clear();
+    }
+
+    /// <summary>
+    /// Toggles the Options menu.
+    /// </summary>
+    private void HandleToggleOptions()
+    {
+        if (_optionsMenuController == null)
+            return;
+
+        // The tutorial uses Escape to open its confirmation dialog.
+        if (briefingActive)
+            return;
+
+        if (_optionsMenuController.IsOpen)
+            _optionsMenuController.TryCancel();
+        else
+            _optionsMenuController.Open();
+    }
+
+    /// <summary>
+    /// Gets whether the Options menu can return to the running game.
+    /// </summary>
+    bool IOptionsMenuHostActions.CanReturnToGame => true;
+
+    /// <summary>
+    /// Gets whether the Options menu can return to the Main Menu.
+    /// </summary>
+    bool IOptionsMenuHostActions.CanReturnToMainMenu => true;
+
+    /// <summary>
+    /// Pauses the game while the Options menu is open.
+    /// </summary>
+    void IOptionsMenuHostActions.PauseForOptions()
+    {
+        AppBootstrap.Instance?.GetInputController()?.PushContext(InputContext.Menu);
+        if (gameManager == null)
+            return;
+
+        _speedBeforeOptions = gameManager.GetGameSpeed();
+        gameManager.SetGameSpeed(TickSpeed.Paused);
+    }
+
+    /// <summary>
+    /// Restores the game speed when the Options menu closes.
+    /// </summary>
+    void IOptionsMenuHostActions.ResumeFromOptions()
+    {
+        AppBootstrap.Instance?.GetInputController()?.PopContext();
+        gameManager?.SetGameSpeed(_speedBeforeOptions);
+    }
+
+    /// <summary>
+    /// Returns the save games displayed in the Options menu.
+    /// </summary>
+    /// <returns>The save rows, newest save first.</returns>
+    IReadOnlyList<OptionsSaveSlot> IOptionsSaveStore.GetSaveSlots()
+    {
+        List<OptionsSaveSlot> rows = new List<OptionsSaveSlot>
+        {
+            new OptionsSaveSlot("Create New Save", string.Empty, null, true, null),
+        };
+        foreach (SaveGameEntry entry in SaveGameManager.Instance.GetSavedGames())
+        {
+            string name = string.IsNullOrEmpty(entry.Metadata?.SaveDisplayName)
+                ? entry.FileName
+                : entry.Metadata.SaveDisplayName;
+            string date =
+                entry.Metadata != null
+                    ? entry.Metadata.LastSavedUtc.ToLocalTime().ToString("g")
+                    : string.Empty;
+            rows.Add(
+                new OptionsSaveSlot(
+                    name,
+                    date,
+                    ResolveSaveFactionIcon(entry.Metadata?.PlayerFactionID),
+                    false,
+                    entry.FileName
+                )
+            );
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Creates a save game with the given display name.
+    /// </summary>
+    /// <param name="displayName">The display name for the new save.</param>
+    void IOptionsSaveWriter.CreateNamedSave(string displayName)
+    {
+        GameRoot game = gameManager?.GetGame();
+        if (game == null)
+            return;
+
+        string fileName = $"save_{DateTime.Now:yyyyMMdd_HHmmss}";
+        SaveGameManager.Instance.SaveGameData(game, fileName, displayName);
+    }
+
+    /// <summary>
+    /// Overwrites an existing save game.
+    /// </summary>
+    /// <param name="fileName">The save file to overwrite.</param>
+    /// <param name="displayName">The display name to preserve or apply.</param>
+    void IOptionsSaveWriter.OverwriteSave(string fileName, string displayName)
+    {
+        GameRoot game = gameManager?.GetGame();
+        if (game == null || string.IsNullOrEmpty(fileName))
+            return;
+
+        SaveGameManager.Instance.SaveGameData(game, fileName, displayName);
+    }
+
+    /// <summary>
+    /// Loads a save game.
+    /// </summary>
+    /// <param name="fileName">The save file to load.</param>
+    /// <returns>True when a game was loaded.</returns>
+    bool IOptionsSaveStore.LoadSave(string fileName)
+    {
+        if (string.IsNullOrEmpty(fileName))
+            return false;
+
+        GameRuntime runtime = AppBootstrap.Instance?.GetRuntime();
+        return runtime?.LoadGame(fileName) ?? false;
+    }
+
+    /// <summary>
+    /// Deletes a save game.
+    /// </summary>
+    /// <param name="fileName">The save file to delete.</param>
+    void IOptionsSaveStore.DeleteSave(string fileName)
+    {
+        SaveGameManager.Instance.DeleteSave(fileName);
+    }
+
+    /// <summary>
+    /// Renames a save game.
+    /// </summary>
+    /// <param name="fileName">The save file to rename.</param>
+    /// <param name="displayName">The new display name.</param>
+    void IOptionsSaveStore.RenameSave(string fileName, string displayName)
+    {
+        SaveGameManager.Instance.SetSaveDisplayName(fileName, displayName);
+    }
+
+    /// <summary>
+    /// Returns the faction icon for a save game.
+    /// </summary>
+    /// <param name="factionId">The saved faction id, or null.</param>
+    /// <returns>The faction icon texture, or null.</returns>
+    private Texture2D ResolveSaveFactionIcon(string factionId)
+    {
+        if (string.IsNullOrEmpty(factionId))
+            return null;
+
+        _saveFactionThemeLibrary ??= new FactionThemeLibrary(
+            AppBootstrap.Instance.GetContentPack().GameData.FactionThemes
+        );
+        string path = _saveFactionThemeLibrary.GetTheme(factionId)?.SaveMenuSlotIconImagePath;
+        return string.IsNullOrEmpty(path)
+            ? null
+            : AppBootstrap.Instance.GetContentAssets().GetTexture(path);
+    }
+
+    /// <summary>
+    /// Returns to the Main Menu.
+    /// </summary>
+    void IOptionsMenuHostActions.ReturnToMainMenu()
+    {
+        AppBootstrap.Instance.LoadScene(SceneNames.MainMenu);
+    }
+
+    /// <summary>
+    /// Quits the game.
+    /// </summary>
+    void IOptionsMenuHostActions.QuitApplication()
+    {
+#if UNITY_EDITOR
+        UnityEditor.EditorApplication.isPlaying = false;
+#else
+        Application.Quit();
+#endif
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyScreenInputController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyScreenInputController.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.InputSystem;
 
 /// <summary>
 /// Routes strategy-surface pointer gestures to targeting, dragging, windows, and the galaxy map.
@@ -19,6 +21,9 @@ public sealed class StrategyScreenInputController : ICancelable
     private readonly Action renderOverlay;
     private UIWindow pressedWindow;
     private bool suppressNextClick;
+    private GameObject _lastCommandTarget;
+    private int _lastCommandX;
+    private int _lastCommandY;
 
     /// <summary>
     /// Creates the strategy-surface input router.
@@ -97,6 +102,16 @@ public sealed class StrategyScreenInputController : ICancelable
             strategyContextMenuRouter.OpenContextMenu(eventData, x, y);
             markDirty();
             return;
+        }
+
+        if (
+            eventData.button == PointerEventData.InputButton.Left
+            && windowManager.GetWindow(eventData) != null
+        )
+        {
+            _lastCommandTarget = GetRaycastTarget(eventData);
+            _lastCommandX = x;
+            _lastCommandY = y;
         }
 
         pressedWindow = windowManager.GetWindow(eventData);
@@ -279,6 +294,63 @@ public sealed class StrategyScreenInputController : ICancelable
     public void SuppressNextClick()
     {
         suppressNextClick = true;
+    }
+
+    /// <summary>
+    /// Runs a context menu action for the item under the pointer.
+    /// </summary>
+    /// <param name="action">The context menu action.</param>
+    /// <returns>True when an enabled command was executed.</returns>
+    public bool TryExecuteContextShortcut(StrategyMenuAction action)
+    {
+        if (targetingController.IsTargeting || EventSystem.current == null)
+            return false;
+
+        if (_lastCommandTarget != null)
+        {
+            PointerEventData selectedEvent = new PointerEventData(EventSystem.current)
+            {
+                button = PointerEventData.InputButton.Right,
+                pointerCurrentRaycast = new RaycastResult { gameObject = _lastCommandTarget },
+            };
+            if (
+                strategyContextMenuRouter.TryExecuteShortcut(
+                    selectedEvent,
+                    _lastCommandX,
+                    _lastCommandY,
+                    action
+                )
+            )
+            {
+                markDirty();
+                renderOverlay();
+                return true;
+            }
+        }
+
+        if (Mouse.current == null)
+            return false;
+
+        PointerEventData eventData = new PointerEventData(EventSystem.current)
+        {
+            button = PointerEventData.InputButton.Right,
+            position = Mouse.current.position.ReadValue(),
+        };
+        List<RaycastResult> raycasts = new List<RaycastResult>();
+        EventSystem.current.RaycastAll(eventData, raycasts);
+        if (raycasts.Count == 0)
+            return false;
+
+        eventData.pointerCurrentRaycast = raycasts[0];
+        if (!tryGetSourcePosition(eventData, eventData.position, out int x, out int y))
+            return false;
+
+        if (!strategyContextMenuRouter.TryExecuteShortcut(eventData, x, y, action))
+            return false;
+
+        markDirty();
+        renderOverlay();
+        return true;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowLayerView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowLayerView.cs
@@ -61,6 +61,9 @@ public sealed class StrategyWindowLayerView : MonoBehaviour
     private EncyclopediaWindowView encyclopediaWindowPrefab;
 
     [SerializeField]
+    private OptionsMenuView _optionsMenuWindowPrefab;
+
+    [SerializeField]
     private Vector2Int constructionWindowOffset;
 
     [SerializeField]
@@ -93,6 +96,8 @@ public sealed class StrategyWindowLayerView : MonoBehaviour
     internal FinderWindowView FinderWindowPrefab => finderWindowPrefab;
 
     internal EncyclopediaWindowView EncyclopediaWindowPrefab => encyclopediaWindowPrefab;
+
+    internal OptionsMenuView OptionsMenuWindowPrefab => _optionsMenuWindowPrefab;
 
     internal Vector2Int ConstructionWindowOffset => constructionWindowOffset;
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowPlacementController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowPlacementController.cs
@@ -114,6 +114,20 @@ public sealed class StrategyWindowPlacementController
     }
 
     /// <summary>
+    /// Returns the centered Options menu position.
+    /// </summary>
+    /// <returns>The Options menu position.</returns>
+    public Vector2Int GetOptionsWindowPosition()
+    {
+        Vector2Int windowSize = windowLayer.GetWindowSize(windowLayer.OptionsMenuWindowPrefab);
+        Vector2Int surfaceSize = windowLayer.GetSurfaceSize();
+        return new Vector2Int(
+            Mathf.RoundToInt(surfaceSize.x / 2f - windowSize.x / 2f),
+            Mathf.RoundToInt(surfaceSize.y / 2f - windowSize.y / 2f)
+        );
+    }
+
+    /// <summary>
     /// Gets the centered confirmation-dialog position from its authored prefab geometry.
     /// </summary>
     /// <returns>The source-space confirmation-dialog position.</returns>

--- a/Assets/Scripts/UserSettings/DisplayResolutionPolicy.cs
+++ b/Assets/Scripts/UserSettings/DisplayResolutionPolicy.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Manages the supported display resolutions.
+/// </summary>
+internal static class DisplayResolutionPolicy
+{
+    private static readonly Vector2Int[] _commonFallbacks =
+    {
+        new Vector2Int(3840, 2160),
+        new Vector2Int(2560, 1440),
+        new Vector2Int(1920, 1080),
+        new Vector2Int(1600, 900),
+        new Vector2Int(1366, 768),
+        new Vector2Int(1280, 720),
+        new Vector2Int(1024, 576),
+        new Vector2Int(960, 540),
+        new Vector2Int(640, 360),
+    };
+
+    /// <summary>
+    /// Checks whether a resolution uses a 16:9 aspect ratio.
+    /// </summary>
+    internal static bool IsSixteenByNine(int width, int height)
+    {
+        return width > 0 && height > 0 && Math.Abs((long)width * 9L - (long)height * 16L) <= 8L;
+    }
+
+    /// <summary>
+    /// Returns the available 16:9 resolutions.
+    /// </summary>
+    internal static List<Vector2Int> GetSupportedResolutions()
+    {
+        List<Vector2Int> supported = new List<Vector2Int>();
+        foreach (Resolution resolution in Screen.resolutions)
+        {
+            if (!IsSixteenByNine(resolution.width, resolution.height))
+                continue;
+
+            Vector2Int size = new Vector2Int(resolution.width, resolution.height);
+            if (!supported.Contains(size))
+                supported.Add(size);
+        }
+
+        supported.Sort(CompareBySize);
+        if (supported.Count == 0)
+            supported.Add(CreateFallback(Screen.width, Screen.height));
+
+        return supported;
+    }
+
+    /// <summary>
+    /// Returns the supported resolution that best matches the requested size.
+    /// </summary>
+    internal static Vector2Int Resolve(
+        IReadOnlyList<Vector2Int> supported,
+        int requestedWidth,
+        int requestedHeight,
+        int fallbackWidth,
+        int fallbackHeight
+    )
+    {
+        int targetWidth = requestedWidth > 0 ? requestedWidth : fallbackWidth;
+        int targetHeight = requestedHeight > 0 ? requestedHeight : fallbackHeight;
+        if (supported == null || supported.Count == 0)
+            return CreateFallback(targetWidth, targetHeight);
+
+        Vector2Int bestFit = default;
+        long bestArea = -1;
+        Vector2Int smallest = default;
+        long smallestArea = long.MaxValue;
+        foreach (Vector2Int candidate in supported)
+        {
+            if (!IsSixteenByNine(candidate.x, candidate.y))
+                continue;
+            if (candidate.x == requestedWidth && candidate.y == requestedHeight)
+                return candidate;
+
+            long area = (long)candidate.x * candidate.y;
+            if (area < smallestArea)
+            {
+                smallest = candidate;
+                smallestArea = area;
+            }
+
+            if (candidate.x <= targetWidth && candidate.y <= targetHeight && area > bestArea)
+            {
+                bestFit = candidate;
+                bestArea = area;
+            }
+        }
+
+        if (bestArea >= 0)
+            return bestFit;
+        return smallestArea < long.MaxValue ? smallest : CreateFallback(targetWidth, targetHeight);
+    }
+
+    private static int CompareBySize(Vector2Int left, Vector2Int right)
+    {
+        int widthComparison = left.x.CompareTo(right.x);
+        return widthComparison != 0 ? widthComparison : left.y.CompareTo(right.y);
+    }
+
+    private static Vector2Int CreateFallback(int targetWidth, int targetHeight)
+    {
+        if (targetWidth <= 0 || targetHeight <= 0)
+            return new Vector2Int(1920, 1080);
+
+        foreach (Vector2Int candidate in _commonFallbacks)
+        {
+            if (candidate.x <= targetWidth && candidate.y <= targetHeight)
+                return candidate;
+        }
+
+        int scale = Math.Max(1, Math.Min(targetWidth / 16, targetHeight / 9));
+        return new Vector2Int(scale * 16, scale * 9);
+    }
+}

--- a/Assets/Scripts/UserSettings/UserVideoSettings.cs
+++ b/Assets/Scripts/UserSettings/UserVideoSettings.cs
@@ -43,7 +43,7 @@ public sealed class UserVideoSettings
     /// </summary>
     public void Normalize()
     {
-        if (ResolutionWidth <= 0 || ResolutionHeight <= 0)
+        if (!DisplayResolutionPolicy.IsSixteenByNine(ResolutionWidth, ResolutionHeight))
         {
             ResolutionWidth = 0;
             ResolutionHeight = 0;

--- a/Assets/Tests/EditMode/EditMode.asmdef
+++ b/Assets/Tests/EditMode/EditMode.asmdef
@@ -5,6 +5,7 @@
     ],
     "references": [
         "GameAssembly",
+        "Unity.InputSystem",
         "Unity.TextMeshPro",
         "UnityEditor.TestRunner",
         "UnityEngine.TestRunner"

--- a/Assets/Tests/EditMode/Managers/InputBindingStoreTests.cs
+++ b/Assets/Tests/EditMode/Managers/InputBindingStoreTests.cs
@@ -1,0 +1,89 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Rebellion.Tests.Managers
+{
+    [TestFixture]
+    public sealed class InputBindingStoreTests
+    {
+        [Test]
+        public void BindingOverrides_TenPreviouslyEmptyActions_RestoreAcrossManagerRestart()
+        {
+            string[] actionNames =
+            {
+                "ShowPopularSupport",
+                "ShowUprisings",
+                "ShowIdleFleets",
+                "ShowFleetsEnroute",
+                "ShowIdlePersonnel",
+                "ShowActivePersonnel",
+                "ShowAvailableEnergy",
+                "ShowAvailableRawMaterial",
+                "ShowMines",
+                "ShowRefineries",
+            };
+            string[] paths =
+            {
+                "<Keyboard>/f1",
+                "<Keyboard>/f2",
+                "<Keyboard>/f3",
+                "<Keyboard>/f4",
+                "<Keyboard>/f5",
+                "<Keyboard>/f6",
+                "<Keyboard>/f7",
+                "<Keyboard>/f8",
+                "<Keyboard>/f9",
+                "<Keyboard>/f10",
+            };
+            GameObject firstRoot = new GameObject("FirstInputManager");
+            GameObject secondRoot = null;
+            try
+            {
+                InputManager first = firstRoot.AddComponent<InputManager>();
+                Guid[] firstSlotIds = new Guid[actionNames.Length];
+                for (int index = 0; index < actionNames.Length; index++)
+                {
+                    string actionPath = $"Strategy/{actionNames[index]}";
+                    firstSlotIds[index] = first.GetBindingSlotId(actionPath, 0);
+                    first.ApplyBindingSlotOverride(actionPath, 0, paths[index]);
+                }
+
+                string json = first.SaveBindingOverrides();
+                json = json.Replace(firstSlotIds[0].ToString(), Guid.NewGuid().ToString());
+                UnityEngine.Object.DestroyImmediate(firstRoot);
+                firstRoot = null;
+
+                secondRoot = new GameObject("SecondInputManager");
+                InputManager second = secondRoot.AddComponent<InputManager>();
+                second.LoadBindingOverrides(json);
+                for (int index = 0; index < actionNames.Length; index++)
+                {
+                    string actionPath = $"Strategy/{actionNames[index]}";
+                    Assert.AreEqual(firstSlotIds[index], second.GetBindingSlotId(actionPath, 0));
+                    Assert.AreEqual(
+                        paths[index],
+                        second.GetEffectiveBindingSlotPath(actionPath, 0)
+                    );
+                }
+            }
+            finally
+            {
+                if (firstRoot != null)
+                    UnityEngine.Object.DestroyImmediate(firstRoot);
+                if (secondRoot != null)
+                    UnityEngine.Object.DestroyImmediate(secondRoot);
+            }
+        }
+
+        [Test]
+        public void IsModifierControlName_RecognizesAggregateKeyboardControls()
+        {
+            Assert.IsTrue(InputManager.IsModifierControlName("ctrl"));
+            Assert.IsTrue(InputManager.IsModifierControlName("shift"));
+            Assert.IsTrue(InputManager.IsModifierControlName("alt"));
+            Assert.IsTrue(InputManager.IsModifierControlName("leftMeta"));
+            Assert.IsFalse(InputManager.IsModifierControlName("b"));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Managers/SaveGameManagerTests.cs
+++ b/Assets/Tests/EditMode/Managers/SaveGameManagerTests.cs
@@ -128,6 +128,47 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
+        public void SaveGameData_OverlongDisplayName_TruncatesStoredName()
+        {
+            GameRoot game = new GameRoot
+            {
+                Summary = new GameSummary(),
+                Factions = _factions,
+                Galaxy = new GalaxyMap(),
+            };
+            string overlongName = new string('N', SaveGameManager.MaxDisplayNameLength + 10);
+
+            _saveGameManager.SaveGameData(game, _saveFileName, overlongName);
+
+            GameRoot loadedGame = _saveGameManager.LoadGameData(_saveFileName);
+            Assert.AreEqual(
+                SaveGameManager.MaxDisplayNameLength,
+                loadedGame.Metadata.SaveDisplayName.Length
+            );
+        }
+
+        [Test]
+        public void SetSaveDisplayName_OverlongName_TruncatesMetadataName()
+        {
+            GameRoot game = new GameRoot
+            {
+                Summary = new GameSummary(),
+                Factions = _factions,
+                Galaxy = new GalaxyMap(),
+            };
+            _saveGameManager.SaveGameData(game, _saveFileName, "Initial Name");
+            string overlongName = new string('N', SaveGameManager.MaxDisplayNameLength + 10);
+
+            _saveGameManager.SetSaveDisplayName(_saveFileName, overlongName);
+
+            SaveGameEntry entry = _saveGameManager.GetSavedGames().Single();
+            Assert.AreEqual(
+                SaveGameManager.MaxDisplayNameLength,
+                entry.Metadata.SaveDisplayName.Length
+            );
+        }
+
+        [Test]
         public void SaveSlotGameData_ValidGame_WritesMetadataSidecar()
         {
             GameRoot game = new GameRoot

--- a/Assets/Tests/EditMode/Managers/UserSettingsManagerTests.cs
+++ b/Assets/Tests/EditMode/Managers/UserSettingsManagerTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Rebellion.Tests.Managers
+{
+    [TestFixture]
+    public sealed class UserSettingsManagerTests
+    {
+        [Test]
+        public void SaveThenLoad_RestoresRuntimeBindingOverridesFromDisk()
+        {
+            string directory = Path.Combine(
+                Path.GetTempPath(),
+                $"rebellion2-settings-{Guid.NewGuid():N}"
+            );
+            string path = Path.Combine(directory, "user-settings.json");
+            GameObject firstRoot = new GameObject("FirstInputManager");
+            GameObject secondRoot = null;
+            try
+            {
+                InputManager firstInput = firstRoot.AddComponent<InputManager>();
+                UserSettingsManager firstSettings = new UserSettingsManager(null, firstInput, path);
+                firstSettings.Load();
+                firstInput.ApplyBindingSlotOverride("Strategy/ShowTroopers", 0, "<Keyboard>/n");
+                firstSettings.Save();
+
+                UnityEngine.Object.DestroyImmediate(firstRoot);
+                firstRoot = null;
+                secondRoot = new GameObject("SecondInputManager");
+                InputManager secondInput = secondRoot.AddComponent<InputManager>();
+                UserSettingsManager secondSettings = new UserSettingsManager(
+                    null,
+                    secondInput,
+                    path
+                );
+                secondSettings.Load();
+
+                Assert.AreEqual(
+                    "<Keyboard>/n",
+                    secondInput.GetEffectiveBindingSlotPath("Strategy/ShowTroopers", 0)
+                );
+            }
+            finally
+            {
+                if (firstRoot != null)
+                    UnityEngine.Object.DestroyImmediate(firstRoot);
+                if (secondRoot != null)
+                    UnityEngine.Object.DestroyImmediate(secondRoot);
+                if (Directory.Exists(directory))
+                    Directory.Delete(directory, true);
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/UI/SceneUI/MainMenu/MainMenuViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/MainMenu/MainMenuViewTests.cs
@@ -269,6 +269,7 @@ namespace Rebellion.Tests.UI.SceneUI.MainMenu
                     "Application/MainMenu/Audio/select",
                     "Application/MainMenu/Audio/galaxysize-select",
                     "Application/MainMenu/Audio/exit-select",
+                    "Application/MainMenu/Audio/faction-select",
                 },
                 _view.GetAudioCuePaths()
             );

--- a/Assets/Tests/EditMode/UI/SceneUI/SaveMenu/Presentation/SaveMenuConfirmDialogViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/SaveMenu/Presentation/SaveMenuConfirmDialogViewTests.cs
@@ -62,6 +62,22 @@ namespace Rebellion.Tests.UI.SceneUI.SaveMenu.Presentation
         }
 
         [Test]
+        public void Show_LegacyFixedBlocker_StretchesAcrossDialogRoot()
+        {
+            RectTransform blocker = _view.transform.Find("InputBlocker") as RectTransform;
+            blocker.anchorMin = new Vector2(0f, 1f);
+            blocker.anchorMax = new Vector2(0f, 1f);
+            blocker.sizeDelta = new Vector2(640f, 480f);
+
+            _view.Show("Confirm");
+
+            Assert.AreEqual(Vector2.zero, blocker.anchorMin);
+            Assert.AreEqual(Vector2.one, blocker.anchorMax);
+            Assert.AreEqual(Vector2.zero, blocker.sizeDelta);
+            Assert.AreEqual(Vector2.zero, blocker.anchoredPosition);
+        }
+
+        [Test]
         public void Hide_VisibleDialog_HidesWithoutResponse()
         {
             int responseCount = 0;

--- a/Assets/Tests/EditMode/UI/SceneUI/SaveMenu/Presentation/SaveMenuSlotRowViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/SaveMenu/Presentation/SaveMenuSlotRowViewTests.cs
@@ -74,6 +74,29 @@ namespace Rebellion.Tests.UI.SceneUI.SaveMenu.Presentation
         }
 
         [Test]
+        public void Render_NameInput_AlignsTextPlaceholderAndCaretViewport()
+        {
+            _view.Render(new SaveSlotRenderData(0, "Campaign", true, false, null));
+
+            TMP_InputField input = GetField<TMP_InputField>("nameInputField");
+            TextMeshProUGUI text = (TextMeshProUGUI)input.textComponent;
+            TextMeshProUGUI placeholder = (TextMeshProUGUI)input.placeholder;
+
+            Assert.AreEqual(TextAlignmentOptions.MidlineLeft, text.alignment);
+            Assert.AreEqual(TextAlignmentOptions.MidlineLeft, placeholder.alignment);
+            Assert.AreEqual(Vector2.zero, text.rectTransform.anchorMin);
+            Assert.AreEqual(Vector2.one, text.rectTransform.anchorMax);
+            Assert.AreEqual(Vector2.zero, placeholder.rectTransform.anchorMin);
+            Assert.AreEqual(Vector2.one, placeholder.rectTransform.anchorMax);
+            Assert.AreSame(input.transform, input.textViewport);
+            Assert.IsTrue(input.customCaretColor);
+            Assert.AreEqual(Color.white, input.caretColor);
+            Assert.AreEqual(2, input.caretWidth);
+            Assert.AreEqual(SaveGameManager.MaxDisplayNameLength, input.characterLimit);
+            Assert.IsFalse(input.onFocusSelectAll);
+        }
+
+        [Test]
         public void Render_UpdatedSameSlot_PreservesInProgressDraft()
         {
             _view.Render(new SaveSlotRenderData(2, "Campaign", true, true, null));

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/ContextMenus/StrategyContextMenuRouterTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/ContextMenus/StrategyContextMenuRouterTests.cs
@@ -145,6 +145,40 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.ContextMenus
         }
 
         [Test]
+        public void TryExecuteShortcut_EnabledMatchingCommand_ExecutesWithoutOpeningMenu()
+        {
+            RecordingReceiver receiver = new RecordingReceiver();
+            StrategyMenuCommand command = new StrategyMenuCommand(
+                StrategyMenuAction.MoveConfirm,
+                "Confirmed Move",
+                true
+            );
+            _provider.Handle = true;
+            _provider.Request = new ContextMenuRequest(
+                _window,
+                new IContextMenuCommand[] { command },
+                receiver
+            );
+            PointerEventData eventData = new PointerEventData(null)
+            {
+                pointerCurrentRaycast = new RaycastResult { gameObject = _window.gameObject },
+            };
+
+            bool executed = _router.TryExecuteShortcut(
+                eventData,
+                17,
+                29,
+                StrategyMenuAction.MoveConfirm
+            );
+
+            Assert.IsTrue(executed);
+            Assert.AreEqual(1, receiver.SelectedCount);
+            Assert.AreSame(command, receiver.LastCommand);
+            Assert.IsFalse(_menuController.IsOpen);
+            Assert.IsFalse(_presenter.Open);
+        }
+
+        [Test]
         public void OpenContextMenu_NullWindow_CancelsRequestAndResetsPresenter()
         {
             RecordingReceiver receiver = new RecordingReceiver();

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayControllerTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayControllerTests.cs
@@ -151,6 +151,31 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
+        public void SelectFilterFromShortcut_ChangedFilter_PlaysControlSoundAndRequestsRender()
+        {
+            _controller.SelectFilterFromShortcut(GalacticInformationFilterMode.Troopers);
+
+            Assert.AreEqual(GalacticInformationFilterMode.Troopers, _controller.FilterMode);
+            CollectionAssert.AreEqual(
+                new[] { StrategyUISoundPaths.GalacticInformationControl },
+                _playedSounds
+            );
+            Assert.AreEqual(1, _actions.RenderRequestCount);
+        }
+
+        [Test]
+        public void SelectFilterFromShortcut_ActiveFilter_DoesNotRepeatControlSound()
+        {
+            _controller.SelectFilter(GalacticInformationFilterMode.Troopers);
+            _actions.RenderRequestCount = 0;
+
+            _controller.SelectFilterFromShortcut(GalacticInformationFilterMode.Troopers);
+
+            Assert.IsEmpty(_playedSounds);
+            Assert.AreEqual(1, _actions.RenderRequestCount);
+        }
+
+        [Test]
         public void SelectorControls_FilterSelection_RouteSemanticControllerAction()
         {
             _controller.Show();

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
@@ -336,6 +336,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             );
 
             Assert.AreEqual(new Color(0.5f, 0.5f, 0.5f, 1f), data.BackgroundColor);
+            Assert.AreEqual("Briefing", data.ActiveFilterLabel.Text);
             Assert.IsNotNull(data.Clusters[0].Stars[0].StarTexture);
         }
 

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Options/OptionsBindingEditorTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Options/OptionsBindingEditorTests.cs
@@ -1,0 +1,109 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Rebellion.Tests.UI.SceneUI.StrategyView.Options
+{
+    [TestFixture]
+    public sealed class OptionsBindingEditorTests
+    {
+        private GameObject _root;
+        private InputManager _inputManager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new GameObject("InputManager");
+            _inputManager = _root.AddComponent<InputManager>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_root);
+        }
+
+        [Test]
+        public void CompositeSignatures_UseActualModifierAndButtonParts()
+        {
+            InputAction decrease = _inputManager.Asset.FindAction(
+                "Strategy/DecreaseGameSpeed",
+                true
+            );
+            InputAction increase = _inputManager.Asset.FindAction(
+                "Strategy/IncreaseGameSpeed",
+                true
+            );
+            int decreasePrimary = InputBindingStore.GetTopLevelBindingIndex(decrease, 0);
+            int increasePrimary = InputBindingStore.GetTopLevelBindingIndex(increase, 0);
+
+            string decreaseSignature = OptionsBindingEditor.GetBindingSignature(
+                decrease,
+                decreasePrimary
+            );
+            string increaseSignature = OptionsBindingEditor.GetBindingSignature(
+                increase,
+                increasePrimary
+            );
+
+            StringAssert.Contains("<Keyboard>/minus", decreaseSignature);
+            StringAssert.EndsWith($"|{KeyboardChordProcessor.Control}", decreaseSignature);
+            Assert.AreNotEqual(decreaseSignature, increaseSignature);
+        }
+
+        [Test]
+        public void CompositeAndProcessorSignatures_MatchForEquivalentChord()
+        {
+            InputAction composite = _inputManager.Asset.FindAction(
+                "Strategy/DecreaseGameSpeed",
+                true
+            );
+            InputAction processor = _inputManager.Asset.FindAction("Strategy/ShowTroopers", true);
+            int compositeIndex = InputBindingStore.GetTopLevelBindingIndex(composite, 0);
+            int processorIndex = InputBindingStore.GetTopLevelBindingIndex(processor, 0);
+            processor.ApplyBindingOverride(
+                processorIndex,
+                new InputBinding
+                {
+                    overridePath = "<Keyboard>/minus",
+                    overrideProcessors = KeyboardChordProcessor.GetProcessorOverride(
+                        KeyboardChordProcessor.Control
+                    ),
+                }
+            );
+
+            Assert.AreEqual(
+                OptionsBindingEditor.GetBindingSignature(composite, compositeIndex),
+                OptionsBindingEditor.GetBindingSignature(processor, processorIndex)
+            );
+        }
+
+        [Test]
+        public void ProcessorSignatures_DistinguishPlainKeyFromModifiedChord()
+        {
+            InputAction first = _inputManager.Asset.FindAction("Strategy/ShowTroopers", true);
+            InputAction second = _inputManager.Asset.FindAction(
+                "Strategy/ShowFighterSquadrons",
+                true
+            );
+            int firstIndex = InputBindingStore.GetTopLevelBindingIndex(first, 0);
+            int secondIndex = InputBindingStore.GetTopLevelBindingIndex(second, 0);
+            first.ApplyBindingOverride(firstIndex, "<Keyboard>/b");
+            second.ApplyBindingOverride(
+                secondIndex,
+                new InputBinding
+                {
+                    overridePath = "<Keyboard>/b",
+                    overrideProcessors = KeyboardChordProcessor.GetProcessorOverride(
+                        KeyboardChordProcessor.Control
+                    ),
+                }
+            );
+
+            Assert.AreNotEqual(
+                OptionsBindingEditor.GetBindingSignature(first, firstIndex),
+                OptionsBindingEditor.GetBindingSignature(second, secondIndex)
+            );
+        }
+    }
+}

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Options/OptionsMenuViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Options/OptionsMenuViewTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Rebellion.Tests.UI.SceneUI.StrategyView.Options
+{
+    [TestFixture]
+    public sealed class OptionsMenuViewTests
+    {
+        private const string _prefabPath = "Assets/Prefabs/UI/OptionsMenu/OptionsMenu.prefab";
+
+        private GameObject _root;
+        private OptionsMenuView _view;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            _view = _root.GetComponent<OptionsMenuView>();
+            UIComponentTestHelper.InvokeLifecycle(_view, "Awake");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UnityEngine.Object.DestroyImmediate(_root);
+        }
+
+        [Test]
+        public void DisplaySteppers_Click_RaiseSemanticRequests()
+        {
+            int resolutionDelta = 0;
+            int fullScreenDelta = 0;
+            _view.ResolutionStepRequested += delta => resolutionDelta = delta;
+            _view.FullScreenStepRequested += delta => fullScreenDelta = delta;
+
+            GetField<Button>("_resolutionNextButton").onClick.Invoke();
+            GetField<Button>("_fullScreenPrevButton").onClick.Invoke();
+
+            Assert.AreEqual(1, resolutionDelta);
+            Assert.AreEqual(-1, fullScreenDelta);
+        }
+
+        [Test]
+        public void DisplaySteppers_Awake_ExpandAcrossCompleteValueBadge()
+        {
+            RectTransform resolutionPrevious = (RectTransform)
+                GetField<Button>("_resolutionPrevButton").transform;
+            RectTransform resolutionNext = (RectTransform)
+                GetField<Button>("_resolutionNextButton").transform;
+            RectTransform fullScreenPrevious = (RectTransform)
+                GetField<Button>("_fullScreenPrevButton").transform;
+            RectTransform fullScreenNext = (RectTransform)
+                GetField<Button>("_fullScreenNextButton").transform;
+
+            Assert.AreEqual(78f, resolutionPrevious.sizeDelta.x);
+            Assert.AreEqual(77f, resolutionNext.sizeDelta.x);
+            Assert.AreEqual(78f, fullScreenPrevious.sizeDelta.x);
+            Assert.AreEqual(77f, fullScreenNext.sizeDelta.x);
+            Assert.AreEqual(272f, resolutionNext.anchoredPosition.x);
+            Assert.AreEqual(272f, fullScreenNext.anchoredPosition.x);
+        }
+
+        [Test]
+        public void RenameInput_AlignmentConfiguresVisibleBlinkingCaret()
+        {
+            _view.AlignRenameInput();
+
+            TMP_InputField input = GetField<TMP_InputField>("_slotRenameField");
+            Assert.IsTrue(input.customCaretColor);
+            Assert.AreEqual(Color.white, input.caretColor);
+            Assert.AreEqual(2, input.caretWidth);
+            Assert.AreEqual(0.85f, input.caretBlinkRate);
+            Assert.AreEqual(SaveGameManager.MaxDisplayNameLength, input.characterLimit);
+            Assert.IsFalse(input.onFocusSelectAll);
+            Assert.AreSame(input.transform, input.textViewport);
+            Assert.AreEqual(
+                TextAlignmentOptions.MidlineLeft,
+                ((TextMeshProUGUI)input.textComponent).alignment
+            );
+        }
+
+        [Test]
+        public void SaveList_OverlongName_TruncatesRenderedText()
+        {
+            OptionsSaveSlot savedGame = new OptionsSaveSlot(
+                new string('N', SaveGameManager.MaxDisplayNameLength + 10),
+                "Today",
+                null,
+                false,
+                "test_save"
+            );
+
+            _view.Render(CreateRenderData(savedGame));
+
+            TextMeshProUGUI renderedName = _root
+                .GetComponentsInChildren<TextMeshProUGUI>(true)
+                .Single(text => text.name == "SlotName0");
+            Assert.AreEqual(SaveGameManager.MaxDisplayNameLength, renderedName.text.Length);
+        }
+
+        [Test]
+        public void SaveList_AfterRowCountGrows_ReactivatesFactionIcon()
+        {
+            Texture2D factionIcon = new Texture2D(16, 16);
+            try
+            {
+                OptionsSaveSlot createNew = new OptionsSaveSlot(
+                    "Create New Save",
+                    string.Empty,
+                    null,
+                    true,
+                    null
+                );
+                OptionsSaveSlot savedGame = new OptionsSaveSlot(
+                    "Test Save",
+                    "Today",
+                    factionIcon,
+                    false,
+                    "test_save"
+                );
+
+                _view.Render(CreateRenderData(createNew, savedGame));
+                _view.Render(CreateRenderData(createNew));
+                _view.Render(CreateRenderData(createNew, savedGame));
+
+                RawImage renderedIcon = _root
+                    .GetComponentsInChildren<RawImage>(true)
+                    .Single(image => image.name == "SlotIcon1");
+                Assert.IsTrue(renderedIcon.gameObject.activeSelf);
+                Assert.IsTrue(renderedIcon.enabled);
+                Assert.AreSame(factionIcon, renderedIcon.texture);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(factionIcon);
+            }
+        }
+
+        [Test]
+        public void RenderFooter_MainMenuHost_HidesUnavailableRowsAndCollapsesQuitToTop()
+        {
+            OptionsMenuRenderData data = new OptionsMenuRenderData(
+                0,
+                0,
+                OptionsMenuTab.Graphics,
+                string.Empty,
+                string.Empty,
+                new Dictionary<UserTacticalOption, bool>(),
+                Array.Empty<float>(),
+                Array.Empty<OptionsBindingRow>(),
+                Array.Empty<OptionsSaveSlot>(),
+                -1,
+                false,
+                true,
+                false,
+                false,
+                -1,
+                false
+            );
+
+            typeof(OptionsMenuView)
+                .GetMethod("RenderFooter", BindingFlags.Instance | BindingFlags.NonPublic)
+                .Invoke(_view, new object[] { data });
+
+            Button backToGame = GetField<Button>("_backToGameButton");
+            Button mainMenu = GetField<Button>("_mainMenuButton");
+            Button quit = GetField<Button>("_quitButton");
+            Assert.IsFalse(backToGame.gameObject.activeSelf);
+            Assert.IsFalse(mainMenu.gameObject.activeSelf);
+            Assert.IsTrue(quit.gameObject.activeSelf);
+            Assert.IsNotNull(quit.transform.parent.GetComponent<VerticalLayoutGroup>());
+            Assert.AreEqual(38, UILayout.GetSourceRect((RectTransform)quit.transform).x);
+            Assert.AreEqual(226, UILayout.GetSourceRect((RectTransform)quit.transform).y);
+        }
+
+        [Test]
+        public void Controls_FirstActionAfterHeader_RaisesModelBindingIndex()
+        {
+            int requestedRow = -1;
+            _view.RebindRequested += (row, _) => requestedRow = row;
+            OptionsMenuRenderData data = new OptionsMenuRenderData(
+                0,
+                0,
+                OptionsMenuTab.Controls,
+                string.Empty,
+                string.Empty,
+                new Dictionary<UserTacticalOption, bool>(),
+                Array.Empty<float>(),
+                new[]
+                {
+                    new OptionsBindingRow("Strategy", string.Empty, string.Empty, true),
+                    new OptionsBindingRow("Show Troopers", "N"),
+                },
+                Array.Empty<OptionsSaveSlot>(),
+                -1,
+                false,
+                false,
+                true,
+                true,
+                -1,
+                false
+            );
+
+            _view.Render(data);
+            GetField<List<Image>>("_bindingBadgeImages")[0].GetComponent<Button>().onClick.Invoke();
+
+            Assert.AreEqual(1, requestedRow);
+        }
+
+        private T GetField<T>(string fieldName)
+        {
+            return (T)
+                typeof(OptionsMenuView)
+                    .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(_view);
+        }
+
+        private static OptionsMenuRenderData CreateRenderData(params OptionsSaveSlot[] saveSlots)
+        {
+            return new OptionsMenuRenderData(
+                0,
+                0,
+                OptionsMenuTab.SaveLoad,
+                string.Empty,
+                string.Empty,
+                new Dictionary<UserTacticalOption, bool>(),
+                Array.Empty<float>(),
+                Array.Empty<OptionsBindingRow>(),
+                saveSlots,
+                -1,
+                false,
+                true,
+                true,
+                true,
+                -1,
+                false
+            );
+        }
+    }
+}

--- a/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Windows/StrategyWindowLayerViewTests.cs
+++ b/Assets/Tests/EditMode/UI/SceneUI/StrategyView/Windows/StrategyWindowLayerViewTests.cs
@@ -112,6 +112,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
             Assert.IsTrue(dimmer.gameObject.activeSelf);
             Assert.AreEqual(0, blocker.transform.GetSiblingIndex());
             Assert.AreEqual(1, dimmer.transform.GetSiblingIndex());
+            Assert.AreEqual(new Color(0f, 0f, 0f, 0.8f), dimmer.color);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UserSettings/UserVideoSettingsTests.cs
+++ b/Assets/Tests/EditMode/UserSettings/UserVideoSettingsTests.cs
@@ -81,6 +81,58 @@ namespace Rebellion.Tests.UserSettings
         }
 
         [Test]
+        public void Normalize_NonSixteenByNineResolution_ClearsLegacySelection()
+        {
+            UserVideoSettings settings = new UserVideoSettings
+            {
+                ResolutionWidth = 3840,
+                ResolutionHeight = 1600,
+            };
+
+            settings.Normalize();
+
+            Assert.AreEqual(0, settings.ResolutionWidth);
+            Assert.AreEqual(0, settings.ResolutionHeight);
+        }
+
+        [Test]
+        public void Resolve_UltrawideTarget_SelectsLargestFittingSixteenByNineMode()
+        {
+            Vector2Int[] supported =
+            {
+                new Vector2Int(1280, 720),
+                new Vector2Int(1920, 1080),
+                new Vector2Int(2560, 1440),
+                new Vector2Int(3840, 2160),
+            };
+
+            Vector2Int selected = DisplayResolutionPolicy.Resolve(
+                supported,
+                3840,
+                1600,
+                3840,
+                1600
+            );
+
+            Assert.AreEqual(new Vector2Int(2560, 1440), selected);
+            Assert.IsTrue(DisplayResolutionPolicy.IsSixteenByNine(selected.x, selected.y));
+        }
+
+        [TestCase(1920, 1080, true)]
+        [TestCase(2560, 1440, true)]
+        [TestCase(3840, 1600, false)]
+        [TestCase(1366, 768, true)]
+        [TestCase(1920, 1200, false)]
+        public void IsSixteenByNine_AcceptsOnlySixteenByNineModes(
+            int width,
+            int height,
+            bool expected
+        )
+        {
+            Assert.AreEqual(expected, DisplayResolutionPolicy.IsSixteenByNine(width, height));
+        }
+
+        [Test]
         public void JsonUtility_ExplicitTacticalOptions_RoundTripsState()
         {
             global::UserSettings settings = new global::UserSettings();

--- a/Docs/Development.md
+++ b/Docs/Development.md
@@ -17,12 +17,13 @@ or otherwise redistribute `rebellion2-media`, `Assets/Content`, or any copyright
 2. Copy `rebellion2-media/Content/` to `rebellion2/Assets/Content/`.
 3. Copy `rebellion2-media/Models/MainMenu/` to
    `rebellion2/Assets/Art/Models/MainMenu/`.
-4. Open `rebellion2` in Unity and allow the assets to import.
-5. Run **Rebellion > UI > Build All**.
+4. Copy `rebellion2-media/UI/` to `rebellion2/Assets/UI/`.
+5. Open `rebellion2` in Unity and allow the assets to import.
+6. Run **Rebellion > UI > Build All**.
 
-The copied content, generated UI prefabs, and generated scenes are local development artifacts and
-are ignored by Git. Repeat the copies when `rebellion2-media` changes and rebuild the UI after
-changing builder code or content used by a builder.
+The copied content and UI, generated UI prefabs, and generated scenes are local development
+artifacts and are ignored by Git. Repeat the copies when `rebellion2-media` changes and rebuild the
+UI after changing builder code or content used by a builder.
 
 ## Commands
 

--- a/EditorAssembly.Lint.csproj
+++ b/EditorAssembly.Lint.csproj
@@ -71,6 +71,20 @@
       <Private>false</Private>
     </Reference>
     <Reference
+      Include="UnityEngine.ImageConversionModule"
+      Condition="Exists('$(UnityManagedAssembliesPath)/UnityEngine.ImageConversionModule.dll')"
+    >
+      <HintPath>$(UnityManagedAssembliesPath)/UnityEngine.ImageConversionModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference
+      Include="UnityEngine.TextRenderingModule"
+      Condition="Exists('$(UnityManagedAssembliesPath)/UnityEngine.TextRenderingModule.dll')"
+    >
+      <HintPath>$(UnityManagedAssembliesPath)/UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference
       Include="UnityEngine.AnimationModule"
       Condition="Exists('$(UnityManagedAssembliesPath)/UnityEngine.AnimationModule.dll')"
     >


### PR DESCRIPTION
## Summary

Adds the unified Options overlay to the main menu and strategy view, then hardens its settings, input, save/load, display, modal, and lifecycle architecture.

The required UI media is isolated in the private companion PR [rebellion2-media#41](https://github.com/davidadas/rebellion2-media/pull/41). No Options PNGs or generated prefabs are committed here.

## Root causes fixed

- Controls rows used compacted visual indices against a model containing section headers, so displayed bindings targeted the wrong actions.
- Binding overrides lacked stable authored slots and a reliable persistence boundary.
- Modifier capture, composite shortcuts, conflict detection, and gameplay input suppression had overlapping ownership.
- Graphics, audio, and input edits were not managed as one transactional Apply/Cancel session.
- Controllers and views mixed orchestration, persistence, generated layout repair, save presentation, and input lifecycle responsibilities.
- Menu and strategy input contexts could remain active behind modal UI.

## Player and developer impact

- Plain keys and modifier chords bind, conflict-check, apply, and survive restart.
- Display settings use supported 16:9 modes and apply through a consistent workflow.
- Save selection follows the saved item after recency sorting, and save-name editing has correct focus/caret behavior.
- Modal dimming, briefing text, confirmation transitions, and targeting cursor ownership are consistent.
- Runtime layout repair hacks are removed; prefab builders author the UI structure.
- Options controllers and views have focused ownership and explicit lifecycle boundaries.
- Development setup documents copying build-time UI assets from `rebellion2-media`.

## Validation

- Unity EditMode: 3,718 passed, 0 failed
- Runtime and EditMode builds: 0 errors, 0 warnings
- Roslynator: 0 diagnostics
- Member-order analyzer: 0 diagnostics
- Analyzer tests: 4 passed
- CSharpier: 689 files clean
- `git diff --check`: clean
- Final branch tree is identical to the validated tree except for removing source-owned PNGs and documenting their media copy path.

## Checklist

- [x] Relevant automated tests pass.
- [x] AI-assisted code received a full adversarial architectural review and cleanup.
- [x] UI builders were rebuilt by the Unity EditMode workflow.
- [x] Content path and structure changes are included in `rebellion2-media#41`.
- [x] Generated UI prefabs, generated scenes, and copyrighted media are not committed.
- [x] Development setup documentation was updated.

A standalone-player smoke test remains appropriate for OS-level fullscreen transitions and physical keyboard behavior, which the editor test runner cannot faithfully reproduce.
