### PR TITLE
Prevent off-map event participants from starting missions

### DIFF
--- a/Assets/Scripts/Game/Missions/MissionFactory.cs
+++ b/Assets/Scripts/Game/Missions/MissionFactory.cs
@@ -172,6 +172,7 @@ namespace Rebellion.Game.Missions
             {
                 if (
                     missionParticipant?.GetOwnerInstanceID() != resolvedContext.OwnerInstanceId
+                    || _game.IsInVoid(missionParticipant)
                     || missionParticipant.IsOnMission()
                     || !missionParticipant.IsMovable()
                     || missionParticipant.CanPerformMission(resolvedContext.MissionTypeID) != true

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -2538,6 +2538,32 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void CanCreateMission_RetainedOfficer_ReturnsFalse()
+        {
+            (
+                GameRoot game,
+                Planet origin,
+                Planet targetPlanet,
+                Officer participant,
+                Officer target,
+                MissionSystem missions
+            ) = BuildOfficerTargetMissionScene(friendlyTarget: false, capturedTarget: false);
+            game.AddToVoid(participant);
+
+            bool canCreate = missions.CanCreateMission(
+                CreateRequest(
+                    MissionTypeIDs.Abduction,
+                    participant,
+                    targetPlanet,
+                    selectedTarget: target
+                )
+            );
+
+            Assert.IsFalse(canCreate);
+            Assert.AreEqual(0, game.GetSceneNodesByType<Mission>().Count);
+        }
+
+        [Test]
         public void InitiateMission_IneligibleSelectedTarget_ReturnsFalse()
         {
             (


### PR DESCRIPTION
## Summary

- Prevents retained event participants from starting normal missions.
- Adds regression coverage for retained officers.

## Why

Keeps off-map event travel isolated from mission scheduling so participants remain registered until their event returns them.

Pairs with [rebellion2-media #44](https://github.com/davidadas/rebellion2-media/pull/44).

## Validation

- Focused EditMode test: passed.
- 1,000-tick regression simulation: passed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable.)
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable.)
