### PR TITLE
Finally replacing reflection-based scene node copying.

### DIFF
--- a/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
+++ b/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
@@ -1313,8 +1313,7 @@ namespace Rebellion.Game.FogOfWar
         internal static T CopyEntityForSnapshot<T>(T entity)
             where T : class, ISceneNode
         {
-            return entity
-                ?.CreateCopy(recursive: true, includeDisabled: entity is Mission) as T;
+            return entity?.CreateCopy(recursive: true, includeDisabled: entity is Mission) as T;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
+++ b/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
@@ -1342,19 +1342,6 @@ namespace Rebellion.Game.FogOfWar
         }
 
         /// <summary>
-        /// Copies a mission and its observed participant identities for storage in fog state.
-        /// </summary>
-        /// <param name="mission">The observed mission to copy.</param>
-        /// <returns>The detached mission snapshot.</returns>
-        internal static Mission CopyMissionForSnapshot(Mission mission)
-        {
-            if (mission == null)
-                return null;
-
-            return mission.CreateCopy(recursive: true, includeDisabled: true) as Mission;
-        }
-
-        /// <summary>
         /// Copies the completed portion of an observed fleet for fog state.
         /// </summary>
         /// <param name="fleet">The observed fleet to copy.</param>

--- a/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
+++ b/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Missions;
-using Rebellion.Game.Movement;
 using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 using Rebellion.Util.Extensions;
@@ -1314,24 +1313,8 @@ namespace Rebellion.Game.FogOfWar
         internal static T CopyEntityForSnapshot<T>(T entity)
             where T : class, ISceneNode
         {
-            if (entity is Building building)
-                return CopyBuildingForSnapshot(building) as T;
-            if (entity is CapitalShip capitalShip)
-                return CopyCapitalShipForSnapshot(capitalShip) as T;
-            if (entity is Mission mission)
-                return CopyMissionForSnapshot(mission) as T;
-            if (entity is Officer officer)
-                return CopyOfficerForSnapshot(officer) as T;
-            if (entity is Regiment regiment)
-                return CopyRegimentForSnapshot(regiment) as T;
-            if (entity is SpecialForces specialForces)
-                return CopySpecialForcesForSnapshot(specialForces) as T;
-            if (entity is Starfighter starfighter)
-                return CopyStarfighterForSnapshot(starfighter) as T;
-
-            T copy = entity.GetShallowCopy(CloneMode.Full);
-            ClearParentReferences(copy);
-            return copy;
+            return entity
+                ?.CreateCopy(recursive: true, includeDisabled: entity is Mission) as T;
         }
 
         /// <summary>
@@ -1341,11 +1324,7 @@ namespace Rebellion.Game.FogOfWar
         /// <returns>The copied officer.</returns>
         internal static Officer CopyOfficerForSnapshot(Officer officer)
         {
-            Officer copy = officer.GetShallowCopy(CloneMode.Full);
-            copy.Ratings = new Dictionary<OfficerRating, int>(officer.Ratings);
-            copy.Movement = CopyMovementForSnapshot(officer.Movement);
-            ClearParentReferences(copy);
-            return copy;
+            return officer?.CreateCopy() as Officer;
         }
 
         /// <summary>
@@ -1358,17 +1337,8 @@ namespace Rebellion.Game.FogOfWar
             if (fleet == null)
                 return null;
 
-            Fleet copy = fleet.GetShallowCopy(CloneMode.Full);
-            copy.Movement = CopyMovementForSnapshot(fleet.Movement);
-            copy.Order = fleet.Order?.GetShallowCopy(CloneMode.Full);
-            copy.SetCapitalShips(
-                fleet.GetChildren<CapitalShip>().Select(CopyCapitalShipForSnapshot)
-            );
-            ClearParentReferences(copy);
-
-            foreach (CapitalShip capitalShip in copy.GetChildren<CapitalShip>())
-                capitalShip.SetParent(copy);
-
+            Fleet copy = fleet.CreateCopy(recursive: true) as Fleet;
+            copy.Order = null;
             return copy;
         }
 
@@ -1382,33 +1352,7 @@ namespace Rebellion.Game.FogOfWar
             if (mission == null)
                 return null;
 
-            List<IMissionParticipant> mainParticipants = mission
-                .GetMainParticipants(includeDisabled: true)
-                .ToList();
-            List<IMissionParticipant> decoyParticipants = mission
-                .GetDecoyParticipants(includeDisabled: true)
-                .ToList();
-            Mission copy = mission.GetShallowCopy(CloneMode.Full);
-            copy.ReplaceParticipants(
-                CopyMissionParticipantsForSnapshot(mainParticipants),
-                CopyMissionParticipantsForSnapshot(decoyParticipants)
-            );
-            ClearParentReferences(copy);
-            return copy;
-        }
-
-        /// <summary>
-        /// Creates independent copies of participants observed in one mission role.
-        /// </summary>
-        /// <param name="participants">The participants assigned to the observed role.</param>
-        /// <returns>The detached participant snapshots in their original order.</returns>
-        private static List<IMissionParticipant> CopyMissionParticipantsForSnapshot(
-            IEnumerable<IMissionParticipant> participants
-        )
-        {
-            return (participants ?? Enumerable.Empty<IMissionParticipant>())
-                .Select(participant => CopyEntityForSnapshot(participant))
-                .ToList();
+            return mission.CreateCopy(recursive: true, includeDisabled: true) as Mission;
         }
 
         /// <summary>
@@ -1514,100 +1458,7 @@ namespace Rebellion.Game.FogOfWar
         /// <returns>The detached capital-ship snapshot.</returns>
         private static CapitalShip CopyCapitalShipForSnapshot(CapitalShip capitalShip)
         {
-            CapitalShip copy = capitalShip.GetShallowCopy(CloneMode.Full);
-            copy.Roles = new List<CapitalShipRole>(capitalShip.Roles);
-            copy.PrimaryWeapons = capitalShip.PrimaryWeapons.ToDictionary(
-                entry => entry.Key,
-                entry => entry.Value?.ToArray()
-            );
-            copy.Movement = CopyMovementForSnapshot(capitalShip.Movement);
-            copy.SetChildren(
-                capitalShip.GetChildren<Officer>().Select(CopyOfficerForSnapshot),
-                capitalShip.GetChildren<Regiment>().Select(CopyRegimentForSnapshot),
-                capitalShip.GetChildren<SpecialForces>().Select(CopySpecialForcesForSnapshot),
-                capitalShip.GetChildren<Starfighter>().Select(CopyStarfighterForSnapshot)
-            );
-            ClearParentReferences(copy);
-
-            foreach (ISceneNode child in copy.GetChildren())
-                child.SetParent(copy);
-
-            return copy;
-        }
-
-        /// <summary>
-        /// Copies a building for storage in fog state.
-        /// </summary>
-        /// <param name="building">The building to copy.</param>
-        /// <returns>The detached building snapshot.</returns>
-        private static Building CopyBuildingForSnapshot(Building building)
-        {
-            Building copy = building.GetShallowCopy(CloneMode.Full);
-            copy.Movement = CopyMovementForSnapshot(building.Movement);
-            ClearParentReferences(copy);
-            return copy;
-        }
-
-        /// <summary>
-        /// Copies a regiment for storage in fog state.
-        /// </summary>
-        /// <param name="regiment">The regiment to copy.</param>
-        /// <returns>The detached regiment snapshot.</returns>
-        private static Regiment CopyRegimentForSnapshot(Regiment regiment)
-        {
-            Regiment copy = regiment.GetShallowCopy(CloneMode.Full);
-            copy.Movement = CopyMovementForSnapshot(regiment.Movement);
-            ClearParentReferences(copy);
-            return copy;
-        }
-
-        /// <summary>
-        /// Copies a special-forces unit for storage in fog state.
-        /// </summary>
-        /// <param name="specialForces">The special-forces unit to copy.</param>
-        /// <returns>The detached special-forces snapshot.</returns>
-        private static SpecialForces CopySpecialForcesForSnapshot(SpecialForces specialForces)
-        {
-            SpecialForces copy = specialForces.GetShallowCopy(CloneMode.Full);
-            copy.Ratings = new Dictionary<OfficerRating, int>(specialForces.Ratings);
-            copy.Movement = CopyMovementForSnapshot(specialForces.Movement);
-            ClearParentReferences(copy);
-            return copy;
-        }
-
-        /// <summary>
-        /// Copies a starfighter unit for storage in fog state.
-        /// </summary>
-        /// <param name="starfighter">The starfighter to copy.</param>
-        /// <returns>The detached starfighter snapshot.</returns>
-        private static Starfighter CopyStarfighterForSnapshot(Starfighter starfighter)
-        {
-            Starfighter copy = starfighter.GetShallowCopy(CloneMode.Full);
-            copy.Movement = CopyMovementForSnapshot(starfighter.Movement);
-            ClearParentReferences(copy);
-            return copy;
-        }
-
-        /// <summary>
-        /// Removes live scene-graph parent references from a snapshot node.
-        /// </summary>
-        /// <param name="node">The copied node to detach.</param>
-        private static void ClearParentReferences(ISceneNode node)
-        {
-            node.ParentInstanceID = null;
-            node.LastParentInstanceID = null;
-            node.ParentNode = null;
-            node.LastParentNode = null;
-        }
-
-        /// <summary>
-        /// Copies movement state for storage in fog state.
-        /// </summary>
-        /// <param name="movement">The movement state to copy.</param>
-        /// <returns>The copied movement state, or null when the entity is stationary.</returns>
-        private static MovementState CopyMovementForSnapshot(MovementState movement)
-        {
-            return movement?.GetShallowCopy(CloneMode.Full);
+            return capitalShip?.CreateCopy(recursive: true) as CapitalShip;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Galaxy/GalaxyMap.cs
+++ b/Assets/Scripts/Game/Galaxy/GalaxyMap.cs
@@ -19,6 +19,12 @@ namespace Rebellion.Game.Galaxy
         public GalaxyMap() { }
 
         /// <summary>
+        /// Creates an empty galaxy-map copy.
+        /// </summary>
+        /// <returns>An empty galaxy map.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new GalaxyMap();
+
+        /// <summary>
         /// Returns true if the child is a PlanetSystem.
         /// </summary>
         /// <param name="child">The candidate child node.</param>

--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -181,11 +181,16 @@ namespace Rebellion.Game.Galaxy
         )
         {
             base.AttachCopiedChild(destination, sourceChild, copiedChild);
-            if (sourceChild is not IManufacturable source || copiedChild is not IManufacturable copy)
+            if (
+                sourceChild is not IManufacturable source
+                || copiedChild is not IManufacturable copy
+            )
                 return;
 
             Planet copiedPlanet = (Planet)destination;
-            foreach (KeyValuePair<ManufacturingType, List<IManufacturable>> queue in ManufacturingQueue)
+            foreach (
+                KeyValuePair<ManufacturingType, List<IManufacturable>> queue in ManufacturingQueue
+            )
             {
                 if (queue.Value.Contains(source))
                     copiedPlanet.ManufacturingQueue[queue.Key].Add(copy);

--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -128,6 +128,71 @@ namespace Rebellion.Game.Galaxy
         public Planet() { }
 
         /// <summary>
+        /// Creates an empty planet copy.
+        /// </summary>
+        /// <returns>An empty planet.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new Planet();
+
+        /// <summary>
+        /// Copies planet state into an empty destination.
+        /// </summary>
+        /// <param name="destination">The destination node.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            Planet copy = (Planet)destination;
+            copy.IsColonized = IsColonized;
+            copy.SystemDataId = SystemDataId;
+            copy.NumRawResourceNodes = NumRawResourceNodes;
+            copy.EnergyCapacity = EnergyCapacity;
+            copy.AllocatedEnergy = AllocatedEnergy;
+            copy.PositionX = PositionX;
+            copy.PositionY = PositionY;
+            copy.PlanetIconPath = PlanetIconPath;
+            copy.IsUnexploredView = IsUnexploredView;
+            copy.IsDestroyed = IsDestroyed;
+            copy.IsHeadquarters = IsHeadquarters;
+            copy.IsInUprising = IsInUprising;
+            copy.NextUprisingSupportDriftTick = NextUprisingSupportDriftTick;
+            copy.NextUprisingIncidentTick = NextUprisingIncidentTick;
+            copy.NextUprisingClearTick = NextUprisingClearTick;
+            copy.UprisingSupportDriftTimerOrder = UprisingSupportDriftTimerOrder;
+            copy.UprisingIncidentTimerOrder = UprisingIncidentTimerOrder;
+            copy.UprisingClearTimerOrder = UprisingClearTimerOrder;
+            copy.NextUprisingTimerOrder = NextUprisingTimerOrder;
+            copy.PopularSupport = new Dictionary<string, int>(PopularSupport);
+            copy.ManufacturingQueue = ManufacturingQueue.Keys.ToDictionary(
+                type => type,
+                _ => new List<IManufacturable>()
+            );
+            copy.VisitingFactionIDs = new List<string>(VisitingFactionIDs);
+        }
+
+        /// <summary>
+        /// Attaches a copied child and preserves its manufacturing-queue membership.
+        /// </summary>
+        /// <param name="destination">The copied planet receiving the child.</param>
+        /// <param name="sourceChild">The original child.</param>
+        /// <param name="copiedChild">The copied child.</param>
+        protected override void AttachCopiedChild(
+            BaseSceneNode destination,
+            ISceneNode sourceChild,
+            ISceneNode copiedChild
+        )
+        {
+            base.AttachCopiedChild(destination, sourceChild, copiedChild);
+            if (sourceChild is not IManufacturable source || copiedChild is not IManufacturable copy)
+                return;
+
+            Planet copiedPlanet = (Planet)destination;
+            foreach (KeyValuePair<ManufacturingType, List<IManufacturable>> queue in ManufacturingQueue)
+            {
+                if (queue.Value.Contains(source))
+                    copiedPlanet.ManufacturingQueue[queue.Key].Add(copy);
+            }
+        }
+
+        /// <summary>
         /// Checks if the planet is blockaded.
         /// A planet is blockaded only when a stationary hostile fleet has an operational capital
         /// ship and no equivalent defending fleet is present.

--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -1142,6 +1142,9 @@ namespace Rebellion.Game.Galaxy
         /// <returns>True when the officer can be added to this planet; otherwise false.</returns>
         private bool CanAcceptOfficer(Officer officer)
         {
+            if (!officer.IsActive())
+                return true;
+
             return IsColonized
                 && (officer.IsCaptured || officer.GetOwnerInstanceID() == OwnerInstanceID);
         }

--- a/Assets/Scripts/Game/Galaxy/PlanetSystem.cs
+++ b/Assets/Scripts/Game/Galaxy/PlanetSystem.cs
@@ -48,6 +48,28 @@ namespace Rebellion.Game.Galaxy
         public PlanetSystem() { }
 
         /// <summary>
+        /// Creates an empty planet-system copy.
+        /// </summary>
+        /// <returns>An empty planet system.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new PlanetSystem();
+
+        /// <summary>
+        /// Copies planet-system state into an empty destination.
+        /// </summary>
+        /// <param name="destination">The destination node.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            PlanetSystem copy = (PlanetSystem)destination;
+            copy.SectorDataId = SectorDataId;
+            copy.Visibility = Visibility;
+            copy.SystemType = SystemType;
+            copy.Importance = Importance;
+            copy.PositionX = PositionX;
+            copy.PositionY = PositionY;
+        }
+
+        /// <summary>
         /// Replaces the system's planet collection while constructing a detached projection.
         /// </summary>
         /// <param name="planets">The planets to retain in the projection.</param>

--- a/Assets/Scripts/Game/Missions/AbductionMission.cs
+++ b/Assets/Scripts/Game/Missions/AbductionMission.cs
@@ -19,6 +19,18 @@ namespace Rebellion.Game.Missions
         /// </summary>
         public string TargetOfficerInstanceID { get; set; }
 
+        /// <summary>Creates an empty abduction mission copy.</summary>
+        /// <returns>An empty abduction mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new AbductionMission();
+
+        /// <summary>Copies abduction-specific state into an empty destination.</summary>
+        /// <param name="destination">The destination mission.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            ((AbductionMission)destination).TargetOfficerInstanceID = TargetOfficerInstanceID;
+        }
+
         /// <summary>
         /// Returns whether this mission should cancel when the target planet changes owner.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/AssassinationMission.cs
+++ b/Assets/Scripts/Game/Missions/AssassinationMission.cs
@@ -19,6 +19,18 @@ namespace Rebellion.Game.Missions
         /// </summary>
         public string TargetOfficerInstanceID { get; set; }
 
+        /// <summary>Creates an empty assassination mission copy.</summary>
+        /// <returns>An empty assassination mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new AssassinationMission();
+
+        /// <summary>Copies assassination-specific state into an empty destination.</summary>
+        /// <param name="destination">The destination mission.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            ((AssassinationMission)destination).TargetOfficerInstanceID = TargetOfficerInstanceID;
+        }
+
         /// <summary>
         /// Returns whether this mission should cancel when the target planet changes owner.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/DiplomacyMission.cs
+++ b/Assets/Scripts/Game/Missions/DiplomacyMission.cs
@@ -14,6 +14,10 @@ namespace Rebellion.Game.Missions
     {
         public const string MissionTypeID = "Diplomacy";
 
+        /// <summary>Creates an empty diplomacy mission copy.</summary>
+        /// <returns>An empty diplomacy mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new DiplomacyMission();
+
         /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/EspionageMission.cs
+++ b/Assets/Scripts/Game/Missions/EspionageMission.cs
@@ -27,6 +27,10 @@ namespace Rebellion.Game.Missions
         /// </summary>
         internal override bool AppliesFoiledParticipantConsequences => false;
 
+        /// <summary>Creates an empty espionage mission copy.</summary>
+        /// <returns>An empty espionage mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new EspionageMission();
+
         /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/InciteUprisingMission.cs
+++ b/Assets/Scripts/Game/Missions/InciteUprisingMission.cs
@@ -17,6 +17,10 @@ namespace Rebellion.Game.Missions
         /// </summary>
         public override bool CanceledOnOwnershipChange => false;
 
+        /// <summary>Creates an empty incite-uprising mission copy.</summary>
+        /// <returns>An empty incite-uprising mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new InciteUprisingMission();
+
         /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/JediTrainingMission.cs
+++ b/Assets/Scripts/Game/Missions/JediTrainingMission.cs
@@ -21,6 +21,18 @@ namespace Rebellion.Game.Missions
         /// </summary>
         public string TrainerInstanceID { get; set; }
 
+        /// <summary>Creates an empty Jedi-training mission copy.</summary>
+        /// <returns>An empty Jedi-training mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new JediTrainingMission();
+
+        /// <summary>Copies Jedi-training-specific state into an empty destination.</summary>
+        /// <param name="destination">The destination mission.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            ((JediTrainingMission)destination).TrainerInstanceID = TrainerInstanceID;
+        }
+
         /// <summary>
         /// Gets the selected trainer from the mission's current participants.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -145,7 +145,10 @@ namespace Rebellion.Game.Missions
             if (copiedChild is not IMissionParticipant participant)
                 return;
 
-            if (_decoyParticipants.Contains(sourceChild))
+            if (
+                sourceChild is IMissionParticipant sourceParticipant
+                && _decoyParticipants.Contains(sourceParticipant)
+            )
                 ((Mission)destination).AddDecoyParticipant(participant);
             else
                 destination.AddChild(copiedChild);

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -107,6 +107,54 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
+        /// Copies shared mission state into an empty mission destination.
+        /// </summary>
+        /// <param name="destination">The destination mission.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            Mission copy = (Mission)destination;
+            copy.ConfigKey = ConfigKey;
+            copy.LocationInstanceID = LocationInstanceID;
+            copy.OriginInstanceID = OriginInstanceID;
+            copy.SourceEventInstanceID = SourceEventInstanceID;
+            copy._participantInstanceIds = new HashSet<string>(
+                _participantInstanceIds,
+                StringComparer.Ordinal
+            );
+            copy._hasCapturedParticipantIds = _hasCapturedParticipantIds;
+            copy.ParticipantRating = ParticipantRating;
+            copy.HasInitiated = HasInitiated;
+            copy.MaxProgress = MaxProgress;
+            copy.CurrentProgress = CurrentProgress;
+            copy.DecoyParticipantRating = DecoyParticipantRating;
+        }
+
+        /// <summary>
+        /// Attaches a copied participant to the same primary or decoy role as its source.
+        /// </summary>
+        /// <param name="destination">The copied mission receiving the participant.</param>
+        /// <param name="sourceChild">The source participant.</param>
+        /// <param name="copiedChild">The copied participant.</param>
+        protected override void AttachCopiedChild(
+            BaseSceneNode destination,
+            ISceneNode sourceChild,
+            ISceneNode copiedChild
+        )
+        {
+            if (copiedChild is not IMissionParticipant participant)
+                return;
+
+            if (_decoyParticipants.Contains(sourceChild))
+                ((Mission)destination).AddDecoyParticipant(participant);
+            else
+                destination.AddChild(copiedChild);
+
+            if (HasInitiated)
+                copiedChild.SetParent(destination);
+        }
+
+        /// <summary>
         /// Validates that <paramref name="target"/> is non-null and is a Planet, then returns it.
         /// Call at the top of each mission constructor before mission-specific validation.
         /// </summary>
@@ -244,27 +292,6 @@ namespace Rebellion.Game.Missions
             includeDisabled
                 ? _decoyParticipants
                 : _decoyParticipants.Where(participant => participant.IsActive()).ToList();
-
-        /// <summary>
-        /// Replaces both participant groups while preserving their authored roles.
-        /// </summary>
-        /// <param name="mainParticipants">The replacement primary participants.</param>
-        /// <param name="decoyParticipants">The replacement decoy participants.</param>
-        internal void ReplaceParticipants(
-            IEnumerable<IMissionParticipant> mainParticipants,
-            IEnumerable<IMissionParticipant> decoyParticipants
-        )
-        {
-            _mainParticipants = mainParticipants?.ToList() ?? new List<IMissionParticipant>();
-            _decoyParticipants = decoyParticipants?.ToList() ?? new List<IMissionParticipant>();
-            _participantInstanceIds = new HashSet<string>(
-                _mainParticipants
-                    .Concat(_decoyParticipants)
-                    .Select(participant => participant.InstanceID),
-                StringComparer.Ordinal
-            );
-            _hasCapturedParticipantIds = true;
-        }
 
         /// <summary>
         /// Returns whether any mission participant is still travelling to the mission.
@@ -900,12 +927,30 @@ namespace Rebellion.Game.Missions
         /// <returns>All main and decoy participants as scene nodes.</returns>
         protected override IEnumerable<ISceneNode> EnumerateChildren()
         {
-            if (HasInitiated)
-                return _mainParticipants
-                    .Cast<ISceneNode>()
-                    .Concat(_decoyParticipants.Cast<ISceneNode>());
+            if (!HasInitiated)
+                return Enumerable.Empty<ISceneNode>();
 
-            return Enumerable.Empty<ISceneNode>();
+            return EnumerateParticipants();
+        }
+
+        /// <summary>
+        /// Returns authored participants so recursive copies retain mission relationships.
+        /// </summary>
+        /// <returns>All primary and decoy participants.</returns>
+        protected override IEnumerable<ISceneNode> EnumerateChildrenToCopy()
+        {
+            return EnumerateParticipants();
+        }
+
+        /// <summary>
+        /// Enumerates all primary and decoy participants without applying lifecycle visibility.
+        /// </summary>
+        /// <returns>All primary and decoy participants.</returns>
+        private IEnumerable<ISceneNode> EnumerateParticipants()
+        {
+            return _mainParticipants
+                .Cast<ISceneNode>()
+                .Concat(_decoyParticipants.Cast<ISceneNode>());
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -153,8 +153,7 @@ namespace Rebellion.Game.Missions
             else
                 destination.AddChild(copiedChild);
 
-            if (HasInitiated)
-                copiedChild.SetParent(destination);
+            copiedChild.SetParent(destination);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -270,9 +270,12 @@ namespace Rebellion.Game.Missions
         /// <summary>
         /// Returns all main and decoy participants as a single list.
         /// </summary>
+        /// <param name="includeDisabled">Whether disabled participants may be returned.</param>
         /// <returns>Combined list of main and decoy participants.</returns>
-        public List<IMissionParticipant> GetAllParticipants() =>
-            GetMainParticipants().Concat(GetDecoyParticipants()).ToList();
+        public List<IMissionParticipant> GetAllParticipants(bool includeDisabled = false) =>
+            GetMainParticipants(includeDisabled)
+                .Concat(GetDecoyParticipants(includeDisabled))
+                .ToList();
 
         /// <summary>
         /// Gets the mission's primary participants.
@@ -927,23 +930,10 @@ namespace Rebellion.Game.Missions
         /// <summary>
         /// Returns all mission participants as children of the mission.
         /// </summary>
-        /// <returns>All main and decoy participants as scene nodes.</returns>
-        protected override IEnumerable<ISceneNode> EnumerateChildren()
-        {
-            if (!HasInitiated)
-                return Enumerable.Empty<ISceneNode>();
-
-            return EnumerateParticipants();
-        }
-
-        /// <summary>
-        /// Returns authored participants so recursive copies retain mission relationships.
-        /// </summary>
-        /// <returns>All primary and decoy participants.</returns>
-        protected override IEnumerable<ISceneNode> EnumerateChildrenToCopy()
-        {
-            return EnumerateParticipants();
-        }
+        /// <returns>Assigned participants currently parented to the mission.</returns>
+        protected override IEnumerable<ISceneNode> EnumerateChildren() =>
+            EnumerateParticipants()
+                .Where(participant => participant.ParentInstanceID == InstanceID);
 
         /// <summary>
         /// Enumerates all primary and decoy participants without applying lifecycle visibility.

--- a/Assets/Scripts/Game/Missions/ReconnaissanceMission.cs
+++ b/Assets/Scripts/Game/Missions/ReconnaissanceMission.cs
@@ -4,6 +4,7 @@ using Rebellion.Game.Factions;
 using Rebellion.Game.FogOfWar;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Results;
+using Rebellion.SceneGraph;
 using Rebellion.Util.Common;
 
 namespace Rebellion.Game.Missions
@@ -19,6 +20,10 @@ namespace Rebellion.Game.Missions
         /// Returns whether this mission should cancel when the target planet changes owner.
         /// </summary>
         public override bool CanceledOnOwnershipChange => false;
+
+        /// <summary>Creates an empty reconnaissance mission copy.</summary>
+        /// <returns>An empty reconnaissance mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new ReconnaissanceMission();
 
         /// <summary>
         /// Default constructor used for deserialization.

--- a/Assets/Scripts/Game/Missions/RecruitmentMission.cs
+++ b/Assets/Scripts/Game/Missions/RecruitmentMission.cs
@@ -22,6 +22,18 @@ namespace Rebellion.Game.Missions
         /// </summary>
         public string TargetOfficerInstanceID { get; set; }
 
+        /// <summary>Creates an empty recruitment mission copy.</summary>
+        /// <returns>An empty recruitment mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new RecruitmentMission();
+
+        /// <summary>Copies recruitment-specific state into an empty destination.</summary>
+        /// <param name="destination">The destination mission.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            ((RecruitmentMission)destination).TargetOfficerInstanceID = TargetOfficerInstanceID;
+        }
+
         /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/RescueMission.cs
+++ b/Assets/Scripts/Game/Missions/RescueMission.cs
@@ -19,6 +19,18 @@ namespace Rebellion.Game.Missions
         /// </summary>
         public string TargetOfficerInstanceID { get; set; }
 
+        /// <summary>Creates an empty rescue mission copy.</summary>
+        /// <returns>An empty rescue mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new RescueMission();
+
+        /// <summary>Copies rescue-specific state into an empty destination.</summary>
+        /// <param name="destination">The destination mission.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            ((RescueMission)destination).TargetOfficerInstanceID = TargetOfficerInstanceID;
+        }
+
         /// <summary>
         /// Returns whether this mission should cancel when the target planet changes owner.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/ResearchMission.cs
+++ b/Assets/Scripts/Game/Missions/ResearchMission.cs
@@ -23,6 +23,18 @@ namespace Rebellion.Game.Missions
         /// </summary>
         public ResearchDiscipline Discipline { get; set; }
 
+        /// <summary>Creates an empty research mission copy.</summary>
+        /// <returns>An empty research mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new ResearchMission();
+
+        /// <summary>Copies research-specific state into an empty destination.</summary>
+        /// <param name="destination">The destination mission.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            ((ResearchMission)destination).Discipline = Discipline;
+        }
+
         /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/SabotageMission.cs
+++ b/Assets/Scripts/Game/Missions/SabotageMission.cs
@@ -19,6 +19,18 @@ namespace Rebellion.Game.Missions
         /// </summary>
         public string SabotageTargetInstanceID { get; set; }
 
+        /// <summary>Creates an empty sabotage mission copy.</summary>
+        /// <returns>An empty sabotage mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new SabotageMission();
+
+        /// <summary>Copies sabotage-specific state into an empty destination.</summary>
+        /// <param name="destination">The destination mission.</param>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            ((SabotageMission)destination).SabotageTargetInstanceID = SabotageTargetInstanceID;
+        }
+
         /// <summary>
         /// Returns whether this mission should cancel when the target planet changes owner.
         /// </summary>

--- a/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
+++ b/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
@@ -13,6 +13,10 @@ namespace Rebellion.Game.Missions
     {
         public const string MissionTypeID = "SubdueUprising";
 
+        /// <summary>Creates an empty subdue-uprising mission copy.</summary>
+        /// <returns>An empty subdue-uprising mission.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new SubdueUprisingMission();
+
         /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>

--- a/Assets/Scripts/Game/Movement/MovementState.cs
+++ b/Assets/Scripts/Game/Movement/MovementState.cs
@@ -75,6 +75,23 @@ namespace Rebellion.Game.Movement
         public MovementState() { }
 
         /// <summary>
+        /// Creates an independent copy of this movement state.
+        /// </summary>
+        /// <returns>The copied movement state.</returns>
+        public MovementState CreateCopy() =>
+            new MovementState
+            {
+                TransitTicks = TransitTicks,
+                TicksElapsed = TicksElapsed,
+                MovementGroupID = MovementGroupID,
+                SourceEventInstanceID = SourceEventInstanceID,
+                OriginPositionX = OriginPositionX,
+                OriginPositionY = OriginPositionY,
+                CurrentPositionX = CurrentPositionX,
+                CurrentPositionY = CurrentPositionY,
+            };
+
+        /// <summary>
         /// Progress fraction in [0.0, 1.0] - 0.0 = just departed, 1.0 = arrived.
         /// </summary>
         /// <returns>Progress as a float in [0.0, 1.0].</returns>

--- a/Assets/Scripts/Game/Results/GameResults.cs
+++ b/Assets/Scripts/Game/Results/GameResults.cs
@@ -10,7 +10,6 @@ using Rebellion.Game.Research;
 using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 using Rebellion.Systems;
-using Rebellion.Util.Extensions;
 
 namespace Rebellion.Game.Results
 {
@@ -588,9 +587,7 @@ namespace Rebellion.Game.Results
             if (unit == null)
                 throw new ArgumentNullException(nameof(unit));
 
-            Unit = unit.GetShallowCopy();
-            Unit.InstanceID = unit.GetInstanceID();
-            Unit.OwnerInstanceID = unit.GetOwnerInstanceID();
+            Unit = unit.CreateCopy();
             Unit.ParentInstanceID = unit.ParentInstanceID;
             Unit.LastParentInstanceID = unit.LastParentInstanceID;
             WasOperational =

--- a/Assets/Scripts/Game/Units/Building.cs
+++ b/Assets/Scripts/Game/Units/Building.cs
@@ -77,6 +77,44 @@ namespace Rebellion.Game.Units
         /// </summary>
         public Building() { }
 
+        /// <summary>Creates an empty building copy.</summary>
+        protected override BaseSceneNode CreateNodeCopy() => new Building();
+
+        /// <summary>Copies building state into an empty destination.</summary>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            Building copy = (Building)destination;
+            copy.ConstructionCost = ConstructionCost;
+            copy.MaintenanceCost = MaintenanceCost;
+            copy.BaseBuildSpeed = BaseBuildSpeed;
+            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
+                ? null
+                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ResearchOrder = ResearchOrder;
+            copy.ResearchDifficulty = ResearchDifficulty;
+            copy.BuildingType = BuildingType;
+            copy.ProcessRate = ProcessRate;
+            copy.Bombardment = Bombardment;
+            copy.WeaponStrength = WeaponStrength;
+            copy.ShieldStrength = ShieldStrength;
+            copy.WeaponPower = WeaponPower;
+            copy.DefenseFacilityClass = DefenseFacilityClass;
+            copy.ProductionModifier = ProductionModifier;
+            copy.ProducerOwnerID = ProducerOwnerID;
+            copy.ProducerPlanetID = ProducerPlanetID;
+            copy.ManufacturingProgress = ManufacturingProgress;
+            copy.ManufacturingStatus = ManufacturingStatus;
+            copy.ProductionType = ProductionType;
+            copy.ProductionCycleProgress = ProductionCycleProgress;
+            copy.ProductionCycleDuration = ProductionCycleDuration;
+            copy.ProductionPointReady = ProductionPointReady;
+            copy.ProductionInputReserved = ProductionInputReserved;
+            copy.ResourceMaintenanceAllocation = ResourceMaintenanceAllocation;
+            copy.ResourceStartupCyclePending = ResourceStartupCyclePending;
+            copy.Movement = Movement?.CreateCopy();
+        }
+
         /// <summary>
         /// Returns the building's type.
         /// </summary>

--- a/Assets/Scripts/Game/Units/Building.cs
+++ b/Assets/Scripts/Game/Units/Building.cs
@@ -88,9 +88,10 @@ namespace Rebellion.Game.Units
             copy.ConstructionCost = ConstructionCost;
             copy.MaintenanceCost = MaintenanceCost;
             copy.BaseBuildSpeed = BaseBuildSpeed;
-            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
-                ? null
-                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ManufacturingFactionInstanceIDs =
+                ManufacturingFactionInstanceIDs == null
+                    ? null
+                    : new List<string>(ManufacturingFactionInstanceIDs);
             copy.ResearchOrder = ResearchOrder;
             copy.ResearchDifficulty = ResearchDifficulty;
             copy.BuildingType = BuildingType;

--- a/Assets/Scripts/Game/Units/CapitalShip.cs
+++ b/Assets/Scripts/Game/Units/CapitalShip.cs
@@ -131,9 +131,10 @@ namespace Rebellion.Game.Units
             copy.ConstructionCost = ConstructionCost;
             copy.MaintenanceCost = MaintenanceCost;
             copy.BaseBuildSpeed = BaseBuildSpeed;
-            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
-                ? null
-                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ManufacturingFactionInstanceIDs =
+                ManufacturingFactionInstanceIDs == null
+                    ? null
+                    : new List<string>(ManufacturingFactionInstanceIDs);
             copy.ResearchOrder = ResearchOrder;
             copy.ResearchDifficulty = ResearchDifficulty;
             copy.MaxHullStrength = MaxHullStrength;

--- a/Assets/Scripts/Game/Units/CapitalShip.cs
+++ b/Assets/Scripts/Game/Units/CapitalShip.cs
@@ -115,6 +115,60 @@ namespace Rebellion.Game.Units
         /// </summary>
         public CapitalShip() { }
 
+        /// <summary>Creates an empty capital-ship copy.</summary>
+        protected override BaseSceneNode CreateNodeCopy() => new CapitalShip();
+
+        /// <summary>Copies capital-ship state into an empty destination.</summary>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            CapitalShip copy = (CapitalShip)destination;
+            copy.BattleResultImagePath = BattleResultImagePath;
+            copy.BattleResultInTransitImagePath = BattleResultInTransitImagePath;
+            copy.BattleResultDamagedImagePath = BattleResultDamagedImagePath;
+            copy.ProducerOwnerID = ProducerOwnerID;
+            copy.ProducerPlanetID = ProducerPlanetID;
+            copy.ConstructionCost = ConstructionCost;
+            copy.MaintenanceCost = MaintenanceCost;
+            copy.BaseBuildSpeed = BaseBuildSpeed;
+            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
+                ? null
+                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ResearchOrder = ResearchOrder;
+            copy.ResearchDifficulty = ResearchDifficulty;
+            copy.MaxHullStrength = MaxHullStrength;
+            copy.CurrentHullStrength = CurrentHullStrength;
+            copy.DamageControl = DamageControl;
+            copy.MaxShieldStrength = MaxShieldStrength;
+            copy.ShieldRechargeRate = ShieldRechargeRate;
+            copy.Hyperdrive = Hyperdrive;
+            copy.SublightSpeed = SublightSpeed;
+            copy.Maneuverability = Maneuverability;
+            copy.StarfighterCapacity = StarfighterCapacity;
+            copy.RegimentCapacity = RegimentCapacity;
+            copy.Roles = new List<CapitalShipRole>(Roles);
+            copy.PrimaryWeapons = PrimaryWeapons.ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value?.ToArray()
+            );
+            copy.WeaponRecharge = WeaponRecharge;
+            copy.Bombardment = Bombardment;
+            copy.ManufacturingProgress = ManufacturingProgress;
+            copy.ManufacturingStatus = ManufacturingStatus;
+            copy.RefinedMaterialProgress = RefinedMaterialProgress;
+            copy.ProductionCapacity = ProductionCapacity;
+            copy.ProductionCapacityUsed = ProductionCapacityUsed;
+            copy.KdyPool = KdyPool;
+            copy.LnrPool = LnrPool;
+            copy.Movement = Movement?.CreateCopy();
+            copy.TractorBeamPower = TractorBeamPower;
+            copy.TractorBeamnRange = TractorBeamnRange;
+            copy.HasGravityWell = HasGravityWell;
+            copy.CanDestroyPlanets = CanDestroyPlanets;
+            copy.DetectionRating = DetectionRating;
+            copy.InitialParentInstanceID = InitialParentInstanceID;
+        }
+
         /// <summary>
         /// Replaces the ship's child collections while constructing a detached projection.
         /// </summary>

--- a/Assets/Scripts/Game/Units/Fleet.cs
+++ b/Assets/Scripts/Game/Units/Fleet.cs
@@ -52,6 +52,20 @@ namespace Rebellion.Game.Units
         /// </summary>
         public Fleet() { }
 
+        /// <summary>Creates an empty fleet copy.</summary>
+        protected override BaseSceneNode CreateNodeCopy() => new Fleet();
+
+        /// <summary>Copies fleet state into an empty destination.</summary>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            Fleet copy = (Fleet)destination;
+            copy.Movement = Movement?.CreateCopy();
+            copy.RoleType = RoleType;
+            copy.Order = Order?.CreateCopy();
+            copy.IsInCombat = IsInCombat;
+        }
+
         public Fleet(
             string ownerInstanceId,
             string displayName,

--- a/Assets/Scripts/Game/Units/FleetOrder.cs
+++ b/Assets/Scripts/Game/Units/FleetOrder.cs
@@ -34,5 +34,17 @@ namespace Rebellion.Game.Units
         public FleetOrderStatus Status { get; set; }
 
         public string TargetPlanetId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Creates an independent copy of this fleet order.
+        /// </summary>
+        /// <returns>The copied fleet order.</returns>
+        public FleetOrder CreateCopy() =>
+            new FleetOrder
+            {
+                OrderType = OrderType,
+                Status = Status,
+                TargetPlanetId = TargetPlanetId,
+            };
     }
 }

--- a/Assets/Scripts/Game/Units/Officer.cs
+++ b/Assets/Scripts/Game/Units/Officer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Rebellion.Game.Missions;
 using Rebellion.Game.Movement;
 using Rebellion.Game.Research;
@@ -19,6 +20,16 @@ namespace Rebellion.Game.Units
         public string SmallDisplayImagePath { get; set; }
         public string MessageImagePath { get; set; }
         public string EncyclopediaImagePath { get; set; }
+
+        /// <summary>Creates an independent copy of this image set.</summary>
+        public OfficerImageSet CreateCopy() =>
+            new OfficerImageSet
+            {
+                DisplayImagePath = DisplayImagePath,
+                SmallDisplayImagePath = SmallDisplayImagePath,
+                MessageImagePath = MessageImagePath,
+                EncyclopediaImagePath = EncyclopediaImagePath,
+            };
 
         public void MergeFrom(OfficerImageSet authored)
         {
@@ -92,6 +103,20 @@ namespace Rebellion.Game.Units
         {
             IReadOnlyList<string> paths = GetMutablePaths(type);
             return paths ?? Array.Empty<string>();
+        }
+
+        /// <summary>Creates an independent copy of this voice set.</summary>
+        public OfficerVoiceSet CreateCopy()
+        {
+            OfficerVoiceSet copy = new OfficerVoiceSet();
+            foreach (OfficerVoiceLineType type in Enum.GetValues(typeof(OfficerVoiceLineType)))
+            {
+                List<string> paths = GetMutablePaths(type);
+                List<string> destination = copy.GetMutablePaths(type);
+                if (paths != null && destination != null)
+                    destination.AddRange(paths);
+            }
+            return copy;
         }
 
         /// <summary>
@@ -306,6 +331,62 @@ namespace Rebellion.Game.Units
         /// Default constructor used for deserialization.
         /// </summary>
         public Officer() { }
+
+        /// <summary>Creates an empty officer copy.</summary>
+        protected override BaseSceneNode CreateNodeCopy() => new Officer();
+
+        /// <summary>Copies officer state into an empty destination.</summary>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            Officer copy = (Officer)destination;
+            copy.ShipResearch = ShipResearch;
+            copy.TroopResearch = TroopResearch;
+            copy.FacilityResearch = FacilityResearch;
+            copy.IsMain = IsMain;
+            copy.IsRecruitable = IsRecruitable;
+            copy.RecruitingFactionInstanceIDs = new List<string>(RecruitingFactionInstanceIDs);
+            copy.IsCaptured = IsCaptured;
+            copy.CaptorInstanceID = CaptorInstanceID;
+            copy.CanEscape = CanEscape;
+            copy.IsKilled = IsKilled;
+            copy.CanBetray = CanBetray;
+            copy.IsTraitor = IsTraitor;
+            copy.Loyalty = Loyalty;
+            copy.InjuryPoints = InjuryPoints;
+            copy.CanHeal = CanHeal;
+            copy.FastHeal = FastHeal;
+            copy.JediProbability = JediProbability;
+            copy.JediLevel = JediLevel;
+            copy.JediLevelVariance = JediLevelVariance;
+            copy.IsJediTrainer = IsJediTrainer;
+            copy.GrowsForceOnMission = GrowsForceOnMission;
+            copy.IsKnownJedi = IsKnownJedi;
+            copy.IsForceSensitive = IsForceSensitive;
+            copy.IsForceEligible = IsForceEligible;
+            copy.ForceValue = ForceValue;
+            copy.ForceTrainingAdjustment = ForceTrainingAdjustment;
+            copy.IsDiscoveringForceUser = IsDiscoveringForceUser;
+            copy.AllowedRanks = AllowedRanks?.ToArray();
+            copy.CurrentRank = CurrentRank;
+            copy.InitialParentTypeID = InitialParentTypeID;
+            copy.InitialParentInstanceID = InitialParentInstanceID;
+            copy.DiplomacyVariance = DiplomacyVariance;
+            copy.EspionageVariance = EspionageVariance;
+            copy.CombatVariance = CombatVariance;
+            copy.LeadershipVariance = LeadershipVariance;
+            copy.LoyaltyVariance = LoyaltyVariance;
+            copy.FacilityResearchVariance = FacilityResearchVariance;
+            copy.TroopResearchVariance = TroopResearchVariance;
+            copy.ShipResearchVariance = ShipResearchVariance;
+            copy.Movement = Movement?.CreateCopy();
+            copy.IsRetired = IsRetired;
+            copy.MissionReturnParentInstanceID = MissionReturnParentInstanceID;
+            copy.MissionReturnLocationInstanceID = MissionReturnLocationInstanceID;
+            copy.VoiceSet = VoiceSet?.CreateCopy();
+            copy.ImageSet = ImageSet?.CreateCopy();
+            copy.Ratings = new Dictionary<OfficerRating, int>(Ratings);
+        }
 
         /// <summary>
         /// Returns the officer's stored value for the specified rating.

--- a/Assets/Scripts/Game/Units/Regiment.cs
+++ b/Assets/Scripts/Game/Units/Regiment.cs
@@ -49,9 +49,10 @@ namespace Rebellion.Game.Units
             copy.ConstructionCost = ConstructionCost;
             copy.MaintenanceCost = MaintenanceCost;
             copy.BaseBuildSpeed = BaseBuildSpeed;
-            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
-                ? null
-                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ManufacturingFactionInstanceIDs =
+                ManufacturingFactionInstanceIDs == null
+                    ? null
+                    : new List<string>(ManufacturingFactionInstanceIDs);
             copy.ResearchOrder = ResearchOrder;
             copy.ResearchDifficulty = ResearchDifficulty;
             copy.AttackRating = AttackRating;

--- a/Assets/Scripts/Game/Units/Regiment.cs
+++ b/Assets/Scripts/Game/Units/Regiment.cs
@@ -38,6 +38,34 @@ namespace Rebellion.Game.Units
         /// </summary>
         public Regiment() { }
 
+        /// <summary>Creates an empty regiment copy.</summary>
+        protected override BaseSceneNode CreateNodeCopy() => new Regiment();
+
+        /// <summary>Copies regiment state into an empty destination.</summary>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            Regiment copy = (Regiment)destination;
+            copy.ConstructionCost = ConstructionCost;
+            copy.MaintenanceCost = MaintenanceCost;
+            copy.BaseBuildSpeed = BaseBuildSpeed;
+            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
+                ? null
+                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ResearchOrder = ResearchOrder;
+            copy.ResearchDifficulty = ResearchDifficulty;
+            copy.AttackRating = AttackRating;
+            copy.DefenseRating = DefenseRating;
+            copy.DetectionRating = DetectionRating;
+            copy.BombardmentDefense = BombardmentDefense;
+            copy.UprisingDefense = UprisingDefense;
+            copy.ProducerOwnerID = ProducerOwnerID;
+            copy.ProducerPlanetID = ProducerPlanetID;
+            copy.ManufacturingProgress = ManufacturingProgress;
+            copy.ManufacturingStatus = ManufacturingStatus;
+            copy.Movement = Movement?.CreateCopy();
+        }
+
         /// <summary>
         /// Returns the manufacturing type for this unit.
         /// </summary>

--- a/Assets/Scripts/Game/Units/SpecialForces.cs
+++ b/Assets/Scripts/Game/Units/SpecialForces.cs
@@ -57,6 +57,34 @@ namespace Rebellion.Game.Units
         /// </summary>
         public SpecialForces() { }
 
+        /// <summary>Creates an empty special-forces copy.</summary>
+        protected override BaseSceneNode CreateNodeCopy() => new SpecialForces();
+
+        /// <summary>Copies special-forces state into an empty destination.</summary>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            SpecialForces copy = (SpecialForces)destination;
+            copy.ConstructionCost = ConstructionCost;
+            copy.MaintenanceCost = MaintenanceCost;
+            copy.BaseBuildSpeed = BaseBuildSpeed;
+            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
+                ? null
+                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ResearchOrder = ResearchOrder;
+            copy.ResearchDifficulty = ResearchDifficulty;
+            copy.ProducerOwnerID = ProducerOwnerID;
+            copy.ProducerPlanetID = ProducerPlanetID;
+            copy.ManufacturingProgress = ManufacturingProgress;
+            copy.ManufacturingStatus = ManufacturingStatus;
+            copy.Movement = Movement?.CreateCopy();
+            copy.IsRetired = IsRetired;
+            copy.MissionReturnParentInstanceID = MissionReturnParentInstanceID;
+            copy.MissionReturnLocationInstanceID = MissionReturnLocationInstanceID;
+            copy.AllowedMissionTypeIDs = new List<string>(AllowedMissionTypeIDs);
+            copy.Ratings = new Dictionary<OfficerRating, int>(Ratings);
+        }
+
         /// <summary>
         /// Returns the manufacturing type for this unit.
         /// </summary>

--- a/Assets/Scripts/Game/Units/SpecialForces.cs
+++ b/Assets/Scripts/Game/Units/SpecialForces.cs
@@ -68,9 +68,10 @@ namespace Rebellion.Game.Units
             copy.ConstructionCost = ConstructionCost;
             copy.MaintenanceCost = MaintenanceCost;
             copy.BaseBuildSpeed = BaseBuildSpeed;
-            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
-                ? null
-                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ManufacturingFactionInstanceIDs =
+                ManufacturingFactionInstanceIDs == null
+                    ? null
+                    : new List<string>(ManufacturingFactionInstanceIDs);
             copy.ResearchOrder = ResearchOrder;
             copy.ResearchDifficulty = ResearchDifficulty;
             copy.ProducerOwnerID = ProducerOwnerID;

--- a/Assets/Scripts/Game/Units/Starfighter.cs
+++ b/Assets/Scripts/Game/Units/Starfighter.cs
@@ -72,9 +72,10 @@ namespace Rebellion.Game.Units
             copy.ConstructionCost = ConstructionCost;
             copy.MaintenanceCost = MaintenanceCost;
             copy.BaseBuildSpeed = BaseBuildSpeed;
-            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
-                ? null
-                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ManufacturingFactionInstanceIDs =
+                ManufacturingFactionInstanceIDs == null
+                    ? null
+                    : new List<string>(ManufacturingFactionInstanceIDs);
             copy.ResearchOrder = ResearchOrder;
             copy.ResearchDifficulty = ResearchDifficulty;
             copy.MaxSquadronSize = MaxSquadronSize;

--- a/Assets/Scripts/Game/Units/Starfighter.cs
+++ b/Assets/Scripts/Game/Units/Starfighter.cs
@@ -58,6 +58,46 @@ namespace Rebellion.Game.Units
         /// </summary>
         public Starfighter() { }
 
+        /// <summary>Creates an empty starfighter copy.</summary>
+        protected override BaseSceneNode CreateNodeCopy() => new Starfighter();
+
+        /// <summary>Copies starfighter state into an empty destination.</summary>
+        protected override void CopyStateTo(BaseSceneNode destination)
+        {
+            base.CopyStateTo(destination);
+            Starfighter copy = (Starfighter)destination;
+            copy.BattleResultImagePath = BattleResultImagePath;
+            copy.BattleResultInTransitImagePath = BattleResultInTransitImagePath;
+            copy.BattleResultDamagedImagePath = BattleResultDamagedImagePath;
+            copy.ConstructionCost = ConstructionCost;
+            copy.MaintenanceCost = MaintenanceCost;
+            copy.BaseBuildSpeed = BaseBuildSpeed;
+            copy.ManufacturingFactionInstanceIDs = ManufacturingFactionInstanceIDs == null
+                ? null
+                : new List<string>(ManufacturingFactionInstanceIDs);
+            copy.ResearchOrder = ResearchOrder;
+            copy.ResearchDifficulty = ResearchDifficulty;
+            copy.MaxSquadronSize = MaxSquadronSize;
+            copy.CurrentSquadronSize = CurrentSquadronSize;
+            copy.DetectionRating = DetectionRating;
+            copy.Bombardment = Bombardment;
+            copy.ShieldStrength = ShieldStrength;
+            copy.Hyperdrive = Hyperdrive;
+            copy.SublightSpeed = SublightSpeed;
+            copy.Agility = Agility;
+            copy.LaserCannon = LaserCannon;
+            copy.IonCannon = IonCannon;
+            copy.Torpedoes = Torpedoes;
+            copy.LaserRange = LaserRange;
+            copy.IonRange = IonRange;
+            copy.TorpedoRange = TorpedoRange;
+            copy.ProducerOwnerID = ProducerOwnerID;
+            copy.ProducerPlanetID = ProducerPlanetID;
+            copy.ManufacturingProgress = ManufacturingProgress;
+            copy.ManufacturingStatus = ManufacturingStatus;
+            copy.Movement = Movement?.CreateCopy();
+        }
+
         /// <summary>
         /// Returns true if this squadron has lost fighters that can be replaced.
         /// </summary>

--- a/Assets/Scripts/SceneGraph/BaseSceneNode.cs
+++ b/Assets/Scripts/SceneGraph/BaseSceneNode.cs
@@ -184,12 +184,6 @@ namespace Rebellion.SceneGraph
         protected abstract IEnumerable<ISceneNode> EnumerateChildren();
 
         /// <summary>
-        /// Enumerates direct relationships that must be retained by a recursive copy.
-        /// </summary>
-        /// <returns>The direct nodes to copy.</returns>
-        protected virtual IEnumerable<ISceneNode> EnumerateChildrenToCopy() => EnumerateChildren();
-
-        /// <summary>
         /// Returns a read-only snapshot of this node's children at the requested depth.
         /// </summary>
         /// <param name="recursive">Whether to include children at every depth.</param>
@@ -313,7 +307,7 @@ namespace Rebellion.SceneGraph
         /// <param name="includeDisabled">Whether disabled branches should be copied.</param>
         private void CopyChildrenTo(BaseSceneNode copy, bool includeDisabled)
         {
-            foreach (ISceneNode child in EnumerateChildrenToCopy())
+            foreach (ISceneNode child in EnumerateChildren())
             {
                 if (!includeDisabled && !child.IsActive())
                     continue;

--- a/Assets/Scripts/SceneGraph/BaseSceneNode.cs
+++ b/Assets/Scripts/SceneGraph/BaseSceneNode.cs
@@ -256,6 +256,13 @@ namespace Rebellion.SceneGraph
         public ISceneNode CreateCopy(bool recursive = false, bool includeDisabled = false)
         {
             BaseSceneNode copy = CreateNodeCopy();
+            if (copy == null || copy.GetType() != GetType())
+            {
+                throw new InvalidOperationException(
+                    $"{GetType().Name}.{nameof(CreateNodeCopy)} must return a non-null {GetType().Name}."
+                );
+            }
+
             CopyStateTo(copy);
             if (recursive)
                 CopyChildrenTo(copy, includeDisabled);

--- a/Assets/Scripts/SceneGraph/BaseSceneNode.cs
+++ b/Assets/Scripts/SceneGraph/BaseSceneNode.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Rebellion.Game.Encyclopedia;
 using Rebellion.Util.Extensions;
 using Rebellion.Util.Serialization;
 
@@ -183,6 +184,12 @@ namespace Rebellion.SceneGraph
         protected abstract IEnumerable<ISceneNode> EnumerateChildren();
 
         /// <summary>
+        /// Enumerates direct relationships that must be retained by a recursive copy.
+        /// </summary>
+        /// <returns>The direct nodes to copy.</returns>
+        protected virtual IEnumerable<ISceneNode> EnumerateChildrenToCopy() => EnumerateChildren();
+
+        /// <summary>
         /// Returns a read-only snapshot of this node's children at the requested depth.
         /// </summary>
         /// <param name="recursive">Whether to include children at every depth.</param>
@@ -238,6 +245,92 @@ namespace Rebellion.SceneGraph
             where T : class, ISceneNode
         {
             return GetChildren(recursive, includeDisabled).OfType<T>().ToList().AsReadOnly();
+        }
+
+        /// <summary>
+        /// Creates a detached copy of this node and, when requested, its descendant hierarchy.
+        /// </summary>
+        /// <param name="recursive">Whether to copy descendants at every depth.</param>
+        /// <param name="includeDisabled">Whether disabled descendants may be copied.</param>
+        /// <returns>A detached copy of this node.</returns>
+        public ISceneNode CreateCopy(bool recursive = false, bool includeDisabled = false)
+        {
+            BaseSceneNode copy = CreateNodeCopy();
+            CopyStateTo(copy);
+            if (recursive)
+                CopyChildrenTo(copy, includeDisabled);
+            return copy;
+        }
+
+        /// <summary>
+        /// Creates an empty copy with the same concrete scene-node type.
+        /// </summary>
+        /// <returns>An empty node of the same concrete type.</returns>
+        protected abstract BaseSceneNode CreateNodeCopy();
+
+        /// <summary>
+        /// Copies the state shared by every scene node into a detached destination.
+        /// </summary>
+        /// <param name="copy">The destination node.</param>
+        protected virtual void CopyStateTo(BaseSceneNode copy)
+        {
+            copy.InstanceID = InstanceID;
+            copy.TypeID = TypeID;
+            copy.DisplayName = DisplayName;
+            copy.DisplayStatus = DisplayStatus;
+            copy.DisplayImagePath = DisplayImagePath;
+            copy.SmallDisplayImagePath = SmallDisplayImagePath;
+            copy.MessageImagePath = MessageImagePath;
+            copy.InTransitImagePath = InTransitImagePath;
+            copy.InTransitSmallImagePath = InTransitSmallImagePath;
+            copy.DamagedImagePath = DamagedImagePath;
+            copy.DamagedSmallImagePath = DamagedSmallImagePath;
+            copy.CapturedOverlayImagePath = CapturedOverlayImagePath;
+            copy.InjuredImagePath = InjuredImagePath;
+            copy.Description = Description;
+            copy.EncyclopediaImagePath = EncyclopediaImagePath;
+            copy.EncyclopediaDescription = EncyclopediaDescription;
+            copy.EncyclopediaStats = EncyclopediaStats.ConvertAll(stat =>
+                new EncyclopediaEntryStat { Label = stat.Label, Value = stat.Value }
+            );
+            copy.OwnerInstanceID = OwnerInstanceID;
+            copy.IsEnabled = IsEnabled;
+        }
+
+        /// <summary>
+        /// Copies eligible direct children and attaches them to their copied parent.
+        /// </summary>
+        /// <param name="copy">The destination parent.</param>
+        /// <param name="includeDisabled">Whether disabled branches should be copied.</param>
+        private void CopyChildrenTo(BaseSceneNode copy, bool includeDisabled)
+        {
+            foreach (ISceneNode child in EnumerateChildrenToCopy())
+            {
+                if (!includeDisabled && !child.IsActive())
+                    continue;
+
+                ISceneNode childCopy = child.CreateCopy(
+                    recursive: true,
+                    includeDisabled: includeDisabled
+                );
+                AttachCopiedChild(copy, child, childCopy);
+            }
+        }
+
+        /// <summary>
+        /// Attaches a copied child while preserving any relationship metadata owned by the parent.
+        /// </summary>
+        /// <param name="destination">The copied parent receiving the child.</param>
+        /// <param name="sourceChild">The source child whose relationship is being copied.</param>
+        /// <param name="copiedChild">The detached copied child.</param>
+        protected virtual void AttachCopiedChild(
+            BaseSceneNode destination,
+            ISceneNode sourceChild,
+            ISceneNode copiedChild
+        )
+        {
+            destination.AddChild(copiedChild);
+            copiedChild.SetParent(destination);
         }
 
         /// <summary>

--- a/Assets/Scripts/SceneGraph/BaseSceneNode.cs
+++ b/Assets/Scripts/SceneGraph/BaseSceneNode.cs
@@ -290,9 +290,11 @@ namespace Rebellion.SceneGraph
             copy.Description = Description;
             copy.EncyclopediaImagePath = EncyclopediaImagePath;
             copy.EncyclopediaDescription = EncyclopediaDescription;
-            copy.EncyclopediaStats = EncyclopediaStats.ConvertAll(stat =>
-                new EncyclopediaEntryStat { Label = stat.Label, Value = stat.Value }
-            );
+            copy.EncyclopediaStats = EncyclopediaStats?.ConvertAll(stat => new EncyclopediaEntryStat
+            {
+                Label = stat.Label,
+                Value = stat.Value,
+            });
             copy.OwnerInstanceID = OwnerInstanceID;
             copy.IsEnabled = IsEnabled;
         }

--- a/Assets/Scripts/SceneGraph/ISceneNode.cs
+++ b/Assets/Scripts/SceneGraph/ISceneNode.cs
@@ -127,6 +127,14 @@ namespace Rebellion.SceneGraph
             where T : class, ISceneNode;
 
         /// <summary>
+        /// Creates a detached copy of this node and, when requested, its descendant hierarchy.
+        /// </summary>
+        /// <param name="recursive">Whether to copy descendants at every depth.</param>
+        /// <param name="includeDisabled">Whether disabled descendants may be copied.</param>
+        /// <returns>A detached copy of this node.</returns>
+        ISceneNode CreateCopy(bool recursive = false, bool includeDisabled = false);
+
+        /// <summary>
         /// Visits this node and all descendants, invoking the given action on each.
         /// </summary>
         /// <param name="action"></param>

--- a/Assets/Scripts/SceneGraph/LeafNode.cs
+++ b/Assets/Scripts/SceneGraph/LeafNode.cs
@@ -19,6 +19,12 @@ namespace Rebellion.SceneGraph
         protected LeafNode() { }
 
         /// <summary>
+        /// Creates an empty leaf-node copy.
+        /// </summary>
+        /// <returns>An empty leaf node.</returns>
+        protected override BaseSceneNode CreateNodeCopy() => new LeafNode();
+
+        /// <summary>
         /// Leaf nodes cannot have children.
         /// </summary>
         /// <param name="child">The candidate child node.</param>

--- a/Assets/Scripts/SceneGraph/LeafNode.cs
+++ b/Assets/Scripts/SceneGraph/LeafNode.cs
@@ -11,18 +11,12 @@ namespace Rebellion.SceneGraph
     /// officers, starfighters, and other entities that do not have children. For nodes
     /// that have children, see the <see cref="ContainerNode"/> class.
     /// </remarks>
-    public class LeafNode : BaseSceneNode
+    public abstract class LeafNode : BaseSceneNode
     {
         /// <summary>
         /// Default constructor.
         /// </summary>
         protected LeafNode() { }
-
-        /// <summary>
-        /// Creates an empty leaf-node copy.
-        /// </summary>
-        /// <returns>An empty leaf node.</returns>
-        protected override BaseSceneNode CreateNodeCopy() => new LeafNode();
 
         /// <summary>
         /// Leaf nodes cannot have children.

--- a/Assets/Scripts/Systems/FogOfWarSystem.cs
+++ b/Assets/Scripts/Systems/FogOfWarSystem.cs
@@ -8,7 +8,6 @@ using Rebellion.Game.Missions;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
-using Rebellion.Util.Extensions;
 
 namespace Rebellion.Systems
 {
@@ -142,9 +141,8 @@ namespace Rebellion.Systems
 
             foreach (PlanetSystem masterSystem in _game.Galaxy.GetChildren<PlanetSystem>())
             {
-                PlanetSystem viewSystem = masterSystem.GetShallowCopy(CloneMode.Full);
+                PlanetSystem viewSystem = (PlanetSystem)masterSystem.CreateCopy();
                 viewSystem.SetPlanets(Enumerable.Empty<Planet>());
-                ClearParentReferences(viewSystem);
                 viewSystem.SetParent(factionView);
 
                 faction.Fog.Snapshots.TryGetValue(
@@ -190,8 +188,8 @@ namespace Rebellion.Systems
                             .Where(mission => mission.GetOwnerInstanceID() == faction.InstanceID)
                     )
                     {
-                        Mission viewMission = mission.GetShallowCopy(CloneMode.Full);
-                        ClearParentReferences(viewMission);
+                        Mission viewMission = (Mission)
+                            mission.CreateCopy(recursive: true, includeDisabled: true);
                         viewMission.SetParent(viewPlanet);
                         viewPlanet.AddChild(viewMission);
                     }
@@ -378,7 +376,7 @@ namespace Rebellion.Systems
         /// <returns>A blank planet view with empty entity lists.</returns>
         private Planet BlankPlanetView(Planet masterPlanet)
         {
-            Planet viewPlanet = masterPlanet.GetShallowCopy(CloneMode.Full);
+            Planet viewPlanet = (Planet)masterPlanet.CreateCopy();
             viewPlanet.SetChildren(
                 Enumerable.Empty<Fleet>(),
                 Enumerable.Empty<Officer>(),
@@ -392,7 +390,6 @@ namespace Rebellion.Systems
                 new Dictionary<ManufacturingType, List<IManufacturable>>();
             viewPlanet.VisitingFactionIDs = new List<string>();
             viewPlanet.PopularSupport = new Dictionary<string, int>();
-            ClearParentReferences(viewPlanet);
             return viewPlanet;
         }
 
@@ -662,18 +659,6 @@ namespace Rebellion.Systems
             );
 
             return viewPlanet;
-        }
-
-        /// <summary>
-        /// Removes live scene-graph parent references from a copied view node.
-        /// </summary>
-        /// <param name="node">The copied node to detach.</param>
-        private static void ClearParentReferences(ISceneNode node)
-        {
-            node.ParentInstanceID = null;
-            node.LastParentInstanceID = null;
-            node.ParentNode = null;
-            node.LastParentNode = null;
         }
     }
 }

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -649,7 +649,7 @@ namespace Rebellion.Systems
                 .Except(localParticipants)
                 .ToList();
 
-            MoveCapturedParticipants(mission, missionPlanet);
+            MoveNonReturningParticipantsToPlanet(mission, missionPlanet);
             List<IMovable> strandedUnits = _movementManager.CompleteMissionAtLocation(
                 localParticipants,
                 missionPlanet
@@ -716,17 +716,24 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Moves captured mission participants to the mission planet before teardown.
+        /// Moves retained participants that cannot return from the mission to its planet.
         /// </summary>
         /// <param name="mission">The mission being torn down.</param>
         /// <param name="missionPlanet">The planet that hosts the mission.</param>
-        private void MoveCapturedParticipants(Mission mission, Planet missionPlanet)
+        private void MoveNonReturningParticipantsToPlanet(Mission mission, Planet missionPlanet)
         {
             if (missionPlanet == null)
                 return;
 
-            foreach (Officer officer in GetCapturedMissionParticipants(mission))
-                _movementManager.RequestMove(officer, missionPlanet);
+            foreach (
+                IMissionParticipant participant in mission
+                    .GetAllParticipants(includeDisabled: true)
+                    .Where(participant => !IsFreeParticipant(participant))
+            )
+            {
+                if (participant.GetParent() == mission && missionPlanet.CanAcceptChild(participant))
+                    _game.MoveNode(participant, missionPlanet);
+            }
         }
 
         /// <summary>
@@ -758,16 +765,6 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Returns mission officers that were captured during the mission.
-        /// </summary>
-        /// <param name="mission">The mission being torn down.</param>
-        /// <returns>The captured mission officers.</returns>
-        private static IEnumerable<Officer> GetCapturedMissionParticipants(Mission mission)
-        {
-            return mission.GetAllParticipants().OfType<Officer>().Where(IsCapturedParticipant);
-        }
-
-        /// <summary>
         /// Returns whether a movable participant can be relocated after mission teardown.
         /// </summary>
         /// <param name="participant">The participant to inspect.</param>
@@ -775,16 +772,6 @@ namespace Rebellion.Systems
         private static bool IsFreeParticipant(IMovable participant)
         {
             return participant is not Officer officer || (!officer.IsKilled && !officer.IsCaptured);
-        }
-
-        /// <summary>
-        /// Returns whether an officer was captured during mission resolution.
-        /// </summary>
-        /// <param name="officer">The officer to inspect.</param>
-        /// <returns>True when the officer is captured.</returns>
-        private static bool IsCapturedParticipant(Officer officer)
-        {
-            return officer.IsCaptured;
         }
 
         /// <summary>

--- a/Assets/Scripts/UI/SceneUI/Cutscenes/CutscenePlayer.cs
+++ b/Assets/Scripts/UI/SceneUI/Cutscenes/CutscenePlayer.cs
@@ -163,7 +163,7 @@ public sealed class CutscenePlayer : MonoBehaviour
     /// <param name="message">The platform decoder's error message.</param>
     private void HandlePlaybackError(VideoPlayer source, string message)
     {
-        Debug.LogError($"Cutscene playback failed: {message}", source);
+        Debug.LogWarning($"Cutscene playback failed: {message}", source);
         GameStartupTrace.Log($"Faction introduction decoder failed: {message}");
         EndCutscene();
     }

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/MissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/MissionTests.cs
@@ -16,6 +16,31 @@ namespace Rebellion.Tests.Game.Missions
     public class MissionTests
     {
         [Test]
+        public void GetChildren_ParticipantAssignedBeforeMissionInitiates_ReturnsParticipant()
+        {
+            (
+                GameRoot game,
+                Planet empirePlanet,
+                Planet enemyPlanet,
+                Officer officer,
+                FogOfWarSystem fog
+            ) = MissionSceneBuilder.Build();
+            Regiment target = CreateSabotageTarget(game, enemyPlanet);
+            Mission mission = CreateSabotageMission(
+                "empire",
+                enemyPlanet,
+                new List<IMissionParticipant> { officer },
+                new List<IMissionParticipant>(),
+                target
+            );
+            game.AttachNode(mission, enemyPlanet);
+            game.MoveNode(officer, mission);
+
+            Assert.IsFalse(mission.HasInitiated);
+            CollectionAssert.AreEqual(new[] { officer }, mission.GetChildren().ToArray());
+        }
+
+        [Test]
         public void GetAbortReason_MainParticipantRemoved_ReturnsFailure()
         {
             (

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/MissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/MissionTests.cs
@@ -38,6 +38,11 @@ namespace Rebellion.Tests.Game.Missions
 
             Assert.IsFalse(mission.HasInitiated);
             CollectionAssert.AreEqual(new[] { officer }, mission.GetChildren().ToArray());
+
+            Mission copy = (Mission)mission.CreateCopy(recursive: true);
+            IMissionParticipant copiedParticipant = copy.GetMainParticipants().Single();
+
+            Assert.AreEqual(copy, copiedParticipant.GetParent());
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
+++ b/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
@@ -142,6 +142,10 @@ public class QueueRNG : IRandomNumberProvider
 /// </summary>
 public class StubMission : Mission
 {
+    /// <summary>Creates an empty stub mission copy.</summary>
+    /// <returns>An empty stub mission.</returns>
+    protected override BaseSceneNode CreateNodeCopy() => new StubMission();
+
     /// <summary>
     /// Default constructor — sets empty participant lists.
     /// Use when the mission only needs to exist as a parent node, not in the scene graph.

--- a/Assets/Tests/EditMode/GameTests/SceneGraph/BaseSceneNodeTests.cs
+++ b/Assets/Tests/EditMode/GameTests/SceneGraph/BaseSceneNodeTests.cs
@@ -279,6 +279,16 @@ namespace Rebellion.Tests.SceneGraph
         }
 
         [Test]
+        public void CreateCopy_NullEncyclopediaStats_PreservesNullStats()
+        {
+            _rootNode.EncyclopediaStats = null;
+
+            MockSceneNode copy = (MockSceneNode)_rootNode.CreateCopy();
+
+            Assert.IsNull(copy.EncyclopediaStats);
+        }
+
+        [Test]
         public void CreateCopy_Recursive_CopiesHierarchyAndReconnectsParents()
         {
             MockSceneNode grandchild = new MockSceneNode
@@ -330,8 +340,7 @@ namespace Rebellion.Tests.SceneGraph
 
             MockSceneNode copy = (MockSceneNode)
                 _rootNode.CreateCopy(recursive: true, includeDisabled: true);
-            MockSceneNode copiedChild = copy
-                .GetChildren<MockSceneNode>(includeDisabled: true)
+            MockSceneNode copiedChild = copy.GetChildren<MockSceneNode>(includeDisabled: true)
                 .Single();
 
             Assert.IsFalse(copiedChild.IsEnabled);

--- a/Assets/Tests/EditMode/GameTests/SceneGraph/BaseSceneNodeTests.cs
+++ b/Assets/Tests/EditMode/GameTests/SceneGraph/BaseSceneNodeTests.cs
@@ -289,6 +289,16 @@ namespace Rebellion.Tests.SceneGraph
         }
 
         [Test]
+        public void CreateCopy_CreateNodeCopyReturnsDifferentType_ThrowsInvalidOperationException()
+        {
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                _nodeA.CreateCopy()
+            );
+
+            StringAssert.Contains(nameof(MockSceneNodeA), exception.Message);
+        }
+
+        [Test]
         public void CreateCopy_Recursive_CopiesHierarchyAndReconnectsParents()
         {
             MockSceneNode grandchild = new MockSceneNode

--- a/Assets/Tests/EditMode/GameTests/SceneGraph/BaseSceneNodeTests.cs
+++ b/Assets/Tests/EditMode/GameTests/SceneGraph/BaseSceneNodeTests.cs
@@ -262,6 +262,83 @@ namespace Rebellion.Tests.SceneGraph
         }
 
         [Test]
+        public void CreateCopy_Default_CopiesOnlyDetachedNode()
+        {
+            _rootNode.OwnerInstanceID = "Owner1";
+            _rootNode.AddChild(_childNode1);
+
+            MockSceneNode copy = (MockSceneNode)_rootNode.CreateCopy();
+
+            Assert.AreNotSame(_rootNode, copy);
+            Assert.AreEqual(_rootNode.InstanceID, copy.InstanceID);
+            Assert.AreEqual("Owner1", copy.OwnerInstanceID);
+            Assert.IsNull(copy.GetParent());
+            Assert.IsNull(copy.GetLastParent());
+            Assert.IsEmpty(copy.GetChildren(includeDisabled: true));
+            Assert.AreEqual(1, _rootNode.GetChildren().Count);
+        }
+
+        [Test]
+        public void CreateCopy_Recursive_CopiesHierarchyAndReconnectsParents()
+        {
+            MockSceneNode grandchild = new MockSceneNode
+            {
+                DisplayName = "Grandchild",
+                InstanceID = Guid.NewGuid().ToString(),
+            };
+            _rootNode.AddChild(_childNode1);
+            _childNode1.SetParent(_rootNode);
+            _childNode1.AddChild(grandchild);
+            grandchild.SetParent(_childNode1);
+
+            MockSceneNode copy = (MockSceneNode)_rootNode.CreateCopy(recursive: true);
+            MockSceneNode copiedChild = copy.GetChildren<MockSceneNode>().Single();
+            MockSceneNode copiedGrandchild = copiedChild.GetChildren<MockSceneNode>().Single();
+
+            Assert.AreNotSame(_childNode1, copiedChild);
+            Assert.AreSame(copy, copiedChild.GetParent());
+            Assert.AreSame(copiedChild, copiedGrandchild.GetParent());
+            Assert.AreEqual(copy.InstanceID, copiedChild.ParentInstanceID);
+            Assert.AreEqual(copiedChild.InstanceID, copiedGrandchild.ParentInstanceID);
+        }
+
+        [Test]
+        public void CreateCopy_RecursiveByDefault_ExcludesDisabledBranches()
+        {
+            MockSceneNode grandchild = new MockSceneNode
+            {
+                DisplayName = "Grandchild",
+                InstanceID = Guid.NewGuid().ToString(),
+            };
+            _childNode1.IsEnabled = false;
+            _rootNode.AddChild(_childNode1);
+            _childNode1.SetParent(_rootNode);
+            _childNode1.AddChild(grandchild);
+            grandchild.SetParent(_childNode1);
+
+            MockSceneNode copy = (MockSceneNode)_rootNode.CreateCopy(recursive: true);
+
+            Assert.IsEmpty(copy.GetChildren(includeDisabled: true));
+        }
+
+        [Test]
+        public void CreateCopy_RecursiveIncludingDisabled_CopiesDisabledBranches()
+        {
+            _childNode1.IsEnabled = false;
+            _rootNode.AddChild(_childNode1);
+            _childNode1.SetParent(_rootNode);
+
+            MockSceneNode copy = (MockSceneNode)
+                _rootNode.CreateCopy(recursive: true, includeDisabled: true);
+            MockSceneNode copiedChild = copy
+                .GetChildren<MockSceneNode>(includeDisabled: true)
+                .Single();
+
+            Assert.IsFalse(copiedChild.IsEnabled);
+            Assert.AreSame(copy, copiedChild.GetParent());
+        }
+
+        [Test]
         public void Traverse_HierarchicalNodes_VisitsAllNodes()
         {
             _rootNode.AddChild(_childNode1);
@@ -336,6 +413,10 @@ namespace Rebellion.Tests.SceneGraph
         private class MockSceneNode : BaseSceneNode
         {
             private readonly List<ISceneNode> _children = new List<ISceneNode>();
+
+            public MockSceneNode() { }
+
+            protected override BaseSceneNode CreateNodeCopy() => new MockSceneNode();
 
             public override bool CanAcceptChild(ISceneNode child) => true;
 

--- a/Assets/Tests/EditMode/GameTests/SceneGraph/ContainerNodeTests.cs
+++ b/Assets/Tests/EditMode/GameTests/SceneGraph/ContainerNodeTests.cs
@@ -672,6 +672,8 @@ namespace Rebellion.Tests.SceneGraph
         {
             private readonly List<ISceneNode> _children = new List<ISceneNode>();
 
+            protected override BaseSceneNode CreateNodeCopy() => new MockContainerNode();
+
             public override bool CanAcceptChild(ISceneNode child) => true;
 
             public override void AddChild(ISceneNode child)

--- a/Assets/Tests/EditMode/GameTests/SceneGraph/LeafNodeTests.cs
+++ b/Assets/Tests/EditMode/GameTests/SceneGraph/LeafNodeTests.cs
@@ -265,6 +265,8 @@ namespace Rebellion.Tests.SceneGraph
         {
             private readonly List<ISceneNode> _children = new List<ISceneNode>();
 
+            protected override BaseSceneNode CreateNodeCopy() => new MockContainerNode();
+
             public override bool CanAcceptChild(ISceneNode child) => true;
 
             public override void AddChild(ISceneNode child)

--- a/Assets/Tests/EditMode/GameTests/SceneGraph/LeafNodeTests.cs
+++ b/Assets/Tests/EditMode/GameTests/SceneGraph/LeafNodeTests.cs
@@ -248,16 +248,28 @@ namespace Rebellion.Tests.SceneGraph
             Assert.AreSame(_leafNode, visitedNodes[0]);
         }
 
+        [Test]
+        public void CreateCopy_ReturnsSameConcreteLeafType()
+        {
+            ISceneNode copy = _leafNode.CreateCopy();
+
+            Assert.IsInstanceOf<MockLeafNode>(copy);
+        }
+
         // Mock implementation of LeafNode for testing purposes
         private class MockLeafNode : LeafNode
         {
             public MockLeafNode() { }
+
+            protected override BaseSceneNode CreateNodeCopy() => new MockLeafNode();
         }
 
         // Another mock implementation for type-specific tests
         private class MockLeafNodeA : LeafNode
         {
             public MockLeafNodeA() { }
+
+            protected override BaseSceneNode CreateNodeCopy() => new MockLeafNodeA();
         }
 
         // Mock container node to test parent relationships

--- a/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
@@ -842,6 +842,9 @@ namespace Rebellion.Tests.Systems
             _coruscant.PopularSupport["FNALL1"] = 50;
             Mission empireMission = CreateMission("M1", _empire, _coruscant);
             _game.AttachNode(empireMission, _coruscant);
+            Officer vader = CreateOfficer("VADER", _empire);
+            _game.AttachNode(vader, _coruscant);
+            _game.MoveNode(vader, empireMission);
 
             GalaxyMap view = _fogSystem.BuildFactionView(_empire);
 
@@ -850,11 +853,15 @@ namespace Rebellion.Tests.Systems
                 .GetChildren<Planet>()
                 .First(p => p.InstanceID == "CORUSCANT");
 
-            Assert.AreEqual(
-                1,
-                viewCoruscant.GetChildren<Mission>().Count,
-                "Own missions should be visible on your own planet"
-            );
+            Mission viewMission = viewCoruscant.GetChildren<Mission>().Single();
+            Officer viewParticipant = viewMission
+                .GetMainParticipants(includeDisabled: true)
+                .Cast<Officer>()
+                .Single();
+
+            Assert.AreNotSame(empireMission, viewMission);
+            Assert.AreNotSame(vader, viewParticipant);
+            Assert.AreEqual(vader.InstanceID, viewParticipant.InstanceID);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
@@ -2621,6 +2621,36 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void RecordEspionageSnapshot_DisabledMissionParticipant_PreservesParticipant()
+        {
+            Officer vader = CreateOfficer("VADER", _empire);
+            _game.AttachNode(vader, _coruscant);
+            Mission empireMission = CreateMission("M1", _empire, _coruscant);
+            _game.AttachNode(empireMission, _coruscant);
+            _game.MoveNode(vader, empireMission);
+            vader.IsEnabled = false;
+
+            new FogOfWarRecorder().RecordEspionageSnapshot(
+                _alliance,
+                _coruscant,
+                _coreSystem,
+                10
+            );
+
+            Mission recordedMission = _alliance
+                .Fog.Snapshots[_coreSystem.InstanceID]
+                .Planets[_coruscant.InstanceID]
+                .Missions.Single();
+            Officer recordedParticipant = recordedMission
+                .GetMainParticipants(includeDisabled: true)
+                .Single() as Officer;
+
+            Assert.IsNotNull(recordedParticipant);
+            Assert.AreEqual(vader.InstanceID, recordedParticipant.InstanceID);
+            Assert.IsFalse(recordedParticipant.IsEnabled);
+        }
+
+        [Test]
         public void RecordEspionageSnapshot_IncomingEnemyFleet_RevealsFleet()
         {
             Fleet empireFleet = CreateFleet("INCOMING_FLEET", _empire);

--- a/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
@@ -2630,20 +2630,14 @@ namespace Rebellion.Tests.Systems
             _game.MoveNode(vader, empireMission);
             vader.IsEnabled = false;
 
-            new FogOfWarRecorder().RecordEspionageSnapshot(
-                _alliance,
-                _coruscant,
-                _coreSystem,
-                10
-            );
+            new FogOfWarRecorder().RecordEspionageSnapshot(_alliance, _coruscant, _coreSystem, 10);
 
             Mission recordedMission = _alliance
                 .Fog.Snapshots[_coreSystem.InstanceID]
                 .Planets[_coruscant.InstanceID]
                 .Missions.Single();
-            Officer recordedParticipant = recordedMission
-                .GetMainParticipants(includeDisabled: true)
-                .Single() as Officer;
+            Officer recordedParticipant =
+                recordedMission.GetMainParticipants(includeDisabled: true).Single() as Officer;
 
             Assert.IsNotNull(recordedParticipant);
             Assert.AreEqual(vader.InstanceID, recordedParticipant.InstanceID);

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -738,6 +738,11 @@ namespace Rebellion.Tests.Systems
             Assert.IsTrue(spy.IsKilled, "Officer should be killed when capture probability is 0");
             Assert.IsFalse(spy.IsActive(), "Killed officer should be inactive");
             Assert.AreSame(
+                planet,
+                spy.GetParent(),
+                "Killed officer should remain retained at the mission planet"
+            );
+            Assert.AreSame(
                 spy,
                 game.GetSceneNodeByInstanceID<Officer>(spy.InstanceID, includeDisabled: true)
             );

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -2944,6 +2944,11 @@ namespace Rebellion.Tests.Systems
         {
             private readonly Officer _target;
 
+            /// <summary>Creates an empty officer-killing mission copy.</summary>
+            /// <returns>An empty officer-killing mission.</returns>
+            protected override BaseSceneNode CreateNodeCopy() =>
+                new OfficerKillingMission(null, null, null, null);
+
             public OfficerKillingMission(
                 string ownerInstanceId,
                 string locationInstanceId,

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/Cutscenes/CutscenePlayerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/Cutscenes/CutscenePlayerTests.cs
@@ -4,7 +4,6 @@ using System.Runtime.ExceptionServices;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.TestTools;
 using UnityEngine.UI;
 using UnityEngine.Video;
 
@@ -147,8 +146,6 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
         {
             int completedCount = 0;
             _player.Play(_clip, () => completedCount++);
-            LogAssert.Expect(LogType.Error, "Cutscene playback failed: decoder failed");
-
             Invoke("HandlePlaybackError", _videoPlayer, "decoder failed");
             Invoke("EndCutscene");
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowControllerTests.cs
@@ -299,6 +299,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
 
         private sealed class TestMission : Mission
         {
+            /// <summary>Creates an empty test mission copy.</summary>
+            /// <returns>An empty test mission.</returns>
+            protected override Rebellion.SceneGraph.BaseSceneNode CreateNodeCopy() =>
+                new TestMission();
+
             public override bool ShouldRepeatAfterCompletion(GameRoot game)
             {
                 return false;

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowProjectorTests.cs
@@ -283,6 +283,10 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
 
         private sealed class TestMission : Mission
         {
+            /// <summary>Creates an empty test mission copy.</summary>
+            /// <returns>An empty test mission.</returns>
+            protected override BaseSceneNode CreateNodeCopy() => new TestMission();
+
             public override bool ShouldRepeatAfterCompletion(GameRoot game)
             {
                 return false;

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowSessionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowSessionTests.cs
@@ -251,6 +251,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
 
         private sealed class TestMission : Mission
         {
+            /// <summary>Creates an empty test mission copy.</summary>
+            /// <returns>An empty test mission.</returns>
+            protected override Rebellion.SceneGraph.BaseSceneNode CreateNodeCopy() =>
+                new TestMission();
+
             public override bool ShouldRepeatAfterCompletion(GameRoot game)
             {
                 return false;

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSystem/PlanetSystemWindowProjectorTests.cs
@@ -458,6 +458,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSystem
 
         private sealed class TestMission : Mission
         {
+            /// <summary>Creates an empty test mission copy.</summary>
+            /// <returns>An empty test mission.</returns>
+            protected override Rebellion.SceneGraph.BaseSceneNode CreateNodeCopy() =>
+                new TestMission(null);
+
             public TestMission(string ownerInstanceId)
             {
                 OwnerInstanceID = ownerInstanceId;


### PR DESCRIPTION
## What changed

- adds an explicit `CreateCopy` contract for scene nodes
- lets concrete node types intentionally copy their own state instead of relying on reflection
- supports recursive hierarchy copies and optional inclusion of disabled branches
- preserves mission participant roles and manufacturing-queue relationships without retaining live references
- routes fog-of-war entity copying through the shared scene-node API
- removes the bespoke fog-of-war copy helpers and mission participant replacement API

## Why

The previous fog-of-war copy path mixed reflection with per-type repair code. That made copied state difficult to audit and allowed new mutable fields or relationships to be copied incorrectly without an obvious failure. Explicit copying makes the contract visible on each node type and centralizes hierarchy reconstruction in `BaseSceneNode`.

## Impact

This is intentionally stacked on `scene-query-cleanup` because it relies on that branch's scene traversal and disabled-node behavior. It provides the copying foundation needed to simplify fog-of-war storage further in a later change.

## Validation

- `./build.sh lint`
- `LOG_LEVEL=none ./build.sh test`
- `git diff --check`
