### PR TITLE
Enable AI colony establishment

### DIFF
--- a/Assets/Scripts/AI/Planners/AIProductionDemand.cs
+++ b/Assets/Scripts/AI/Planners/AIProductionDemand.cs
@@ -10,6 +10,7 @@ namespace Rebellion.AI.Planners
     public enum AIProductionDemandKind
     {
         None,
+        Colony,
         Mine,
         Refinery,
         ConstructionFacility,

--- a/Assets/Scripts/AI/Planners/AIProductionDemandGenerator.cs
+++ b/Assets/Scripts/AI/Planners/AIProductionDemandGenerator.cs
@@ -26,6 +26,7 @@ namespace Rebellion.AI.Planners
             if (context?.Game == null || context.Faction == null || context.Assessment == null)
                 return demands;
 
+            AddColonyDemands(context, demands);
             AddResourceBalanceDemand(context, demands);
             AddPlanetaryDefenseDemands(context, demands);
             AddPlanetaryStarfighterDemands(context, demands);
@@ -37,6 +38,57 @@ namespace Rebellion.AI.Planners
             AddProductionFacilityUpgradeDemands(context, demands);
 
             return demands;
+        }
+
+        /// <summary>
+        /// Adds a first-facility demand for each claimed but uncolonized planet.
+        /// </summary>
+        /// <param name="context">The current AI turn context.</param>
+        /// <param name="demands">The demand list to update.</param>
+        private void AddColonyDemands(AITurnContext context, List<AIProductionDemand> demands)
+        {
+            foreach (
+                Planet planet in context
+                    .Assessment.OwnedPlanets.Where(IsClaimedUncolonizedPlanet)
+                    .OrderByDescending(planet => planet.GetUnminedResourceNodeCount())
+                    .ThenBy(planet => planet.InstanceID, StringComparer.Ordinal)
+            )
+            {
+                BuildingType buildingType =
+                    planet.GetUnminedResourceNodeCount() > 0
+                        ? BuildingType.Mine
+                        : BuildingType.Refinery;
+                demands.Add(
+                    new AIProductionDemand(
+                        $"production:{context.Faction.InstanceID}:{AIProductionDemandKind.Colony}:{planet.InstanceID}",
+                        AIProductionDemandKind.Colony,
+                        ManufacturingType.Building,
+                        buildingType,
+                        planet,
+                        1,
+                        context.Game.Config.AI.Infrastructure.EconomySevereDemandPercent
+                    )
+                );
+            }
+        }
+
+        /// <summary>
+        /// Returns whether a planet is a live military claim awaiting its first facility.
+        /// </summary>
+        /// <param name="planet">The planet to inspect.</param>
+        /// <returns>True when the planet requires a founding facility.</returns>
+        private static bool IsClaimedUncolonizedPlanet(Planet planet)
+        {
+            return planet?.IsColonized == false
+                && !planet.IsDestroyed
+                && planet.GetAvailableEnergy() > 0
+                && planet
+                    .GetAllRegiments()
+                    .Any(regiment =>
+                        regiment.ManufacturingStatus == ManufacturingStatus.Complete
+                        && regiment.Movement == null
+                        && regiment.GetOwnerInstanceID() == planet.GetOwnerInstanceID()
+                    );
         }
 
         private void AddPlanetaryDefenseDemands(

--- a/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
+++ b/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
@@ -136,7 +136,8 @@ namespace Rebellion.AI.Planners
 
             return demand.Kind switch
             {
-                AIProductionDemandKind.Mine
+                AIProductionDemandKind.Colony
+                or AIProductionDemandKind.Mine
                 or AIProductionDemandKind.Refinery
                 or AIProductionDemandKind.ConstructionFacility
                 or AIProductionDemandKind.Shipyard

--- a/Assets/Scripts/AI/Proposals/AIManufactureProposal.cs
+++ b/Assets/Scripts/AI/Proposals/AIManufactureProposal.cs
@@ -343,8 +343,9 @@ namespace Rebellion.AI.Proposals
 
             return Demand.Kind switch
             {
-                AIProductionDemandKind.Mine or AIProductionDemandKind.Refinery =>
-                    CanManufactureBuilding(context),
+                AIProductionDemandKind.Colony
+                or AIProductionDemandKind.Mine
+                or AIProductionDemandKind.Refinery => CanManufactureBuilding(context),
                 AIProductionDemandKind.ConstructionFacility
                 or AIProductionDemandKind.Shipyard
                 or AIProductionDemandKind.TrainingFacility

--- a/Assets/Tests/EditMode/AI/Planners/AIProductionDemandGeneratorTests.cs
+++ b/Assets/Tests/EditMode/AI/Planners/AIProductionDemandGeneratorTests.cs
@@ -17,6 +17,53 @@ namespace Rebellion.Tests.AI.Planners
     public class AIProductionDemandGeneratorTests
     {
         [Test]
+        public void Generate_WithClaimedUncolonizedPlanet_AddsColonyDemand()
+        {
+            GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction _);
+            PlanetSystem system = AITestSceneBuilder.AddSystem(game, "sys1");
+            Planet planet = AITestSceneBuilder.AddPlanet(
+                game,
+                system,
+                "claimed-world",
+                empire.InstanceID,
+                rawResourceNodes: 2
+            );
+            planet.IsColonized = false;
+            game.AttachNode(
+                AITestSceneBuilder.CreateRegiment("garrison", empire.InstanceID),
+                planet
+            );
+            AITurnContext context = AITestSceneBuilder.CreateContext(game, empire);
+
+            AIProductionDemand demand = new AIProductionDemandGenerator()
+                .Generate(context)
+                .Single(item => item.Kind == AIProductionDemandKind.Colony);
+
+            Assert.AreSame(planet, demand.DestinationPlanet);
+            Assert.AreEqual(BuildingType.Mine, demand.BuildingType);
+            Assert.AreEqual(1, demand.QuantityNeeded);
+        }
+
+        [Test]
+        public void Generate_WithAbandonedUncolonizedPlanet_DoesNotAddColonyDemand()
+        {
+            GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction _);
+            PlanetSystem system = AITestSceneBuilder.AddSystem(game, "sys1");
+            Planet planet = AITestSceneBuilder.AddPlanet(
+                game,
+                system,
+                "abandoned-world",
+                empire.InstanceID
+            );
+            planet.IsColonized = false;
+            AITurnContext context = AITestSceneBuilder.CreateContext(game, empire);
+
+            List<AIProductionDemand> demands = new AIProductionDemandGenerator().Generate(context);
+
+            Assert.IsFalse(demands.Any(item => item.Kind == AIProductionDemandKind.Colony));
+        }
+
+        [Test]
         public void Generate_WithUnminedResourcesAndBalancedEconomy_AddsMineAndRefineryDemand()
         {
             GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction _);

--- a/Assets/Tests/EditMode/AI/Planners/AIProductionPlannerTests.cs
+++ b/Assets/Tests/EditMode/AI/Planners/AIProductionPlannerTests.cs
@@ -17,6 +17,57 @@ namespace Rebellion.Tests.AI.Planners
     public class AIProductionPlannerTests
     {
         [Test]
+        public void Plan_WithClaimedUncolonizedPlanet_AddsColonyManufactureProposal()
+        {
+            GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction _);
+            PlanetSystem system = AITestSceneBuilder.AddSystem(game, "sys1");
+            Planet producer = AITestSceneBuilder.AddPlanet(
+                game,
+                system,
+                "producer",
+                empire.InstanceID,
+                rawResourceNodes: 2
+            );
+            AITestSceneBuilder.AddProductionFacility(
+                game,
+                producer,
+                "construction-yard",
+                BuildingType.ConstructionFacility,
+                ManufacturingType.Building
+            );
+            Planet colony = AITestSceneBuilder.AddPlanet(
+                game,
+                system,
+                "colony",
+                empire.InstanceID,
+                rawResourceNodes: 2
+            );
+            colony.IsColonized = false;
+            game.AttachNode(
+                AITestSceneBuilder.CreateRegiment("garrison", empire.InstanceID),
+                colony
+            );
+            Building mine = AITestSceneBuilder.CreateBuildingTemplate(
+                "mine-template",
+                BuildingType.Mine
+            );
+            empire.ResearchQueue[ManufacturingType.Building] = new List<Technology>
+            {
+                new Technology(mine),
+            };
+            AITurnContext context = AITestSceneBuilder.CreateContext(game, empire);
+
+            AIManufactureProposal proposal = new AIProductionPlanner()
+                .Plan(context)
+                .OfType<AIManufactureProposal>()
+                .Single(item => item.Demand.Kind == AIProductionDemandKind.Colony);
+
+            Assert.AreSame(producer, proposal.ProducerPlanet);
+            Assert.AreSame(colony, proposal.Destination);
+            Assert.AreSame(mine, proposal.Product.GetReference());
+        }
+
+        [Test]
         public void Plan_WithMineDemandAndUnlockedMine_AddsManufactureProposal()
         {
             GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction _);


### PR DESCRIPTION
## Summary

- Adds production demand for claimed, uncolonized planets
- Builds the first facility needed to establish a permanent colony
- Preserves abandonment behavior for claims without permanent facilities

## Why

AI factions can claim planets with regiments but never establish permanent colonies because production planning ignores uncolonized destinations.

## Validation

- Passes formatting, analyzers, assembly builds, and lint
- Passes the new production demand and planning tests
- Confirms the broader test run reaches the new tests successfully; unrelated local generated-prefab and missing-content failures remain outside this change