### PR TITLE
Simplify event unit movement

### DIFF
--- a/Assets/Scripts/Game/Events/GameAction.cs
+++ b/Assets/Scripts/Game/Events/GameAction.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.Util.Common;
 using Rebellion.Util.Serialization;
@@ -52,16 +53,19 @@ namespace Rebellion.Game.Events
         public GameRoot Game { get; }
         public IRandomNumberProvider Random { get; }
         public GameEventExecutionContext Activation { get; }
+        public IUnitMovement UnitMovement { get; }
 
         public GameActionContext(
             GameRoot game,
             IRandomNumberProvider random,
-            GameEventExecutionContext activation = null
+            GameEventExecutionContext activation = null,
+            IUnitMovement unitMovement = null
         )
         {
             Game = game ?? throw new ArgumentNullException(nameof(game));
             Random = random ?? throw new ArgumentNullException(nameof(random));
             Activation = activation;
+            UnitMovement = unitMovement;
         }
     }
 }

--- a/Assets/Scripts/Game/Events/GameActions.cs
+++ b/Assets/Scripts/Game/Events/GameActions.cs
@@ -1526,15 +1526,12 @@ namespace Rebellion.Game.Events
                 context,
                 "PlaceUnits"
             );
-            return new List<GameResult>
-            {
-                new UnitPlacementRequestedResult
-                {
-                    Units = units,
-                    Destinations = destinations,
-                    Tick = context.Game.CurrentTick,
-                },
-            };
+            if (context.UnitMovement == null)
+                throw new InvalidOperationException(
+                    "PlaceUnits requires the unit movement runtime."
+                );
+            context.UnitMovement.TryPlaceUnits(units, destinations);
+            return new List<GameResult>();
         }
     }
 
@@ -1560,15 +1557,17 @@ namespace Rebellion.Game.Events
                 throw new InvalidOperationException(
                     "SendUnits requires active units at a valid scene location."
                 );
-            return new List<GameResult>
-            {
-                new UnitMovementRequestedResult
-                {
-                    Units = units,
-                    Destinations = destinations,
-                    Tick = context.Game.CurrentTick,
-                },
-            };
+            if (context.UnitMovement == null)
+                throw new InvalidOperationException(
+                    "SendUnits requires the unit movement runtime."
+                );
+            context.UnitMovement.TrySendUnits(
+                units,
+                destinations,
+                context.Activation?.Event?.InstanceID,
+                out IReadOnlyList<GameResult> results
+            );
+            return results.ToList();
         }
     }
 

--- a/Assets/Scripts/Game/Events/GameEvent.cs
+++ b/Assets/Scripts/Game/Events/GameEvent.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.Util.Common;
 using Rebellion.Util.Serialization;
@@ -82,14 +83,21 @@ namespace Rebellion.Game.Events
         /// <param name="game">The current game state.</param>
         /// <param name="provider">Random number provider for stochastic actions.</param>
         /// <param name="context">The scoped target, trigger, state, and runtime bindings.</param>
+        /// <param name="unitMovement">The authoritative unit movement operations.</param>
         /// <returns>Combined results from all executed actions.</returns>
         internal List<GameResult> Execute(
             GameRoot game,
             IRandomNumberProvider provider,
-            GameEventExecutionContext context
+            GameEventExecutionContext context,
+            IUnitMovement unitMovement = null
         )
         {
-            GameActionContext actionContext = new GameActionContext(game, provider, context);
+            GameActionContext actionContext = new GameActionContext(
+                game,
+                provider,
+                context,
+                unitMovement
+            );
             return GameAction.ExecuteAll(Actions, actionContext);
         }
     }

--- a/Assets/Scripts/Game/Movement/MovementState.cs
+++ b/Assets/Scripts/Game/Movement/MovementState.cs
@@ -1,8 +1,36 @@
+using System.Collections.Generic;
 using System.Drawing;
+using Rebellion.Game.Results;
+using Rebellion.Game.Units;
+using Rebellion.SceneGraph;
 using Rebellion.Util.Serialization;
 
 namespace Rebellion.Game.Movement
 {
+    /// <summary>
+    /// Defines the authoritative operations for placing units and sending them through transit.
+    /// </summary>
+    public interface IUnitMovement
+    {
+        /// <summary>
+        /// Sends a unit group to the first destination that accepts the complete group.
+        /// </summary>
+        bool TrySendUnits(
+            IReadOnlyList<IMovable> units,
+            IReadOnlyList<ContainerNode> destinations,
+            string sourceEventInstanceID,
+            out IReadOnlyList<GameResult> results
+        );
+
+        /// <summary>
+        /// Places a unit group immediately at the first destination that accepts it.
+        /// </summary>
+        bool TryPlaceUnits(
+            IReadOnlyList<IMovable> units,
+            IReadOnlyList<ContainerNode> destinations
+        );
+    }
+
     /// <summary>
     /// Encapsulates active movement state for IMovable units.
     /// Existence of this object means unit is in transit.

--- a/Assets/Scripts/Game/Results/GameResults.cs
+++ b/Assets/Scripts/Game/Results/GameResults.cs
@@ -454,24 +454,6 @@ namespace Rebellion.Game.Results
         public AdvisorNotification AdvisorNotification { get; set; }
     }
 
-    /// <summary>
-    /// A data-defined event requested movement through the authoritative movement system.
-    /// </summary>
-    public class UnitMovementRequestedResult : GameResult
-    {
-        public List<IMovable> Units { get; set; } = new List<IMovable>();
-        public List<ContainerNode> Destinations { get; set; } = new List<ContainerNode>();
-    }
-
-    /// <summary>
-    /// A data-defined event requested immediate placement without transit.
-    /// </summary>
-    public sealed class UnitPlacementRequestedResult : GameResult
-    {
-        public List<IMovable> Units { get; set; } = new List<IMovable>();
-        public List<ContainerNode> Destinations { get; set; } = new List<ContainerNode>();
-    }
-
     #endregion
 
     #region GameObject Lifecycle

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -303,14 +303,14 @@ public sealed class GameManager
     private void InitializeSystems()
     {
         _messageSystem = new MessageSystem(_game, _gameData.MessageDefinitions.GetDeepCopy());
-        _eventSystem = new GameEventSystem(_game, _randomProvider);
-        _eventSystem.ValidateEvents(_game.GetEventPool());
         _fogOfWarSystem = new FogOfWarSystem(_game);
         _blockadeSystem = new BlockadeSystem(_game, _randomProvider);
         _fleetSystem = new FleetSystem(_game);
         _personnelSystem = new PersonnelSystem(_game);
         _duelSystem = new DuelSystem(_game, _randomProvider);
         _movementSystem = new MovementSystem(_game, _fogOfWarSystem, _fleetSystem, _blockadeSystem);
+        _eventSystem = new GameEventSystem(_game, _randomProvider, _movementSystem);
+        _eventSystem.ValidateEvents(_game.GetEventPool());
         _headquartersSystem = new HeadquartersSystem(_game, _movementSystem);
         _manufacturingSystem = new ManufacturingSystem(_game, _fleetSystem, _movementSystem);
         _factionAutomationSystem = new FactionAutomationSystem(
@@ -371,8 +371,6 @@ public sealed class GameManager
         _resultProcessor = new GameResultProcessor();
         _resultProcessor.Subscribe<GameResult>(_eventSystem);
         _resultProcessor.Subscribe<BlockadeChangedResult>(_movementSystem);
-        _resultProcessor.Subscribe<UnitMovementRequestedResult>(_movementSystem);
-        _resultProcessor.Subscribe<UnitPlacementRequestedResult>(_movementSystem);
         _resultProcessor.Subscribe<DuelRequestedResult>(_duelSystem);
         _resultProcessor.Subscribe<UnitArrivedResult>(_headquartersSystem);
         _resultProcessor.Subscribe<PlanetOwnershipChangedResult>(_headquartersSystem);

--- a/Assets/Scripts/Systems/GameEventSystem.cs
+++ b/Assets/Scripts/Systems/GameEventSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Rebellion.Game;
 using Rebellion.Game.Events;
+using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.SceneGraph;
 using Rebellion.Util.Common;
@@ -16,16 +17,23 @@ namespace Rebellion.Systems
     {
         private readonly GameRoot _game;
         private readonly IRandomNumberProvider _provider;
+        private readonly IUnitMovement _unitMovement;
 
         /// <summary>
         /// Creates a new GameEventSystem.
         /// </summary>
         /// <param name="game">The game instance.</param>
         /// <param name="provider">Random number provider for stochastic event actions.</param>
-        public GameEventSystem(GameRoot game, IRandomNumberProvider provider)
+        /// <param name="unitMovement">The authoritative unit movement operations.</param>
+        public GameEventSystem(
+            GameRoot game,
+            IRandomNumberProvider provider,
+            IUnitMovement unitMovement = null
+        )
         {
             _game = game;
             _provider = provider;
+            _unitMovement = unitMovement;
         }
 
         /// <summary>
@@ -359,7 +367,7 @@ namespace Rebellion.Systems
             }
 
             GameLogger.Log($"Executing game event: {gameEvent.InstanceID}");
-            results = gameEvent.Execute(_game, _provider, context);
+            results = gameEvent.Execute(_game, _provider, context, _unitMovement);
 
             state.ExecutionCount++;
             state.LastExecutionTick = _game.CurrentTick;

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -20,10 +20,7 @@ namespace Rebellion.Systems
     /// The only system that calls game.MoveNode() for movement purposes.
     /// Other systems request movement via RequestMove() — never call MoveNode() directly.
     /// </summary>
-    public class MovementSystem
-        : IGameResultHandler<BlockadeChangedResult>,
-            IGameResultHandler<UnitMovementRequestedResult>,
-            IGameResultHandler<UnitPlacementRequestedResult>
+    public class MovementSystem : IGameResultHandler<BlockadeChangedResult>, IUnitMovement
     {
         private readonly GameRoot _game;
         private readonly FogOfWarSystem _fogOfWar;
@@ -117,31 +114,18 @@ namespace Rebellion.Systems
             return reactions;
         }
 
-        /// <summary>
-        /// Accepts event-authored movement requests, tries their destinations in authored order,
-        /// and submits the complete unit group through normal movement validation and transit.
-        /// </summary>
-        List<GameResult> IGameResultHandler<UnitMovementRequestedResult>.HandleResults(
-            IReadOnlyList<UnitMovementRequestedResult> results
+        /// <inheritdoc />
+        public bool TrySendUnits(
+            IReadOnlyList<IMovable> units,
+            IReadOnlyList<ContainerNode> destinations,
+            string sourceEventInstanceID,
+            out IReadOnlyList<GameResult> results
         )
         {
-            if (results == null)
-                return new List<GameResult>();
-
             List<GameResult> reactions = new List<GameResult>();
-            foreach (UnitMovementRequestedResult result in results)
-            {
-                if (result?.Units == null || result.Destinations == null)
-                    continue;
-                TryRequestMove(
-                    result.Units,
-                    result.Destinations,
-                    result.SourceEventInstanceID,
-                    reactions
-                );
-            }
-
-            return reactions;
+            bool accepted = TryRequestMove(units, destinations, sourceEventInstanceID, reactions);
+            results = reactions;
+            return accepted;
         }
 
         /// <summary>
@@ -180,25 +164,21 @@ namespace Rebellion.Systems
             return false;
         }
 
-        List<GameResult> IGameResultHandler<UnitPlacementRequestedResult>.HandleResults(
-            IReadOnlyList<UnitPlacementRequestedResult> results
+        /// <inheritdoc />
+        public bool TryPlaceUnits(
+            IReadOnlyList<IMovable> units,
+            IReadOnlyList<ContainerNode> destinations
         )
         {
-            if (results == null)
-                return new List<GameResult>();
-
-            foreach (UnitPlacementRequestedResult result in results)
+            if (units == null || units.Count == 0 || destinations == null)
+                return false;
+            List<IMovable> unitGroup = units.ToList();
+            foreach (ContainerNode destination in destinations)
             {
-                if (result?.Units == null || result.Destinations == null)
-                    continue;
-                foreach (ContainerNode candidate in result.Destinations)
-                {
-                    if (TryPlaceGroup(result.Units, candidate))
-                        break;
-                }
+                if (destination != null && TryPlaceGroup(unitGroup, destination))
+                    return true;
             }
-
-            return new List<GameResult>();
+            return false;
         }
 
         /// <summary>

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
@@ -9,6 +9,7 @@ using Rebellion.Game.FogOfWar;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Messages;
 using Rebellion.Game.Missions;
+using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
@@ -34,8 +35,15 @@ namespace Rebellion.Tests.Game.Events
             this GameAction action,
             GameRoot game,
             IRandomNumberProvider random,
-            GameEventExecutionContext activation
-        ) => action.Execute(new GameActionContext(game, random, activation));
+            GameEventExecutionContext activation,
+            IUnitMovement unitMovement = null
+        ) => action.Execute(new GameActionContext(game, random, activation, unitMovement));
+
+        internal static List<GameResult> Execute(
+            this GameAction action,
+            GameRoot game,
+            IUnitMovement unitMovement
+        ) => action.Execute(new GameActionContext(game, game.Random, null, unitMovement));
     }
 
     [TestFixture]
@@ -382,7 +390,7 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
-        public void SendUnits_ValidReferences_EmitsAuthoritativeRequest()
+        public void SendUnits_ValidReferences_UsesAuthoritativeMovement()
         {
             GameRoot game = BuildGame(out Planet destination, out Planet origin);
             Officer officer = EntityFactory.CreateOfficer("traveler", "rebels");
@@ -392,14 +400,32 @@ namespace Rebellion.Tests.Game.Events
                 UnitInstanceID = officer.InstanceID,
                 DestinationInstanceID = destination.InstanceID,
             };
+            RecordingUnitMovement movement = new RecordingUnitMovement();
 
-            UnitMovementRequestedResult result = action
-                .Execute(game)
-                .OfType<UnitMovementRequestedResult>()
-                .Single();
+            action.Execute(game, movement);
 
-            CollectionAssert.AreEqual(new[] { officer }, result.Units);
-            CollectionAssert.AreEqual(new[] { destination }, result.Destinations);
+            CollectionAssert.AreEqual(new[] { officer }, movement.Units);
+            CollectionAssert.AreEqual(new[] { destination }, movement.Destinations);
+            Assert.AreSame(origin, officer.GetParent());
+        }
+
+        [Test]
+        public void PlaceUnits_ValidReferences_UsesAuthoritativeMovement()
+        {
+            GameRoot game = BuildGame(out Planet destination, out Planet origin);
+            Officer officer = EntityFactory.CreateOfficer("traveler", "rebels");
+            game.AttachNode(officer, origin);
+            PlaceUnitsAction action = new PlaceUnitsAction
+            {
+                UnitInstanceID = officer.InstanceID,
+                DestinationInstanceID = destination.InstanceID,
+            };
+            RecordingUnitMovement movement = new RecordingUnitMovement();
+
+            action.Execute(game, movement);
+
+            CollectionAssert.AreEqual(new[] { officer }, movement.Units);
+            CollectionAssert.AreEqual(new[] { destination }, movement.Destinations);
             Assert.AreSame(origin, officer.GetParent());
         }
 
@@ -424,7 +450,7 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
-        public void SendUnits_SelectFirstDestination_EmitsAllOrderedCandidates()
+        public void SendUnits_SelectFirstDestination_UsesAllOrderedCandidates()
         {
             GameRoot game = BuildGame(out Planet first, out Planet origin);
             Planet second = new Planet
@@ -451,13 +477,11 @@ namespace Rebellion.Tests.Game.Events
                     },
                 },
             };
+            RecordingUnitMovement movement = new RecordingUnitMovement();
 
-            UnitMovementRequestedResult result = action
-                .Execute(game)
-                .OfType<UnitMovementRequestedResult>()
-                .Single();
+            action.Execute(game, movement);
 
-            CollectionAssert.AreEqual(new[] { first, second }, result.Destinations);
+            CollectionAssert.AreEqual(new[] { first, second }, movement.Destinations);
         }
 
         [Test]
@@ -1285,6 +1309,35 @@ namespace Rebellion.Tests.Game.Events
             Assert.Zero(game.EventRuntime.GetVariable("wrong"));
             Assert.AreEqual(1, game.EventRuntime.GetVariable("first"));
             Assert.AreEqual(2, game.EventRuntime.GetVariable("second"));
+        }
+
+        private sealed class RecordingUnitMovement : IUnitMovement
+        {
+            public IReadOnlyList<IMovable> Units { get; private set; }
+            public IReadOnlyList<ContainerNode> Destinations { get; private set; }
+
+            public bool TrySendUnits(
+                IReadOnlyList<IMovable> units,
+                IReadOnlyList<ContainerNode> destinations,
+                string sourceEventInstanceID,
+                out IReadOnlyList<GameResult> results
+            )
+            {
+                Units = units;
+                Destinations = destinations;
+                results = Array.Empty<GameResult>();
+                return true;
+            }
+
+            public bool TryPlaceUnits(
+                IReadOnlyList<IMovable> units,
+                IReadOnlyList<ContainerNode> destinations
+            )
+            {
+                Units = units;
+                Destinations = destinations;
+                return true;
+            }
         }
     }
 }

--- a/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
@@ -189,21 +189,15 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void HandleMovementRequest_ValidRequest_RoutesThroughAuthoritativeMovePath()
+        public void TrySendUnits_ValidRequest_RoutesThroughAuthoritativeMovePath()
         {
             (GameRoot game, _, Planet destination, Officer officer, MovementSystem movement) =
                 BuildScene();
-            IGameResultHandler<UnitMovementRequestedResult> handler = movement;
-
-            handler.HandleResults(
-                new[]
-                {
-                    new UnitMovementRequestedResult
-                    {
-                        Units = new List<IMovable> { officer },
-                        Destinations = new List<ContainerNode> { destination },
-                    },
-                }
+            movement.TrySendUnits(
+                new List<IMovable> { officer },
+                new List<ContainerNode> { destination },
+                null,
+                out _
             );
 
             Assert.AreEqual(destination, officer.GetParent());
@@ -211,20 +205,14 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void HandleMovementRequest_EventOriginatedRequest_PropagatesSourceToArrival()
+        public void TrySendUnits_EventOriginatedRequest_PropagatesSourceToArrival()
         {
             (_, _, Planet destination, Officer officer, MovementSystem movement) = BuildScene();
-            IGameResultHandler<UnitMovementRequestedResult> handler = movement;
-            handler.HandleResults(
-                new[]
-                {
-                    new UnitMovementRequestedResult
-                    {
-                        Units = new List<IMovable> { officer },
-                        Destinations = new List<ContainerNode> { destination },
-                        SourceEventInstanceID = "SEND_OFFICER",
-                    },
-                }
+            movement.TrySendUnits(
+                new List<IMovable> { officer },
+                new List<ContainerNode> { destination },
+                "SEND_OFFICER",
+                out _
             );
             int transitTicks = officer.Movement.TransitTicks;
 
@@ -237,21 +225,14 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void HandleMovementRequest_EventOriginatedRequestAlreadyAtDestination_EmitsArrival()
+        public void TrySendUnits_EventOriginatedRequestAlreadyAtDestination_EmitsArrival()
         {
             (_, Planet origin, _, Officer officer, MovementSystem movement) = BuildScene();
-            IGameResultHandler<UnitMovementRequestedResult> handler = movement;
-
-            List<GameResult> results = handler.HandleResults(
-                new[]
-                {
-                    new UnitMovementRequestedResult
-                    {
-                        Units = new List<IMovable> { officer },
-                        Destinations = new List<ContainerNode> { origin },
-                        SourceEventInstanceID = "SEND_OFFICER",
-                    },
-                }
+            movement.TrySendUnits(
+                new List<IMovable> { officer },
+                new List<ContainerNode> { origin },
+                "SEND_OFFICER",
+                out IReadOnlyList<GameResult> results
             );
             UnitArrivedResult arrival = results.OfType<UnitArrivedResult>().Single();
 
@@ -261,7 +242,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void HandlePlacementRequest_DetachedRetainedUnit_PlacesWithoutTransit()
+        public void TryPlaceUnits_DetachedRetainedUnit_PlacesWithoutTransit()
         {
             (
                 GameRoot game,
@@ -272,17 +253,9 @@ namespace Rebellion.Tests.Systems
             ) = BuildScene();
             game.AddToVoid(officer);
             game.RemoveFromVoid(officer);
-            IGameResultHandler<UnitPlacementRequestedResult> handler = movement;
-
-            handler.HandleResults(
-                new[]
-                {
-                    new UnitPlacementRequestedResult
-                    {
-                        Units = new List<IMovable> { officer },
-                        Destinations = new List<ContainerNode> { destination },
-                    },
-                }
+            movement.TryPlaceUnits(
+                new List<IMovable> { officer },
+                new List<ContainerNode> { destination }
             );
 
             Assert.AreSame(destination, officer.GetParent());
@@ -291,7 +264,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void HandleMovementRequest_FirstCandidateRejectsGroup_UsesNextCandidate()
+        public void TrySendUnits_FirstCandidateRejectsGroup_UsesNextCandidate()
         {
             (
                 GameRoot game,
@@ -307,17 +280,11 @@ namespace Rebellion.Tests.Systems
                 IsColonized = true,
             };
             game.AttachNode(rejected, origin.GetParent());
-            IGameResultHandler<UnitMovementRequestedResult> handler = movement;
-
-            handler.HandleResults(
-                new[]
-                {
-                    new UnitMovementRequestedResult
-                    {
-                        Units = new List<IMovable> { officer },
-                        Destinations = new List<ContainerNode> { rejected, destination },
-                    },
-                }
+            movement.TrySendUnits(
+                new List<IMovable> { officer },
+                new List<ContainerNode> { rejected, destination },
+                null,
+                out _
             );
 
             Assert.AreSame(destination, officer.GetParent());
@@ -325,7 +292,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void HandlePlacementRequest_GroupExceedsCapacity_LeavesEveryUnitUnchanged()
+        public void TryPlaceUnits_GroupExceedsCapacity_LeavesEveryUnitUnchanged()
         {
             (GameRoot game, Planet origin, Planet destination, _, MovementSystem movement) =
                 BuildScene();
@@ -363,17 +330,9 @@ namespace Rebellion.Tests.Systems
             game.AttachNode(second, sourceShip);
             game.AttachNode(destinationFleet, destination);
             game.AttachNode(destinationShip, destinationFleet);
-            IGameResultHandler<UnitPlacementRequestedResult> handler = movement;
-
-            handler.HandleResults(
-                new[]
-                {
-                    new UnitPlacementRequestedResult
-                    {
-                        Units = new List<IMovable> { first, second },
-                        Destinations = new List<ContainerNode> { destinationFleet },
-                    },
-                }
+            movement.TryPlaceUnits(
+                new List<IMovable> { first, second },
+                new List<ContainerNode> { destinationFleet }
             );
 
             Assert.AreSame(sourceShip, first.GetParent());


### PR DESCRIPTION
## Summary

- Routes authored `SendUnits` and `PlaceUnits` actions directly through the authoritative movement contract.
- Removes command-shaped movement and placement results from the result pipeline.
- Removes the corresponding result subscriptions and handler adapters from `GameManager` and `MovementSystem`.
- Preserves event source identifiers on movement facts and keeps authored destination fallback order intact.

## Rationale

`UnitMovementRequestedResult` and `UnitPlacementRequestedResult` represented commands as though they were completed game facts. That forced event movement through the reaction pipeline before the authoritative movement operation could run. This change gives the event runtime a narrow movement-domain contract, while `MovementSystem` remains the implementation and sole owner of movement validation and mutation.

## Impact

Authored movement uses the same validation, capacity, transit, blockade, and arrival behavior without creating intermediate request results. Existing XML remains unchanged.

## Validation

- Passes `./build.sh all`.
- Passes all 3,904 EditMode tests.
- Meets line coverage at 79.5% and method coverage at 90.8%.
- Passes `./build.sh build` for the standalone macOS player.
