### PR TITLE
Fixing inconsistencies with mission behavior.

### DIFF
--- a/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
@@ -47,7 +47,9 @@ public static class MainMenuPrefabBuilder
     // Spinning-planet backdrop.
     private const string _starfieldAddress = "Application/MainMenu/UI/starfield";
     private const string _cloudTextureAddress = "Application/MainMenu/UI/clouds";
+    private const string _cloudShaderName = "Custom/PlanetClouds";
     private const string _atmosphereShaderName = "Custom/AtmosphereRim";
+    private const string _planetDayNightShaderName = "Custom/PlanetDayNightShade";
     private const string _renderTexturePath = "Assets/Art/Models/MainMenu/Planet.renderTexture";
     private const string _citadelModelAddress = "Application/MainMenu/Models/citadel";
     private const string _citadelRenderTexturePath =
@@ -55,7 +57,12 @@ public static class MainMenuPrefabBuilder
     private const string _rigName = "PlanetRig";
     private const string _backdropName = "SpaceBackdrop";
     private const string _foregroundName = "Cockpit";
-    private const float _cloudSpinDegreesPerSecond = 0.25f; // cloud drift; planet turns at half this
+    private const float _cloudSpinDegreesPerSecond = 1f / 3f;
+    private static readonly Vector3 _planetSunDirection = new Vector3(
+        0.80f,
+        0.46f,
+        -0.38f
+    ).normalized;
     private static readonly Vector3 _planetRigOrigin = new Vector3(12000f, 12000f, 12000f);
 
     // Spinning 3D icon rigs.
@@ -2065,7 +2072,7 @@ public static class MainMenuPrefabBuilder
         clouds.layer = planetLayer;
         clouds
             .AddComponent<RuntimeMaterialBinding>()
-            .Configure("Unlit/Transparent", _cloudTextureAddress);
+            .Configure(_cloudShaderName, _cloudTextureAddress);
 
         // Atmosphere: a static shell just outside the clouds with a Fresnel rim glow, so the limb
         // reads as a lit atmosphere. Built from a primitive with the custom rim shader assigned here.
@@ -2077,11 +2084,21 @@ public static class MainMenuPrefabBuilder
         atmosphere.layer = planetLayer;
         atmosphere.AddComponent<RuntimeMaterialBinding>().Configure(_atmosphereShaderName);
 
+        // A final multiply shell reproduces the prototype's world-space day/night terminator over
+        // the complete composited globe, including the asynchronously loaded surface and clouds.
+        GameObject dayNightShade = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        dayNightShade.name = "DayNightShade";
+        UnityEngine.Object.DestroyImmediate(dayNightShade.GetComponent<Collider>());
+        dayNightShade.transform.SetParent(rig.transform, false);
+        dayNightShade.transform.localScale = Vector3.one * 2.040f;
+        dayNightShade.layer = planetLayer;
+        dayNightShade.AddComponent<RuntimeMaterialBinding>().Configure(_planetDayNightShaderName);
+
         // Dedicated sun for the planet, masked to their layer so it never touches the icons.
         // Gives the rocky surface real directional shading; the emission only lifts the night side.
         GameObject sunObject = new GameObject("PlanetSun", typeof(Light));
         sunObject.transform.SetParent(rig.transform, false);
-        sunObject.transform.localRotation = Quaternion.Euler(45.63f, 122.25f, 0f);
+        sunObject.transform.localRotation = Quaternion.LookRotation(-_planetSunDirection);
         Light sun = sunObject.GetComponent<Light>();
         sun.type = LightType.Directional;
         sun.intensity = 0.6f;

--- a/Assets/Scripts/AI/Proposals/AIMissionProposal.cs
+++ b/Assets/Scripts/AI/Proposals/AIMissionProposal.cs
@@ -186,7 +186,7 @@ namespace Rebellion.AI.Proposals
                 {
                     MissionTypeID = MissionTypeID,
                     Location = TargetPlanet,
-                    TargetOfficer = TargetOfficer,
+                    SelectedTarget = TargetOfficer,
                     Discipline = Discipline,
                     MainParticipants = new List<IMissionParticipant> { Participant },
                 }
@@ -209,7 +209,7 @@ namespace Rebellion.AI.Proposals
                     {
                         MissionTypeID = MissionTypeID,
                         Location = TargetPlanet,
-                        TargetOfficer = TargetOfficer,
+                        SelectedTarget = TargetOfficer,
                         Discipline = Discipline,
                         MainParticipants = new List<IMissionParticipant> { Participant },
                     }

--- a/Assets/Scripts/Game/Messages/MessageFactory.cs
+++ b/Assets/Scripts/Game/Messages/MessageFactory.cs
@@ -683,7 +683,7 @@ namespace Rebellion.Game.Messages
                     result.Outcome == MissionOutcome.Success
                     && result.Mission?.ConfigKey == MissionTypeIDs.Recruitment
                 )
-                .Select(result => GetMissionOfficerInstanceID(result.Mission))
+                .Select(result => GetMissionRelatedOfficerInstanceID(result.Mission))
                 .Where(id => !string.IsNullOrEmpty(id))
                 .ToHashSet();
 
@@ -1336,7 +1336,7 @@ namespace Rebellion.Game.Messages
             IEnumerable<OfficerKilledResult> killedResults
         )
         {
-            string officerID = GetMissionOfficerInstanceID(result?.Mission);
+            string officerID = GetMissionRelatedOfficerInstanceID(result?.Mission);
             if (string.IsNullOrEmpty(officerID))
                 return string.Empty;
 
@@ -1352,21 +1352,20 @@ namespace Rebellion.Game.Messages
         }
 
         /// <summary>
-        /// Gets the target officer instance ID for missions that target officers.
+        /// Gets the officer instance ID associated with a mission report. Recruitment reports
+        /// use the recruited officer outcome; officer-targeting missions use their objective.
         /// </summary>
         /// <param name="mission">The mission to inspect.</param>
-        /// <returns>The target officer instance ID, or null when the mission does not target an officer.</returns>
-        private static string GetMissionOfficerInstanceID(Mission mission)
+        /// <returns>The related officer instance ID, or null when none is available.</returns>
+        private static string GetMissionRelatedOfficerInstanceID(Mission mission)
         {
-            if (
-                mission?.ConfigKey == MissionTypeIDs.Recruitment
-                || mission?.ConfigKey == MissionTypeIDs.Abduction
-                || mission?.ConfigKey == MissionTypeIDs.Assassination
-                || mission?.ConfigKey == MissionTypeIDs.Rescue
-            )
-                return GetMissionTargetOfficerInstanceID(mission);
-
-            return null;
+            return mission switch
+            {
+                RecruitmentMission recruitment => recruitment.RecruitedOfficerInstanceID,
+                AbductionMission or AssassinationMission or RescueMission =>
+                    GetMissionTargetOfficerInstanceID(mission),
+                _ => null,
+            };
         }
 
         /// <summary>
@@ -1378,7 +1377,6 @@ namespace Rebellion.Game.Messages
         {
             return mission switch
             {
-                RecruitmentMission recruitment => recruitment.TargetOfficerInstanceID,
                 AbductionMission abduction => abduction.TargetOfficerInstanceID,
                 AssassinationMission assassination => assassination.TargetOfficerInstanceID,
                 RescueMission rescue => rescue.TargetOfficerInstanceID,

--- a/Assets/Scripts/Game/Missions/AbductionMission.cs
+++ b/Assets/Scripts/Game/Missions/AbductionMission.cs
@@ -32,11 +32,6 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns whether this mission should cancel when the target planet changes owner.
-        /// </summary>
-        public override bool CanceledOnOwnershipChange => false;
-
-        /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>
         public AbductionMission()
@@ -85,7 +80,7 @@ namespace Rebellion.Game.Missions
             if (!(ctx.Location is Planet planet))
                 return null;
 
-            Officer target = ctx.TargetOfficer;
+            Officer target = ctx.SelectedTarget as Officer;
             Planet targetPlanet = target?.GetParentOfType<Planet>();
             if (
                 target == null
@@ -110,24 +105,13 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>TargetUnavailable when the target is no longer valid; otherwise null.</returns>
-        public override MissionCompletionReason? GetAbortReason(GameRoot game)
+        protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
-            MissionCompletionReason? reason = base.GetAbortReason(game);
+            MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);
             if (reason.HasValue)
                 return reason;
 
             return HasValidTarget(game) ? null : MissionCompletionReason.TargetUnavailable;
-        }
-
-        /// <summary>
-        /// Returns false if the target officer has already been captured or has moved
-        /// away from the mission's planet before execution.
-        /// </summary>
-        /// <param name="game">The current game state.</param>
-        /// <returns>True if the target is still free and on the mission planet.</returns>
-        protected override bool IsMissionSatisfied(GameRoot game)
-        {
-            return HasValidTarget(game);
         }
 
         /// <summary>
@@ -168,21 +152,24 @@ namespace Rebellion.Game.Missions
         /// <returns>The abduction effects followed by the terminal mission result.</returns>
         internal override List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
         {
+            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
+            if (invalidationReason.HasValue)
+                return BuildInvalidatedResults(game, provider, invalidationReason.Value);
+
             List<GameResult> results = new List<GameResult>();
-            bool targetAvailable = IsMissionSatisfied(game);
             bool targetKilled = false;
             List<IMissionParticipant> successfulParticipants = ResolveSuccessfulParticipants(
                 provider,
                 game,
                 participant =>
                 {
-                    ImproveMissionParticipantRating(participant);
-                    if (!targetAvailable || targetKilled)
-                        return;
+                    if (targetKilled)
+                        return true;
 
                     List<GameResult> attemptResults = OnSuccess(game, provider, participant);
                     results.AddRange(attemptResults);
                     targetKilled = attemptResults.Exists(result => result is OfficerKilledResult);
+                    return true;
                 }
             );
 
@@ -192,12 +179,6 @@ namespace Rebellion.Game.Missions
             {
                 outcome = MissionOutcome.Failed;
                 completionReason = MissionCompletionReason.Failure;
-                results.AddRange(OnFailed(game, provider));
-            }
-            else if (!targetAvailable)
-            {
-                outcome = MissionOutcome.Failed;
-                completionReason = MissionCompletionReason.TargetUnavailable;
                 results.AddRange(OnFailed(game, provider));
             }
             else

--- a/Assets/Scripts/Game/Missions/AbductionMission.cs
+++ b/Assets/Scripts/Game/Missions/AbductionMission.cs
@@ -150,12 +150,11 @@ namespace Rebellion.Game.Missions
         /// <param name="game">The current game state.</param>
         /// <param name="provider">RNG provider for success, injury, and death rolls.</param>
         /// <returns>The abduction effects followed by the terminal mission result.</returns>
-        internal override List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
+        internal override List<GameResult> ResolveObjective(
+            GameRoot game,
+            IRandomNumberProvider provider
+        )
         {
-            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
-            if (invalidationReason.HasValue)
-                return BuildInvalidatedResults(game, provider, invalidationReason.Value);
-
             List<GameResult> results = new List<GameResult>();
             bool targetKilled = false;
             List<IMissionParticipant> successfulParticipants = ResolveSuccessfulParticipants(

--- a/Assets/Scripts/Game/Missions/AssassinationMission.cs
+++ b/Assets/Scripts/Game/Missions/AssassinationMission.cs
@@ -152,12 +152,11 @@ namespace Rebellion.Game.Missions
         /// <param name="game">The current game state.</param>
         /// <param name="provider">RNG provider for all probability rolls.</param>
         /// <returns>The hit effects followed by the terminal mission result.</returns>
-        internal override List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
+        internal override List<GameResult> ResolveObjective(
+            GameRoot game,
+            IRandomNumberProvider provider
+        )
         {
-            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
-            if (invalidationReason.HasValue)
-                return BuildInvalidatedResults(game, provider, invalidationReason.Value);
-
             List<GameResult> results = new List<GameResult>();
             MissionOutcome outcome = MissionOutcome.Failed;
             MissionCompletionReason completionReason = MissionCompletionReason.Failure;

--- a/Assets/Scripts/Game/Missions/AssassinationMission.cs
+++ b/Assets/Scripts/Game/Missions/AssassinationMission.cs
@@ -32,11 +32,6 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns whether this mission should cancel when the target planet changes owner.
-        /// </summary>
-        public override bool CanceledOnOwnershipChange => false;
-
-        /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>
         public AssassinationMission()
@@ -85,7 +80,7 @@ namespace Rebellion.Game.Missions
             if (!(ctx.Location is Planet planet))
                 return null;
 
-            Officer target = ctx.TargetOfficer;
+            Officer target = ctx.SelectedTarget as Officer;
             Planet targetPlanet = target?.GetParentOfType<Planet>();
             if (
                 target == null
@@ -111,24 +106,13 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>TargetUnavailable when the target is no longer valid; otherwise null.</returns>
-        public override MissionCompletionReason? GetAbortReason(GameRoot game)
+        protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
-            MissionCompletionReason? reason = base.GetAbortReason(game);
+            MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);
             if (reason.HasValue)
                 return reason;
 
             return HasValidTarget(game) ? null : MissionCompletionReason.TargetUnavailable;
-        }
-
-        /// <summary>
-        /// Returns false if the target officer has already been killed or has moved
-        /// away from the mission's planet before execution.
-        /// </summary>
-        /// <param name="game">The current game state.</param>
-        /// <returns>True if the target is still alive and on the mission planet.</returns>
-        protected override bool IsMissionSatisfied(GameRoot game)
-        {
-            return HasValidTarget(game);
         }
 
         /// <summary>
@@ -170,41 +154,32 @@ namespace Rebellion.Game.Missions
         /// <returns>The hit effects followed by the terminal mission result.</returns>
         internal override List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
         {
+            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
+            if (invalidationReason.HasValue)
+                return BuildInvalidatedResults(game, provider, invalidationReason.Value);
+
             List<GameResult> results = new List<GameResult>();
             MissionOutcome outcome = MissionOutcome.Failed;
             MissionCompletionReason completionReason = MissionCompletionReason.Failure;
 
-            bool targetAvailable = IsMissionSatisfied(game);
             bool targetKilled = false;
             List<IMissionParticipant> successfulParticipants = ResolveSuccessfulParticipants(
                 provider,
                 game,
                 participant =>
                 {
-                    if (!targetAvailable)
-                        return;
                     if (targetKilled)
-                    {
-                        ImproveMissionParticipantRating(participant);
-                        return;
-                    }
+                        return true;
 
                     List<GameResult> attemptResults = OnSuccess(game, provider, participant);
                     results.AddRange(attemptResults);
                     if (attemptResults.Exists(result => result is OfficerKilledResult))
-                    {
                         targetKilled = true;
-                        ImproveMissionParticipantRating(participant);
-                    }
+                    return targetKilled;
                 }
             );
             if (successfulParticipants.Count == 0)
             {
-                results.AddRange(OnFailed(game, provider));
-            }
-            else if (!targetAvailable)
-            {
-                completionReason = MissionCompletionReason.TargetUnavailable;
                 results.AddRange(OnFailed(game, provider));
             }
             else if (targetKilled)

--- a/Assets/Scripts/Game/Missions/DiplomacyMission.cs
+++ b/Assets/Scripts/Game/Missions/DiplomacyMission.cs
@@ -88,9 +88,9 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>The abort reason, or null when the mission may advance.</returns>
-        public override MissionCompletionReason? GetAbortReason(GameRoot game)
+        protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
-            MissionCompletionReason? reason = base.GetAbortReason(game);
+            MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);
             if (reason.HasValue)
                 return reason;
 

--- a/Assets/Scripts/Game/Missions/EspionageMission.cs
+++ b/Assets/Scripts/Game/Missions/EspionageMission.cs
@@ -17,11 +17,6 @@ namespace Rebellion.Game.Missions
         public const string MissionTypeID = "Espionage";
 
         /// <summary>
-        /// Returns whether this mission should cancel when the target planet changes owner.
-        /// </summary>
-        public override bool CanceledOnOwnershipChange => false;
-
-        /// <summary>
         /// Returns whether detected participants receive the standard foiled-mission consequences.
         /// </summary>
         internal override bool AppliesFoiledParticipantConsequences => false;
@@ -82,16 +77,6 @@ namespace Rebellion.Game.Missions
                 ctx.MainParticipants,
                 ctx.DecoyParticipants
             );
-        }
-
-        /// <summary>
-        /// Returns true as long as the mission is still attached to a planet.
-        /// </summary>
-        /// <param name="game">The current game state.</param>
-        /// <returns>True if the mission parent is a planet.</returns>
-        protected override bool IsMissionSatisfied(GameRoot game)
-        {
-            return GetParent() is Planet;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Missions/InciteUprisingMission.cs
+++ b/Assets/Scripts/Game/Missions/InciteUprisingMission.cs
@@ -14,11 +14,6 @@ namespace Rebellion.Game.Missions
     {
         public const string MissionTypeID = "InciteUprising";
 
-        /// <summary>
-        /// Returns whether this mission should cancel when the target planet changes owner.
-        /// </summary>
-        public override bool CanceledOnOwnershipChange => false;
-
         /// <summary>Creates an empty incite-uprising mission copy.</summary>
         /// <returns>An empty incite-uprising mission.</returns>
         protected override BaseSceneNode CreateNodeCopy() => new InciteUprisingMission();

--- a/Assets/Scripts/Game/Missions/JediTrainingMission.cs
+++ b/Assets/Scripts/Game/Missions/JediTrainingMission.cs
@@ -217,7 +217,10 @@ namespace Rebellion.Game.Missions
         /// <param name="game">The current game state.</param>
         /// <param name="provider">The random number provider used for training rolls.</param>
         /// <returns>The training progress results followed by the mission completion result.</returns>
-        internal override List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
+        internal override List<GameResult> ResolveObjective(
+            GameRoot game,
+            IRandomNumberProvider provider
+        )
         {
             List<GameResult> results = new List<GameResult>();
             Officer trainer = Trainer;

--- a/Assets/Scripts/Game/Missions/JediTrainingMission.cs
+++ b/Assets/Scripts/Game/Missions/JediTrainingMission.cs
@@ -176,9 +176,9 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>The abort reason, or null when training may advance.</returns>
-        public override MissionCompletionReason? GetAbortReason(GameRoot game)
+        protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
-            MissionCompletionReason? reason = base.GetAbortReason(game);
+            MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);
             if (reason.HasValue)
                 return reason;
 

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -61,7 +61,6 @@ namespace Rebellion.Game.Missions
         }
 
         public string LocationInstanceID { get; set; }
-        public string OriginInstanceID { get; set; }
 
         /// <summary>
         /// Gets or sets the content event that authored this mission, when applicable.
@@ -127,8 +126,14 @@ namespace Rebellion.Game.Missions
             OwnerInstanceID = ownerInstanceId;
             LocationInstanceID = locationInstanceId;
 
-            _mainParticipants = mainParticipants ?? new List<IMissionParticipant>();
-            _decoyParticipants = decoyParticipants ?? new List<IMissionParticipant>();
+            _mainParticipants =
+                mainParticipants != null
+                    ? new List<IMissionParticipant>(mainParticipants)
+                    : new List<IMissionParticipant>();
+            _decoyParticipants =
+                decoyParticipants != null
+                    ? new List<IMissionParticipant>(decoyParticipants)
+                    : new List<IMissionParticipant>();
             ParticipantRating = participantRating;
         }
 
@@ -142,7 +147,6 @@ namespace Rebellion.Game.Missions
             Mission copy = (Mission)destination;
             copy.ConfigKey = ConfigKey;
             copy.LocationInstanceID = LocationInstanceID;
-            copy.OriginInstanceID = OriginInstanceID;
             copy.SourceEventInstanceID = SourceEventInstanceID;
             copy._mainParticipantInstanceIds = new HashSet<string>(
                 _mainParticipantInstanceIds,
@@ -216,11 +220,6 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns whether this mission is canceled when target ownership changes.
-        /// </summary>
-        public virtual bool CanceledOnOwnershipChange => true;
-
-        /// <summary>
         /// Returns whether detected mission participants suffer capture, death, or destruction.
         /// </summary>
         internal virtual bool AppliesFoiledParticipantConsequences => true;
@@ -235,10 +234,13 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>The abort reason, or null when the mission may advance.</returns>
-        public virtual MissionCompletionReason? GetAbortReason(GameRoot game) =>
-            _mainParticipants.Count == 0 || HaveMainParticipantsChanged()
-                ? MissionCompletionReason.Failure
-                : null;
+        public MissionCompletionReason? GetAbortReason(GameRoot game)
+        {
+            if (_mainParticipants.Count == 0 || HaveMainParticipantsChanged())
+                return MissionCompletionReason.Failure;
+
+            return GetMissionInvalidationReason(game);
+        }
 
         /// <summary>
         /// Returns whether the mission should repeat after completing one execution.
@@ -557,13 +559,16 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="provider">RNG provider for rolling against the success probability.</param>
         /// <param name="game">The current game state.</param>
-        /// <param name="onParticipantSucceeded">Optional action applied immediately after each successful attempt.</param>
+        /// <param name="resolveSuccessfulAttempt">
+        /// Optional mission-specific resolution applied immediately after each successful roll.
+        /// Return true when that attempt earned the mission's normal participant improvement.
+        /// </param>
         /// <param name="stopAfterFirstSuccess">Whether resolution stops after the first successful attempt.</param>
         /// <returns>The participants whose attempts succeeded, in attempt order.</returns>
         protected internal List<IMissionParticipant> ResolveSuccessfulParticipants(
             IRandomNumberProvider provider,
             GameRoot game,
-            Action<IMissionParticipant> onParticipantSucceeded = null,
+            Func<IMissionParticipant, bool> resolveSuccessfulAttempt = null,
             bool stopAfterFirstSuccess = false
         )
         {
@@ -582,7 +587,8 @@ namespace Rebellion.Game.Missions
                     continue;
 
                 successfulParticipants.Add(participant);
-                onParticipantSucceeded?.Invoke(participant);
+                if (resolveSuccessfulAttempt?.Invoke(participant) == true)
+                    ImproveMissionParticipantRating(participant);
                 if (stopAfterFirstSuccess)
                     return successfulParticipants;
             }
@@ -593,7 +599,8 @@ namespace Rebellion.Game.Missions
                     continue;
 
                 successfulParticipants.Add(specialForces);
-                onParticipantSucceeded?.Invoke(specialForces);
+                if (resolveSuccessfulAttempt?.Invoke(specialForces) == true)
+                    ImproveMissionParticipantRating(specialForces);
                 if (stopAfterFirstSuccess)
                     return successfulParticipants;
             }
@@ -927,6 +934,10 @@ namespace Rebellion.Game.Missions
         /// <returns>All results produced by the outcome, with a MissionCompletedResult appended last.</returns>
         internal virtual List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
         {
+            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
+            if (invalidationReason.HasValue)
+                return BuildInvalidatedResults(game, provider, invalidationReason.Value);
+
             List<GameResult> results = new List<GameResult>();
             MissionOutcome outcome;
             MissionCompletionReason completionReason;
@@ -937,20 +948,10 @@ namespace Rebellion.Game.Missions
             );
             if (successfulParticipants.Count > 0)
             {
-                if (!IsMissionSatisfied(game))
-                {
-                    outcome = MissionOutcome.Failed;
-                    completionReason = MissionCompletionReason.TargetUnavailable;
-                    results.AddRange(OnFailed(game, provider));
-                }
-                else
-                {
-                    outcome = MissionOutcome.Success;
-                    completionReason = MissionCompletionReason.Success;
-                    results.AddRange(OnSuccess(game, provider, successfulParticipants[0]));
-                    foreach (IMissionParticipant participant in successfulParticipants)
-                        ImproveMissionParticipantRating(participant);
-                }
+                outcome = MissionOutcome.Success;
+                completionReason = MissionCompletionReason.Success;
+                results.AddRange(OnSuccess(game, provider, successfulParticipants[0]));
+                ImproveMissionParticipants(successfulParticipants);
             }
             else
             {
@@ -960,6 +961,30 @@ namespace Rebellion.Game.Missions
             }
 
             results.Add(BuildCompletedResult(outcome, completionReason, game));
+            return results;
+        }
+
+        /// <summary>
+        /// Completes a mission invalidated before participant attempts began.
+        /// </summary>
+        /// <param name="game">The current game state.</param>
+        /// <param name="provider">RNG provider passed to the mission-specific failure handler.</param>
+        /// <param name="completionReason">The reason the mission can no longer advance.</param>
+        /// <returns>The failure effects followed by the requested completion result.</returns>
+        protected List<GameResult> BuildInvalidatedResults(
+            GameRoot game,
+            IRandomNumberProvider provider,
+            MissionCompletionReason completionReason
+        )
+        {
+            List<GameResult> results = OnFailed(game, provider);
+            MissionCompletedResult completed = BuildCompletedResult(
+                MissionOutcome.Failed,
+                completionReason,
+                game
+            );
+            completed.CanContinue = false;
+            results.Add(completed);
             return results;
         }
 
@@ -1064,11 +1089,28 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns whether the mission can still complete successfully.
+        /// Applies this mission's configured improvement to each eligible successful participant.
+        /// </summary>
+        /// <param name="participants">The successful participants to improve.</param>
+        private void ImproveMissionParticipants(IEnumerable<IMissionParticipant> participants)
+        {
+            foreach (IMissionParticipant participant in participants)
+                ImproveMissionParticipantRating(participant);
+        }
+
+        /// <summary>
+        /// Returns why the mission's current objective state prevents it from advancing.
+        /// The shared implementation requires every mission to remain attached to a live planet;
+        /// subclasses extend this with mission-specific rules.
         /// </summary>
         /// <param name="game">The current game state.</param>
-        /// <returns>True if the mission target conditions are still valid; false to force a Failed outcome.</returns>
-        protected virtual bool IsMissionSatisfied(GameRoot game) => true;
+        /// <returns>The invalidation reason, or null while the mission may advance.</returns>
+        protected virtual MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
+        {
+            return GetParent() is Planet { IsDestroyed: false }
+                ? null
+                : MissionCompletionReason.TargetUnavailable;
+        }
 
         /// <summary>
         /// Applies successful mission effects.

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -12,6 +12,39 @@ using Rebellion.Util.Serialization;
 namespace Rebellion.Game.Missions
 {
     /// <summary>
+    /// Provides the external operations needed while a mission executes its post-arrival lifecycle.
+    /// </summary>
+    internal interface IMissionExecutionRuntime
+    {
+        /// <summary>
+        /// Resolves this tick's detection attempt.
+        /// </summary>
+        /// <param name="mission">The mission executing its lifecycle.</param>
+        /// <param name="results">The result collection receiving detection consequences.</param>
+        /// <returns>True when detection foils the mission.</returns>
+        bool ResolveDetection(Mission mission, List<GameResult> results);
+
+        /// <summary>
+        /// Resolves betrayal or the completed mission objective.
+        /// </summary>
+        /// <param name="mission">The mission whose progress is complete.</param>
+        /// <returns>The results produced by objective resolution.</returns>
+        List<GameResult> ResolveCompletedObjective(Mission mission);
+
+        /// <summary>
+        /// Applies repeat or teardown infrastructure after mission completion.
+        /// </summary>
+        /// <param name="mission">The mission that reached a terminal state.</param>
+        /// <param name="completedResult">The terminal result, or null for an invalid mission.</param>
+        /// <param name="results">The result collection receiving teardown consequences.</param>
+        void FinishMission(
+            Mission mission,
+            MissionCompletedResult completedResult,
+            List<GameResult> results
+        );
+    }
+
+    /// <summary>
     /// Describes one hostile unit that can detect a mission or confront a detected participant.
     /// </summary>
     internal sealed class MissionDetector
@@ -250,8 +283,8 @@ namespace Rebellion.Game.Missions
         public abstract bool ShouldRepeatAfterCompletion(GameRoot game);
 
         /// <summary>
-        /// Produces mission-specific state changes when the mission ends before normal execution.
-        /// The mission system remains responsible for participant teardown and terminal results.
+        /// Produces mission-specific state changes when the mission ends before objective resolution.
+        /// The execution runtime remains responsible for participant teardown.
         /// </summary>
         internal virtual List<GameResult> ResolveInterruption(
             GameRoot game,
@@ -927,17 +960,75 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Executes the mission and returns all generated results.
+        /// Executes one post-arrival lifecycle step for this mission.
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <param name="provider">RNG provider for all probability rolls.</param>
-        /// <returns>All results produced by the outcome, with a MissionCompletedResult appended last.</returns>
-        internal virtual List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
+        /// <param name="runtime">External mission operations supplied by the mission system.</param>
+        /// <returns>All results produced by validation, detection, or objective resolution.</returns>
+        internal List<GameResult> Execute(
+            GameRoot game,
+            IRandomNumberProvider provider,
+            IMissionExecutionRuntime runtime
+        )
         {
-            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
-            if (invalidationReason.HasValue)
-                return BuildInvalidatedResults(game, provider, invalidationReason.Value);
+            List<GameResult> results = new List<GameResult>();
+            MissionCompletionReason? abortReason = GetAbortReason(game);
+            if (abortReason.HasValue)
+            {
+                AddMissionResults(ResolveInterruption(game, provider), results);
+                results.Add(
+                    BuildTerminatingResult(
+                        MissionOutcome.Failed,
+                        abortReason.Value,
+                        game,
+                        GetAllParticipants()
+                    )
+                );
+                runtime.FinishMission(this, null, results);
+                return results;
+            }
 
+            List<IMissionParticipant> participantsBeforeDetection = GetAllParticipants();
+            if (runtime.ResolveDetection(this, results))
+            {
+                AddMissionResults(ResolveInterruption(game, provider), results);
+                MissionCompletedResult completed = BuildTerminatingResult(
+                    MissionOutcome.Foiled,
+                    MissionCompletionReason.Foiled,
+                    game,
+                    participantsBeforeDetection
+                );
+                results.Add(completed);
+                runtime.FinishMission(this, completed, results);
+                return results;
+            }
+
+            IncrementProgress();
+            if (!IsComplete())
+                return results;
+
+            results.AddRange(runtime.ResolveCompletedObjective(this));
+            MissionCompletedResult completedResult = results
+                .OfType<MissionCompletedResult>()
+                .LastOrDefault();
+            if (completedResult != null)
+                runtime.FinishMission(this, completedResult, results);
+
+            return results;
+        }
+
+        /// <summary>
+        /// Resolves the completed mission objective and returns its terminal results.
+        /// </summary>
+        /// <param name="game">The current game state.</param>
+        /// <param name="provider">RNG provider for all probability rolls.</param>
+        /// <returns>All objective results, with a MissionCompletedResult appended last.</returns>
+        internal virtual List<GameResult> ResolveObjective(
+            GameRoot game,
+            IRandomNumberProvider provider
+        )
+        {
             List<GameResult> results = new List<GameResult>();
             MissionOutcome outcome;
             MissionCompletionReason completionReason;
@@ -965,27 +1056,25 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Completes a mission invalidated before participant attempts began.
+        /// Adds mission-origin metadata to interruption results before appending them.
         /// </summary>
-        /// <param name="game">The current game state.</param>
-        /// <param name="provider">RNG provider passed to the mission-specific failure handler.</param>
-        /// <param name="completionReason">The reason the mission can no longer advance.</param>
-        /// <returns>The failure effects followed by the requested completion result.</returns>
-        protected List<GameResult> BuildInvalidatedResults(
-            GameRoot game,
-            IRandomNumberProvider provider,
-            MissionCompletionReason completionReason
+        /// <param name="source">The results produced by the interruption.</param>
+        /// <param name="destination">The lifecycle result collection.</param>
+        private void AddMissionResults(
+            IEnumerable<GameResult> source,
+            ICollection<GameResult> destination
         )
         {
-            List<GameResult> results = OnFailed(game, provider);
-            MissionCompletedResult completed = BuildCompletedResult(
-                MissionOutcome.Failed,
-                completionReason,
-                game
-            );
-            completed.CanContinue = false;
-            results.Add(completed);
-            return results;
+            if (source == null)
+                return;
+
+            foreach (GameResult result in source.Where(result => result != null))
+            {
+                result.MissionInstanceID = InstanceID;
+                if (string.IsNullOrEmpty(result.SourceEventInstanceID))
+                    result.SourceEventInstanceID = SourceEventInstanceID;
+                destination.Add(result);
+            }
         }
 
         /// <summary>
@@ -1060,6 +1149,31 @@ namespace Rebellion.Game.Missions
         {
             MissionCompletedResult result = BuildCompletedResult(outcome, game, participants);
             result.CompletionReason = completionReason;
+            return result;
+        }
+
+        /// <summary>
+        /// Builds a terminal mission result that cannot repeat.
+        /// </summary>
+        /// <param name="outcome">The terminal mission outcome.</param>
+        /// <param name="completionReason">The reason the mission terminated.</param>
+        /// <param name="game">The current game state.</param>
+        /// <param name="participants">The participants captured before terminal side effects.</param>
+        /// <returns>A non-continuing mission completion result.</returns>
+        private MissionCompletedResult BuildTerminatingResult(
+            MissionOutcome outcome,
+            MissionCompletionReason completionReason,
+            GameRoot game,
+            List<IMissionParticipant> participants
+        )
+        {
+            MissionCompletedResult result = BuildCompletedResult(
+                outcome,
+                completionReason,
+                game,
+                participants
+            );
+            result.CanContinue = false;
             return result;
         }
 

--- a/Assets/Scripts/Game/Missions/MissionContext.cs
+++ b/Assets/Scripts/Game/Missions/MissionContext.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Rebellion.Game.Research;
-using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 
 namespace Rebellion.Game.Missions
@@ -44,11 +43,6 @@ namespace Rebellion.Game.Missions
         /// Decoy participants assigned to distract defenders.
         /// </summary>
         public List<IMissionParticipant> DecoyParticipants { get; set; }
-
-        /// <summary>
-        /// The specific officer to target for Abduction, Assassination, and Rescue missions.
-        /// </summary>
-        public Officer TargetOfficer { get; set; }
 
         /// <summary>
         /// The research discipline for Research missions.

--- a/Assets/Scripts/Game/Missions/MissionFactory.cs
+++ b/Assets/Scripts/Game/Missions/MissionFactory.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Research;
-using Rebellion.Game.Units;
 
 namespace Rebellion.Game.Missions
 {
@@ -145,7 +144,6 @@ namespace Rebellion.Game.Missions
                 SelectedTarget = context.SelectedTarget,
                 MainParticipants = context.MainParticipants ?? new List<IMissionParticipant>(),
                 DecoyParticipants = context.DecoyParticipants ?? new List<IMissionParticipant>(),
-                TargetOfficer = context.TargetOfficer ?? context.SelectedTarget as Officer,
                 Discipline = context.Discipline,
             };
 
@@ -220,7 +218,6 @@ namespace Rebellion.Game.Missions
                 SelectedTarget = context.SelectedTarget,
                 MainParticipants = context.MainParticipants,
                 DecoyParticipants = context.DecoyParticipants,
-                TargetOfficer = context.TargetOfficer,
                 Discipline = option.Discipline,
             };
         }

--- a/Assets/Scripts/Game/Missions/MissionStartRequest.cs
+++ b/Assets/Scripts/Game/Missions/MissionStartRequest.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Rebellion.Game.Research;
-using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 
 namespace Rebellion.Game.Missions
@@ -17,7 +16,6 @@ namespace Rebellion.Game.Missions
             new List<IMissionParticipant>();
         public List<IMissionParticipant> DecoyParticipants { get; set; } =
             new List<IMissionParticipant>();
-        public Officer TargetOfficer { get; set; }
         public ResearchDiscipline? Discipline { get; set; }
     }
 }

--- a/Assets/Scripts/Game/Missions/ReconnaissanceMission.cs
+++ b/Assets/Scripts/Game/Missions/ReconnaissanceMission.cs
@@ -101,18 +101,12 @@ namespace Rebellion.Game.Missions
         /// <param name="game">Current game state.</param>
         /// <param name="provider">RNG provider.</param>
         /// <returns>All results produced by the mission.</returns>
-        internal override List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
+        internal override List<GameResult> ResolveObjective(
+            GameRoot game,
+            IRandomNumberProvider provider
+        )
         {
             List<GameResult> results = new List<GameResult>();
-
-            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
-            if (invalidationReason.HasValue)
-            {
-                results.Add(
-                    BuildCompletedResult(MissionOutcome.Failed, invalidationReason.Value, game)
-                );
-                return results;
-            }
 
             results.AddRange(OnSuccess(game, provider, GetMainParticipants().FirstOrDefault()));
             results.Add(

--- a/Assets/Scripts/Game/Missions/ReconnaissanceMission.cs
+++ b/Assets/Scripts/Game/Missions/ReconnaissanceMission.cs
@@ -16,11 +16,6 @@ namespace Rebellion.Game.Missions
     {
         public const string MissionTypeID = "Reconnaissance";
 
-        /// <summary>
-        /// Returns whether this mission should cancel when the target planet changes owner.
-        /// </summary>
-        public override bool CanceledOnOwnershipChange => false;
-
         /// <summary>Creates an empty reconnaissance mission copy.</summary>
         /// <returns>An empty reconnaissance mission.</returns>
         protected override BaseSceneNode CreateNodeCopy() => new ReconnaissanceMission();
@@ -101,16 +96,6 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns true while the mission remains attached to a planet target.
-        /// </summary>
-        /// <param name="game">The current game state.</param>
-        /// <returns>True if the mission is still attached to a planet.</returns>
-        protected override bool IsMissionSatisfied(GameRoot game)
-        {
-            return GetParent() is Planet;
-        }
-
-        /// <summary>
         /// Resolves reconnaissance without a success roll.
         /// </summary>
         /// <param name="game">Current game state.</param>
@@ -120,14 +105,11 @@ namespace Rebellion.Game.Missions
         {
             List<GameResult> results = new List<GameResult>();
 
-            if (!IsMissionSatisfied(game))
+            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
+            if (invalidationReason.HasValue)
             {
                 results.Add(
-                    BuildCompletedResult(
-                        MissionOutcome.Failed,
-                        MissionCompletionReason.TargetUnavailable,
-                        game
-                    )
+                    BuildCompletedResult(MissionOutcome.Failed, invalidationReason.Value, game)
                 );
                 return results;
             }
@@ -138,12 +120,6 @@ namespace Rebellion.Game.Missions
             );
             return results;
         }
-
-        /// <summary>
-        /// Reconnaissance does not award mission rating improvements.
-        /// </summary>
-        /// <param name="participant">The participant whose reconnaissance attempt completed.</param>
-        internal override void ImproveMissionParticipantRating(IMissionParticipant participant) { }
 
         /// <summary>
         /// Marks the target as visited for the mission owner and records the observed planet state.

--- a/Assets/Scripts/Game/Missions/RecruitmentMission.cs
+++ b/Assets/Scripts/Game/Missions/RecruitmentMission.cs
@@ -151,12 +151,11 @@ namespace Rebellion.Game.Missions
         /// <param name="game">The current game state.</param>
         /// <param name="provider">RNG provider for success and candidate-selection rolls.</param>
         /// <returns>The recruitment result followed by the terminal mission result.</returns>
-        internal override List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
+        internal override List<GameResult> ResolveObjective(
+            GameRoot game,
+            IRandomNumberProvider provider
+        )
         {
-            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
-            if (invalidationReason.HasValue)
-                return BuildInvalidatedResults(game, provider, invalidationReason.Value);
-
             RecruitedOfficerInstanceID = null;
             List<IMissionParticipant> successfulParticipants = ResolveSuccessfulParticipants(
                 provider,

--- a/Assets/Scripts/Game/Missions/RecruitmentMission.cs
+++ b/Assets/Scripts/Game/Missions/RecruitmentMission.cs
@@ -18,9 +18,10 @@ namespace Rebellion.Game.Missions
         public const string MissionTypeID = "Recruitment";
 
         /// <summary>
-        /// Instance ID of the officer selected as the recruitment target.
+        /// Instance ID of the officer produced by the most recent successful recruitment attempt.
+        /// The mission target itself is always the planet identified by LocationInstanceID.
         /// </summary>
-        public string TargetOfficerInstanceID { get; set; }
+        public string RecruitedOfficerInstanceID { get; set; }
 
         /// <summary>Creates an empty recruitment mission copy.</summary>
         /// <returns>An empty recruitment mission.</returns>
@@ -31,7 +32,8 @@ namespace Rebellion.Game.Missions
         protected override void CopyStateTo(BaseSceneNode destination)
         {
             base.CopyStateTo(destination);
-            ((RecruitmentMission)destination).TargetOfficerInstanceID = TargetOfficerInstanceID;
+            ((RecruitmentMission)destination).RecruitedOfficerInstanceID =
+                RecruitedOfficerInstanceID;
         }
 
         /// <summary>
@@ -46,19 +48,17 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Initializes a recruitment mission with its current selected recruit.
+        /// Initializes a recruitment mission at its target planet.
         /// </summary>
         /// <param name="ownerInstanceId">Faction that owns the mission.</param>
         /// <param name="target">Planet where the mission occurs.</param>
         /// <param name="mainParticipants">Primary mission participants.</param>
         /// <param name="decoyParticipants">Decoy mission participants.</param>
-        /// <param name="targetOfficerInstanceId">Officer selected as the recruit, or null before selection.</param>
         private RecruitmentMission(
             string ownerInstanceId,
             ISceneNode target,
             List<IMissionParticipant> mainParticipants,
-            List<IMissionParticipant> decoyParticipants,
-            string targetOfficerInstanceId
+            List<IMissionParticipant> decoyParticipants
         )
             : base(
                 MissionTypeID,
@@ -67,15 +67,12 @@ namespace Rebellion.Game.Missions
                 mainParticipants,
                 decoyParticipants,
                 OfficerRating.Leadership
-            )
-        {
-            TargetOfficerInstanceID = targetOfficerInstanceId;
-        }
+            ) { }
 
         /// <summary>
         /// Returns a new RecruitmentMission when this faction has at least one recruitable officer on an owned planet.
         /// </summary>
-        /// <param name="ctx">Mission context; must include a valid target.</param>
+        /// <param name="ctx">Mission context containing the target planet and participants.</param>
         /// <returns>A configured mission, or null if no unrecruited officers exist.</returns>
         public static RecruitmentMission TryCreate(MissionContext ctx)
         {
@@ -96,8 +93,7 @@ namespace Rebellion.Game.Missions
                 ctx.OwnerInstanceId,
                 ctx.Location,
                 ctx.MainParticipants,
-                ctx.DecoyParticipants,
-                null
+                ctx.DecoyParticipants
             );
         }
 
@@ -119,9 +115,18 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>True if at least one unrecruited officer is available.</returns>
-        protected override bool IsMissionSatisfied(GameRoot game)
+        protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
-            return game.GetUnrecruitedOfficers(OwnerInstanceID).Count > 0;
+            MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);
+            if (reason.HasValue)
+                return reason;
+
+            return
+                GetParent() is Planet planet
+                && planet.GetOwnerInstanceID() == OwnerInstanceID
+                && game.GetUnrecruitedOfficers(OwnerInstanceID).Count > 0
+                ? null
+                : MissionCompletionReason.TargetUnavailable;
         }
 
         /// <summary>
@@ -148,19 +153,23 @@ namespace Rebellion.Game.Missions
         /// <returns>The recruitment result followed by the terminal mission result.</returns>
         internal override List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
         {
-            TargetOfficerInstanceID = null;
+            MissionCompletionReason? invalidationReason = GetMissionInvalidationReason(game);
+            if (invalidationReason.HasValue)
+                return BuildInvalidatedResults(game, provider, invalidationReason.Value);
+
+            RecruitedOfficerInstanceID = null;
             List<IMissionParticipant> successfulParticipants = ResolveSuccessfulParticipants(
                 provider,
                 game,
-                participant =>
+                _ =>
                 {
                     List<Officer> targets = game.GetUnrecruitedOfficers(OwnerInstanceID);
                     if (targets.Count == 0)
-                        return;
+                        return false;
 
-                    Officer target = targets.RandomElement(provider);
-                    TargetOfficerInstanceID = target.InstanceID;
-                    ImproveMissionParticipantRating(participant);
+                    Officer recruitedOfficer = targets.RandomElement(provider);
+                    RecruitedOfficerInstanceID = recruitedOfficer.InstanceID;
+                    return true;
                 },
                 stopAfterFirstSuccess: true
             );
@@ -168,7 +177,7 @@ namespace Rebellion.Game.Missions
             List<GameResult> results;
             MissionOutcome outcome;
             MissionCompletionReason completionReason;
-            if (!string.IsNullOrEmpty(TargetOfficerInstanceID))
+            if (!string.IsNullOrEmpty(RecruitedOfficerInstanceID))
             {
                 outcome = MissionOutcome.Success;
                 completionReason = MissionCompletionReason.Success;
@@ -189,7 +198,7 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Transfers the selected target officer to this faction and moves them to the mission planet.
+        /// Transfers the recruited officer to this faction and moves them to the target planet.
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <param name="provider">RNG provider used during mission execution.</param>
@@ -206,7 +215,7 @@ namespace Rebellion.Game.Missions
                 return new List<GameResult>();
 
             Officer target = game.GetUnrecruitedOfficers(OwnerInstanceID)
-                .FirstOrDefault(officer => officer.InstanceID == TargetOfficerInstanceID);
+                .FirstOrDefault(officer => officer.InstanceID == RecruitedOfficerInstanceID);
             if (target == null)
                 return new List<GameResult>();
 

--- a/Assets/Scripts/Game/Missions/RecruitmentMission.cs
+++ b/Assets/Scripts/Game/Missions/RecruitmentMission.cs
@@ -111,10 +111,13 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns false when this faction no longer has an unrecruited officer available.
+        /// Returns why recruitment can no longer continue at the mission planet.
         /// </summary>
         /// <param name="game">The current game state.</param>
-        /// <returns>True if at least one unrecruited officer is available.</returns>
+        /// <returns>
+        /// The target-unavailable reason when the planet is no longer friendly or no candidate
+        /// remains; otherwise null.
+        /// </returns>
         protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
             MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);

--- a/Assets/Scripts/Game/Missions/RescueMission.cs
+++ b/Assets/Scripts/Game/Missions/RescueMission.cs
@@ -32,11 +32,6 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns whether this mission should cancel when the target planet changes owner.
-        /// </summary>
-        public override bool CanceledOnOwnershipChange => false;
-
-        /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>
         public RescueMission()
@@ -85,7 +80,7 @@ namespace Rebellion.Game.Missions
             if (!(ctx.Location is Planet planet))
                 return null;
 
-            Officer target = ctx.TargetOfficer;
+            Officer target = ctx.SelectedTarget as Officer;
             Planet targetPlanet = target?.GetParentOfType<Planet>();
             if (
                 target == null
@@ -110,24 +105,13 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>TargetUnavailable when the target is no longer valid; otherwise null.</returns>
-        public override MissionCompletionReason? GetAbortReason(GameRoot game)
+        protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
-            MissionCompletionReason? reason = base.GetAbortReason(game);
+            MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);
             if (reason.HasValue)
                 return reason;
 
             return HasValidTarget(game) ? null : MissionCompletionReason.TargetUnavailable;
-        }
-
-        /// <summary>
-        /// Returns false if the target officer is no longer captured or has moved
-        /// away from the mission's planet before execution.
-        /// </summary>
-        /// <param name="game">The current game state.</param>
-        /// <returns>True if the target is still captured and on the mission planet.</returns>
-        protected override bool IsMissionSatisfied(GameRoot game)
-        {
-            return HasValidTarget(game);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Missions/ResearchMission.cs
+++ b/Assets/Scripts/Game/Missions/ResearchMission.cs
@@ -134,13 +134,15 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>The failure reason, or null when research can advance.</returns>
-        public override MissionCompletionReason? GetAbortReason(GameRoot game)
+        protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
-            MissionCompletionReason? reason = base.GetAbortReason(game);
+            MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);
             if (reason.HasValue)
                 return reason;
 
-            return IsMissionSatisfied(game) ? null : MissionCompletionReason.TargetUnavailable;
+            return GetParent() is Planet p && p.GetOwnerInstanceID() == OwnerInstanceID
+                ? null
+                : MissionCompletionReason.TargetUnavailable;
         }
 
         /// <summary>
@@ -170,16 +172,6 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Checks whether the mission target planet is still owned by the mission's faction.
-        /// </summary>
-        /// <param name="game">The current game state.</param>
-        /// <returns>True if the parent planet is owned by this faction.</returns>
-        protected override bool IsMissionSatisfied(GameRoot game)
-        {
-            return GetParent() is Planet p && p.GetOwnerInstanceID() == OwnerInstanceID;
-        }
-
-        /// <summary>
         /// Research missions target own planets and are never foiled.
         /// </summary>
         /// <param name="detectorRating">The detector rating (unused).</param>
@@ -204,10 +196,11 @@ namespace Rebellion.Game.Missions
         {
             List<GameResult> results = new List<GameResult>();
             MissionOutcome outcome = MissionOutcome.Failed;
+            MissionCompletionReason? abortReason = GetAbortReason(game);
             MissionCompletionReason completionReason =
-                GetAbortReason(game) ?? MissionCompletionReason.TargetUnavailable;
+                abortReason ?? MissionCompletionReason.TargetUnavailable;
             Faction faction = game.GetFactionByOwnerInstanceID(OwnerInstanceID);
-            if (faction != null && IsMissionSatisfied(game))
+            if (faction != null && !abortReason.HasValue)
             {
                 int earnedPoints = AccumulatePointsFromParticipants(game.Config.Research, provider);
                 if (earnedPoints > 0)
@@ -247,9 +240,19 @@ namespace Rebellion.Game.Missions
                     continue;
 
                 earnedPoints += RollReward(config, provider);
-                officer.IncrementBaseRating(Discipline);
+                ImproveMissionParticipantRating(participant);
             }
             return earnedPoints;
+        }
+
+        /// <summary>
+        /// Improves the successful officer's rating for this mission's research discipline.
+        /// </summary>
+        /// <param name="participant">The research participant whose attempt succeeded.</param>
+        internal override void ImproveMissionParticipantRating(IMissionParticipant participant)
+        {
+            if (participant is Officer officer && participant.CanImproveMissionRating)
+                officer.IncrementBaseRating(Discipline);
         }
 
         /// <summary>
@@ -353,7 +356,7 @@ namespace Rebellion.Game.Missions
         /// <returns>True if the mission should repeat.</returns>
         public override bool ShouldRepeatAfterCompletion(GameRoot game)
         {
-            if (!IsMissionSatisfied(game))
+            if (GetMissionInvalidationReason(game).HasValue)
                 return false;
 
             Faction faction = game?.GetFactionByOwnerInstanceID(OwnerInstanceID);

--- a/Assets/Scripts/Game/Missions/ResearchMission.cs
+++ b/Assets/Scripts/Game/Missions/ResearchMission.cs
@@ -192,15 +192,16 @@ namespace Rebellion.Game.Missions
         /// <param name="game">The current game state.</param>
         /// <param name="provider">RNG provider for chance rolls and reward rolls.</param>
         /// <returns>Transition results, with a MissionCompletedResult appended.</returns>
-        internal override List<GameResult> Execute(GameRoot game, IRandomNumberProvider provider)
+        internal override List<GameResult> ResolveObjective(
+            GameRoot game,
+            IRandomNumberProvider provider
+        )
         {
             List<GameResult> results = new List<GameResult>();
             MissionOutcome outcome = MissionOutcome.Failed;
-            MissionCompletionReason? abortReason = GetAbortReason(game);
-            MissionCompletionReason completionReason =
-                abortReason ?? MissionCompletionReason.TargetUnavailable;
+            MissionCompletionReason completionReason = MissionCompletionReason.TargetUnavailable;
             Faction faction = game.GetFactionByOwnerInstanceID(OwnerInstanceID);
-            if (faction != null && !abortReason.HasValue)
+            if (faction != null)
             {
                 int earnedPoints = AccumulatePointsFromParticipants(game.Config.Research, provider);
                 if (earnedPoints > 0)

--- a/Assets/Scripts/Game/Missions/SabotageMission.cs
+++ b/Assets/Scripts/Game/Missions/SabotageMission.cs
@@ -33,11 +33,6 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns whether this mission should cancel when the target planet changes owner.
-        /// </summary>
-        public override bool CanceledOnOwnershipChange => false;
-
-        /// <summary>
         /// Default constructor used for deserialization.
         /// </summary>
         public SabotageMission()
@@ -117,23 +112,13 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>TargetUnavailable when the target is no longer valid; otherwise null.</returns>
-        public override MissionCompletionReason? GetAbortReason(GameRoot game)
+        protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
-            MissionCompletionReason? reason = base.GetAbortReason(game);
+            MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);
             if (reason.HasValue)
                 return reason;
 
             return HasValidTarget(game) ? null : MissionCompletionReason.TargetUnavailable;
-        }
-
-        /// <summary>
-        /// Returns false if the selected target can no longer be sabotaged before execution.
-        /// </summary>
-        /// <param name="game">The current game state.</param>
-        /// <returns>True if the selected target is still eligible.</returns>
-        protected override bool IsMissionSatisfied(GameRoot game)
-        {
-            return HasValidTarget(game);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
+++ b/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
@@ -78,25 +78,15 @@ namespace Rebellion.Game.Missions
         /// </summary>
         /// <param name="game">The current game state.</param>
         /// <returns>The abort reason, or null when the mission may advance.</returns>
-        public override MissionCompletionReason? GetAbortReason(GameRoot game)
+        protected override MissionCompletionReason? GetMissionInvalidationReason(GameRoot game)
         {
-            MissionCompletionReason? reason = base.GetAbortReason(game);
+            MissionCompletionReason? reason = base.GetMissionInvalidationReason(game);
             if (reason.HasValue)
                 return reason;
 
             return GetParent() is Planet p && p.IsInUprising
                 ? null
                 : MissionCompletionReason.Failure;
-        }
-
-        /// <summary>
-        /// Returns false if the uprising has ended on the target planet before execution.
-        /// </summary>
-        /// <param name="game">The current game state.</param>
-        /// <returns>True if the planet is still in uprising.</returns>
-        protected override bool IsMissionSatisfied(GameRoot game)
-        {
-            return GetParent() is Planet p && p.IsInUprising;
         }
 
         /// <summary>
@@ -140,7 +130,7 @@ namespace Rebellion.Game.Missions
         /// <returns>True while the owned target planet remains in uprising.</returns>
         public override bool ShouldRepeatAfterCompletion(GameRoot game)
         {
-            return IsMissionSatisfied(game)
+            return !GetMissionInvalidationReason(game).HasValue
                 && GetParent() is Planet planet
                 && planet.GetOwnerInstanceID() == OwnerInstanceID;
         }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -404,7 +404,6 @@ public sealed class GameManager
         _resultProcessor.Subscribe<HeadquartersLostResult>(_victorySystem);
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_planetaryControlSystem);
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_uprisingSystem);
-        _resultProcessor.Subscribe<PlanetUprisingStartedResult>(_missionSystem);
         _resultProcessor.Subscribe<MissionCompletedResult>(_jediSystem);
         _resultProcessor.Subscribe<IntelligenceRevealedResult>(_fogOfWarSystem);
         _resultProcessor.Observe<GameObjectSabotagedResult>(_fogOfWarSystem.ProcessResults);

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -13,11 +13,10 @@ using Rebellion.Util.Common;
 namespace Rebellion.Systems
 {
     /// <summary>
-    /// Manages the lifecycle of missions each tick.
-    /// Mission creation and scene graph attachment are delegated to MissionFactory.
-    /// Participant movement and mission initiation are orchestrated here.
+    /// Orchestrates mission creation, participant travel, and external execution services.
+    /// Each mission owns its post-arrival lifecycle.
     /// </summary>
-    public class MissionSystem
+    public class MissionSystem : IMissionExecutionRuntime
     {
         private readonly GameRoot _game;
         private readonly IRandomNumberProvider _provider;
@@ -242,6 +241,30 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
+        /// Adds the originating mission to interruption results before returning them to the pipeline.
+        /// </summary>
+        /// <param name="mission">The mission producing the results.</param>
+        /// <param name="source">The results to stamp.</param>
+        /// <param name="destination">The collection receiving stamped results.</param>
+        private static void AddMissionResults(
+            Mission mission,
+            IEnumerable<GameResult> source,
+            ICollection<GameResult> destination
+        )
+        {
+            if (source == null)
+                return;
+
+            foreach (GameResult result in source.Where(result => result != null))
+            {
+                result.MissionInstanceID = mission.InstanceID;
+                if (string.IsNullOrEmpty(result.SourceEventInstanceID))
+                    result.SourceEventInstanceID = mission.SourceEventInstanceID;
+                destination.Add(result);
+            }
+        }
+
+        /// <summary>
         /// Resolves mission participants while preserving the caller's observed target state.
         /// </summary>
         /// <param name="request">The mission start request to resolve.</param>
@@ -348,7 +371,10 @@ namespace Rebellion.Systems
             if (mission == null || mission.GetParent() == null)
                 return new List<GameResult>();
 
-            List<GameResult> results = AdvanceMission(mission);
+            if (mission.IsWaitingForParticipants())
+                return new List<GameResult>();
+
+            List<GameResult> results = mission.Execute(_game, _provider, this);
             foreach (GameResult result in results)
                 result.MissionInstanceID = mission.InstanceID;
 
@@ -356,76 +382,24 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Advances a single mission through one lifecycle step.
+        /// Resolves this tick's mission detection through the mission system's external services.
         /// </summary>
-        /// <param name="mission">The mission to advance.</param>
-        /// <returns>Results produced by detection or execution this tick; empty otherwise.</returns>
-        private List<GameResult> AdvanceMission(Mission mission)
+        /// <param name="mission">The mission executing its lifecycle.</param>
+        /// <param name="results">The result collection receiving detection consequences.</param>
+        /// <returns>True when detection foils the mission.</returns>
+        bool IMissionExecutionRuntime.ResolveDetection(Mission mission, List<GameResult> results)
         {
-            List<GameResult> results = new List<GameResult>();
-
-            if (mission.IsWaitingForParticipants())
-                return results;
-
-            MissionCompletionReason? abortReason = mission.GetAbortReason(_game);
-            if (abortReason.HasValue)
-            {
-                AddMissionResults(mission, mission.ResolveInterruption(_game, _provider), results);
-                results.Add(
-                    BuildTerminatingMissionResult(
-                        mission,
-                        MissionOutcome.Failed,
-                        abortReason.Value,
-                        mission.GetAllParticipants()
-                    )
-                );
-                TearDownMission(mission, null, results);
-                return results;
-            }
-
-            results.AddRange(ResolveDetectionInterruption(mission));
-            if (FinishMissionIfCompleted(mission, results))
-                return results;
-
-            mission.IncrementProgress();
-            if (!mission.IsComplete())
-                return results;
-
-            results.AddRange(ExecuteMission(mission));
-            FinishMissionIfCompleted(mission, results);
-            return results;
+            bool missionFoiled = ResolveDetection(mission, results);
+            ApplyOfficerDeaths(results);
+            return missionFoiled;
         }
 
         /// <summary>
-        /// Adds the originating mission to interruption results before returning them to the pipeline.
+        /// Resolves betrayal or the objective for a mission that completed its progress.
         /// </summary>
-        /// <param name="mission">The mission producing the results.</param>
-        /// <param name="source">The results to stamp.</param>
-        /// <param name="destination">The collection receiving stamped results.</param>
-        private static void AddMissionResults(
-            Mission mission,
-            IEnumerable<GameResult> source,
-            List<GameResult> destination
-        )
-        {
-            if (source == null)
-                return;
-
-            foreach (GameResult result in source.Where(result => result != null))
-            {
-                result.MissionInstanceID = mission.InstanceID;
-                if (string.IsNullOrEmpty(result.SourceEventInstanceID))
-                    result.SourceEventInstanceID = mission.SourceEventInstanceID;
-                destination.Add(result);
-            }
-        }
-
-        /// <summary>
-        /// Executes a completed mission through its appropriate resolution system.
-        /// </summary>
-        /// <param name="mission">The mission ready to execute.</param>
+        /// <param name="mission">The mission resolving its completed objective.</param>
         /// <returns>The results produced by mission resolution.</returns>
-        private List<GameResult> ExecuteMission(Mission mission)
+        List<GameResult> IMissionExecutionRuntime.ResolveCompletedObjective(Mission mission)
         {
             List<GameResult> results;
             if (
@@ -440,7 +414,7 @@ namespace Rebellion.Systems
             }
             else if (!_uprisingSystem.TryExecuteMission(mission, out results))
             {
-                results = mission.Execute(_game, _provider);
+                results = mission.ResolveObjective(_game, _provider);
             }
 
             ApplyOfficerDeaths(results);
@@ -464,81 +438,23 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Resolves mission detection before a mission advances progress.
-        /// </summary>
-        /// <param name="mission">The mission to inspect.</param>
-        /// <returns>Detection results, including a mission completion result when detection ends the mission.</returns>
-        private List<GameResult> ResolveDetectionInterruption(Mission mission)
-        {
-            List<GameResult> results = new List<GameResult>();
-            List<IMissionParticipant> participantsBeforeDetection = mission.GetAllParticipants();
-            bool missionFoiled = ResolveDetection(mission, results);
-            ApplyOfficerDeaths(results);
-
-            if (!missionFoiled)
-                return results;
-
-            AddMissionResults(mission, mission.ResolveInterruption(_game, _provider), results);
-            results.Add(
-                BuildTerminatingMissionResult(
-                    mission,
-                    MissionOutcome.Foiled,
-                    MissionCompletionReason.Foiled,
-                    participantsBeforeDetection
-                )
-            );
-            return results;
-        }
-
-        /// <summary>
-        /// Returns the mission completion result for a terminal mission state.
-        /// </summary>
-        /// <param name="mission">The mission being terminated.</param>
-        /// <param name="outcome">The mission outcome to report.</param>
-        /// <param name="completionReason">The mission completion reason to report.</param>
-        /// <param name="participants">Participants captured before teardown side effects.</param>
-        /// <returns>A non-continuing mission completion result.</returns>
-        private MissionCompletedResult BuildTerminatingMissionResult(
-            Mission mission,
-            MissionOutcome outcome,
-            MissionCompletionReason completionReason,
-            List<IMissionParticipant> participants
-        )
-        {
-            MissionCompletedResult result = mission.BuildCompletedResult(
-                outcome,
-                completionReason,
-                _game,
-                participants
-            );
-            result.CanContinue = false;
-            return result;
-        }
-
-        /// <summary>
-        /// Repeats or tears down a mission when the results include a completion result.
+        /// Repeats or tears down a mission after its lifecycle reaches a terminal state.
         /// </summary>
         /// <param name="mission">The mission to finish.</param>
+        /// <param name="completedResult">The terminal result, or null for an invalid mission.</param>
         /// <param name="results">Results produced by this mission tick.</param>
-        /// <returns>True if the mission completed this tick.</returns>
-        private bool FinishMissionIfCompleted(Mission mission, List<GameResult> results)
+        void IMissionExecutionRuntime.FinishMission(
+            Mission mission,
+            MissionCompletedResult completedResult,
+            List<GameResult> results
+        )
         {
-            MissionCompletedResult completedResult = results
-                .OfType<MissionCompletedResult>()
-                .LastOrDefault();
             if (completedResult == null)
-                return false;
-
-            if (completedResult.CanContinue)
-            {
+                TearDownMission(mission, null, results);
+            else if (completedResult.CanContinue)
                 BeginMission(mission);
-            }
             else
-            {
                 TearDownMission(mission, completedResult, results);
-            }
-
-            return true;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -17,7 +17,7 @@ namespace Rebellion.Systems
     /// Mission creation and scene graph attachment are delegated to MissionFactory.
     /// Participant movement and mission initiation are orchestrated here.
     /// </summary>
-    public class MissionSystem : IGameResultHandler<PlanetUprisingStartedResult>
+    public class MissionSystem
     {
         private readonly GameRoot _game;
         private readonly IRandomNumberProvider _provider;
@@ -79,27 +79,6 @@ namespace Rebellion.Systems
 
             AddRecruitmentExhaustedResults(results, recruitmentAvailabilityBefore);
             return results;
-        }
-
-        /// <summary>
-        /// Aborts missions invalidated by uprisings reported in a result batch.
-        /// </summary>
-        /// <param name="results">The result batch to inspect.</param>
-        /// <returns>The terminal results produced by aborted missions.</returns>
-        public List<GameResult> HandleResults(IReadOnlyList<PlanetUprisingStartedResult> results)
-        {
-            List<GameResult> missionResults = new List<GameResult>();
-            if (results == null)
-                return missionResults;
-
-            IEnumerable<Planet> affectedPlanets = results
-                .Select(result => result.Planet)
-                .Where(planet => planet != null)
-                .Distinct();
-            foreach (Planet planet in affectedPlanets)
-                missionResults.AddRange(AbortInvalidMissions(planet));
-
-            return missionResults;
         }
 
         /// <summary>
@@ -263,47 +242,6 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Aborts active missions whose target conditions became invalid on a planet.
-        /// </summary>
-        /// <param name="planet">The planet whose missions must be re-evaluated.</param>
-        /// <returns>The terminal mission results produced by the aborted missions.</returns>
-        internal List<GameResult> AbortInvalidMissions(Planet planet)
-        {
-            List<GameResult> results = new List<GameResult>();
-            if (planet == null)
-                return results;
-
-            List<Mission> missions = _game
-                .GetSceneNodesByType<Mission>()
-                .Where(mission => mission.GetParentOfType<Planet>() == planet)
-                .ToList();
-            foreach (Mission mission in missions)
-            {
-                MissionCompletionReason? reason = mission.GetAbortReason(_game);
-                if (!reason.HasValue)
-                    continue;
-                if (
-                    mission.IsWaitingForParticipants()
-                    && reason.Value == MissionCompletionReason.TargetUnavailable
-                )
-                    continue;
-
-                MissionCompletedResult result = BuildTerminatingMissionResult(
-                    mission,
-                    MissionOutcome.Failed,
-                    reason.Value,
-                    mission.GetAllParticipants()
-                );
-                result.MissionInstanceID = mission.InstanceID;
-                AddMissionResults(mission, mission.ResolveInterruption(_game, _provider), results);
-                results.Add(result);
-                TearDownMission(mission, null, results);
-            }
-
-            return results;
-        }
-
-        /// <summary>
         /// Resolves mission participants while preserving the caller's observed target state.
         /// </summary>
         /// <param name="request">The mission start request to resolve.</param>
@@ -328,8 +266,6 @@ namespace Rebellion.Systems
             if (mainParticipants == null || decoyParticipants == null)
                 return null;
 
-            Officer targetOfficer = request.TargetOfficer ?? request.SelectedTarget as Officer;
-
             return new MissionContext
             {
                 Game = _game,
@@ -339,7 +275,6 @@ namespace Rebellion.Systems
                 SelectedTarget = request.SelectedTarget,
                 MainParticipants = mainParticipants,
                 DecoyParticipants = decoyParticipants,
-                TargetOfficer = targetOfficer,
                 Discipline = request.Discipline,
             };
         }
@@ -503,13 +438,7 @@ namespace Rebellion.Systems
                 betrayalResults.AddRange(mission.ResolveBetrayedMission(_game, _provider));
                 results = betrayalResults;
             }
-            else if (_uprisingSystem.TryExecuteMission(mission, out results))
-            {
-                results.AddRange(
-                    HandleResults(results.OfType<PlanetUprisingStartedResult>().ToList())
-                );
-            }
-            else
+            else if (!_uprisingSystem.TryExecuteMission(mission, out results))
             {
                 results = mission.Execute(_game, _provider);
             }
@@ -987,11 +916,7 @@ namespace Rebellion.Systems
             foreach (IMissionParticipant participant in mission.GetAllParticipants())
             {
                 if (participant.GetParent() != mission)
-                {
-                    if (mission.OriginInstanceID == null)
-                        mission.OriginInstanceID = participant.GetParent()?.GetInstanceID();
                     _movementManager.SendToMission(participant, mission);
-                }
             }
 
             mission.Initiate(RollMissionDuration(mission));

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Rebellion.Game;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
-using Rebellion.Game.Missions;
 using Rebellion.Game.Requests;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
@@ -417,7 +416,6 @@ namespace Rebellion.Systems
                     newOwner
                 );
 
-                CancelCompetingMissions(planet, newOwnerId);
                 if (newOwner != null)
                     TransferBuildings(planet, newOwner);
 
@@ -692,31 +690,6 @@ namespace Rebellion.Systems
                 return;
 
             _fogOfWarSystem.CaptureSnapshot(faction, planet, sector, _game.CurrentTick);
-        }
-
-        /// <summary>
-        /// Cancels missions targeting this planet that belong to factions other than the new owner.
-        /// </summary>
-        /// <param name="planet">The planet changing ownership.</param>
-        /// <param name="newOwnerID">The instance ID of the new owning faction.</param>
-        private void CancelCompetingMissions(Planet planet, string newOwnerID)
-        {
-            List<Mission> competing = _game
-                .GetSceneNodesByType<Mission>()
-                .Where(m =>
-                    m.CanceledOnOwnershipChange
-                    && m.OwnerInstanceID != newOwnerID
-                    && m.GetParentOfType<Planet>() == planet
-                )
-                .ToList();
-
-            foreach (Mission mission in competing)
-            {
-                foreach (IMissionParticipant participant in mission.GetAllParticipants())
-                    _movementSystem.EvacuateToNearestFriendlyPlanet(participant);
-
-                _game.DetachNode(mission);
-            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/UprisingSystem.cs
+++ b/Assets/Scripts/Systems/UprisingSystem.cs
@@ -149,14 +149,13 @@ namespace Rebellion.Systems
             mission.ResolveSuccessfulParticipants(
                 _provider,
                 _game,
-                participant =>
+                _ =>
                 {
                     if (objectiveAchieved && mission is SubdueUprisingMission)
-                        return;
+                        return false;
 
                     objectiveAchieved = ResolveMissionAttempt(mission, results);
-                    if (objectiveAchieved)
-                        mission.ImproveMissionParticipantRating(participant);
+                    return objectiveAchieved;
                 }
             );
 

--- a/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
@@ -308,9 +308,17 @@ public sealed class MainMenuController : MonoBehaviour
             return;
 
         view.RenderOptionsOverlay(true);
-        optionsMenuController.Open(tab);
-        optionsMenuController.RenderWindows();
-        optionsDirty = false;
+        try
+        {
+            optionsMenuController.Open(tab);
+            optionsMenuController.RenderWindows();
+            optionsDirty = false;
+        }
+        catch
+        {
+            view.RenderOptionsOverlay(false);
+            throw;
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsMenuController.cs
+++ b/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsMenuController.cs
@@ -755,7 +755,7 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
     }
 
     /// <summary>
-    /// Steps the selected resolution and applies it immediately.
+    /// Steps the staged resolution selection.
     /// </summary>
     /// <param name="delta">The step direction.</param>
     private void HandleResolutionStep(int delta)
@@ -765,7 +765,7 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
     }
 
     /// <summary>
-    /// Steps the display mode and applies it immediately.
+    /// Steps the staged display-mode selection.
     /// </summary>
     /// <param name="delta">The step direction.</param>
     private void HandleFullScreenStep(int delta)

--- a/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsMenuView.cs
+++ b/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsMenuView.cs
@@ -214,6 +214,7 @@ public sealed class OptionsMenuView : MonoBehaviour, IContentInitializable
             _rowActiveSpriteAddress,
             border
         );
+        VerifyContentReferences();
     }
 
     /// <summary>
@@ -970,8 +971,6 @@ public sealed class OptionsMenuView : MonoBehaviour, IContentInitializable
             throw new MissingReferenceException($"{name}/BackgroundImage is missing.");
         if (_headerTextField == null || _pageTitleTextField == null)
             throw new MissingReferenceException($"{name} is missing a title field.");
-        if (_rowIdleSprite == null || _rowActiveSprite == null)
-            throw new MissingReferenceException($"{name} is missing a row sprite.");
         if (
             string.IsNullOrWhiteSpace(_rowIdleSpriteAddress)
             || string.IsNullOrWhiteSpace(_rowActiveSpriteAddress)
@@ -1030,5 +1029,14 @@ public sealed class OptionsMenuView : MonoBehaviour, IContentInitializable
         _bindingKeyBadgeTemplate.gameObject.SetActive(false);
         _bindingKeyTemplate.gameObject.SetActive(false);
         _bindingRestoreTemplate.gameObject.SetActive(false);
+    }
+
+    /// <summary>
+    /// Verifies sprites restored after instantiation from external content.
+    /// </summary>
+    private void VerifyContentReferences()
+    {
+        if (_rowIdleSprite == null || _rowActiveSprite == null)
+            throw new MissingReferenceException($"{name} is missing a row sprite.");
     }
 }

--- a/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsSaveListView.cs
+++ b/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsSaveListView.cs
@@ -122,6 +122,7 @@ public sealed class OptionsSaveListView : MonoBehaviour, IContentInitializable
             _rowActiveSpriteAddress,
             border
         );
+        VerifyContentReferences();
     }
 
     /// <summary>
@@ -618,8 +619,6 @@ public sealed class OptionsSaveListView : MonoBehaviour, IContentInitializable
             throw new MissingReferenceException(
                 $"{name} rename field has no masked text viewport."
             );
-        if (_rowIdleSprite == null || _rowActiveSprite == null)
-            throw new MissingReferenceException($"{name} is missing a row sprite.");
         if (
             string.IsNullOrWhiteSpace(_rowIdleSpriteAddress)
             || string.IsNullOrWhiteSpace(_rowActiveSpriteAddress)
@@ -632,5 +631,14 @@ public sealed class OptionsSaveListView : MonoBehaviour, IContentInitializable
         _metaTemplate.gameObject.SetActive(false);
         _deleteTemplate.gameObject.SetActive(false);
         _renameField.gameObject.SetActive(false);
+    }
+
+    /// <summary>
+    /// Verifies sprites restored after instantiation from external content.
+    /// </summary>
+    private void VerifyContentReferences()
+    {
+        if (_rowIdleSprite == null || _rowActiveSprite == null)
+            throw new MissingReferenceException($"{name} is missing a row sprite.");
     }
 }

--- a/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsSettingsSession.cs
+++ b/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsSettingsSession.cs
@@ -107,7 +107,6 @@ internal sealed class OptionsSettingsSession
         _inputManager.LoadBindingOverrides(_snapshotBindingOverrides);
         _inputDiffersFromSnapshot = false;
         ApplyAllVolumes();
-        ApplyResolution();
         RebuildResolutions();
         IsDirty = false;
     }
@@ -127,7 +126,6 @@ internal sealed class OptionsSettingsSession
                 Video.ResolutionHeight = 0;
                 Video.FullScreenMode = (int)FullScreenMode.ExclusiveFullScreen;
                 Video.RestoreTacticalDefaults();
-                ApplyResolution();
                 RebuildResolutions();
                 break;
             case OptionsMenuTab.Audio:
@@ -219,7 +217,7 @@ internal sealed class OptionsSettingsSession
     }
 
     /// <summary>
-    /// Selects and immediately applies an adjacent supported resolution.
+    /// Stages an adjacent supported resolution.
     /// </summary>
     internal void StepResolution(int delta)
     {
@@ -232,12 +230,11 @@ internal sealed class OptionsSettingsSession
         Vector2Int resolution = _resolutions[_resolutionIndex];
         Video.ResolutionWidth = resolution.x;
         Video.ResolutionHeight = resolution.y;
-        _displayManager.Apply(Video);
         RefreshDirtyState();
     }
 
     /// <summary>
-    /// Selects and immediately applies an adjacent fullscreen mode.
+    /// Stages an adjacent fullscreen mode.
     /// </summary>
     internal void StepFullScreen(int delta)
     {
@@ -248,7 +245,6 @@ internal sealed class OptionsSettingsSession
             ((current + delta) % _fullScreenModes.Length + _fullScreenModes.Length)
             % _fullScreenModes.Length;
         Video.FullScreenMode = _fullScreenModes[next];
-        ApplyResolution();
         RefreshDirtyState();
     }
 
@@ -376,14 +372,6 @@ internal sealed class OptionsSettingsSession
         Video.ResolutionWidth = current.x;
         Video.ResolutionHeight = current.y;
         _resolutionIndex = _resolutions.IndexOf(current);
-    }
-
-    /// <summary>
-    /// Delegates the current video settings to the display owner.
-    /// </summary>
-    private void ApplyResolution()
-    {
-        _displayManager.Apply(Video);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Missions/MissionCreateWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Missions/MissionCreateWindowController.cs
@@ -527,7 +527,6 @@ public sealed class MissionCreateWindowController
         {
             Location = target.Planet.Planet,
             SelectedTarget = target.Item,
-            TargetOfficer = target.Item as Officer,
             MainParticipants = participants.ToList(),
             DecoyParticipants = new List<IMissionParticipant>(),
         };
@@ -554,7 +553,6 @@ public sealed class MissionCreateWindowController
             MissionTypeID = choice.MissionTypeID,
             Location = missionPlanet,
             SelectedTarget = session.Target.GetSpecificMissionTarget(choice.MissionTypeID),
-            TargetOfficer = session.Target.GetMissionTargetOfficer(choice.MissionTypeID),
             Discipline = choice.Discipline,
             MainParticipants = session.Agents.ToList(),
             DecoyParticipants = session.Decoys.ToList(),

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Targeting/StrategyMissionTarget.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Targeting/StrategyMissionTarget.cs
@@ -66,21 +66,4 @@ public sealed class StrategyMissionTarget : ITargetable
 
         return null;
     }
-
-    /// <summary>
-    /// Resolves the officer target used by one officer-directed mission type.
-    /// </summary>
-    /// <param name="missionTypeID">The requested mission type identifier.</param>
-    /// <returns>The selected officer, or null when the mission is not officer-directed.</returns>
-    public Officer GetMissionTargetOfficer(string missionTypeID)
-    {
-        if (
-            missionTypeID == MissionTypeIDs.Abduction
-            || missionTypeID == MissionTypeIDs.Assassination
-            || missionTypeID == MissionTypeIDs.Rescue
-        )
-            return Item as Officer;
-
-        return null;
-    }
 }

--- a/Assets/Shaders/PlanetClouds.shader
+++ b/Assets/Shaders/PlanetClouds.shader
@@ -1,0 +1,66 @@
+Shader "Custom/PlanetClouds"
+{
+    Properties
+    {
+        _MainTex ("Cloud Texture", 2D) = "white" {}
+        _PoleFadeStart ("Pole Fade Start", Range(0.0, 1.0)) = 0.992
+        _PoleFadeEnd ("Pole Fade End", Range(0.0, 1.0)) = 0.9998
+    }
+
+    SubShader
+    {
+        Tags { "Queue" = "Transparent" "RenderType" = "Transparent" "IgnoreProjector" = "True" }
+        Blend SrcAlpha OneMinusSrcAlpha, One OneMinusSrcAlpha
+        ZWrite Off
+        Cull Back
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 position : SV_POSITION;
+                float2 uv : TEXCOORD0;
+                float pole : TEXCOORD1;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float _PoleFadeStart;
+            float _PoleFadeEnd;
+
+            v2f vert(appdata input)
+            {
+                v2f output;
+                output.position = UnityObjectToClipPos(input.vertex);
+                output.uv = TRANSFORM_TEX(input.uv, _MainTex);
+                output.pole = abs(normalize(input.normal).y);
+                return output;
+            }
+
+            fixed4 frag(v2f input) : SV_Target
+            {
+                fixed4 cloud = tex2D(_MainTex, input.uv);
+                float poleFade = 1.0 - smoothstep(
+                    _PoleFadeStart,
+                    _PoleFadeEnd,
+                    input.pole
+                );
+                cloud.a *= poleFade;
+                return cloud;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/PlanetClouds.shader.meta
+++ b/Assets/Shaders/PlanetClouds.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8081047f7041463c9648031eee9666ce
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/PlanetDayNightShade.shader
+++ b/Assets/Shaders/PlanetDayNightShade.shader
@@ -1,0 +1,64 @@
+Shader "Custom/PlanetDayNightShade"
+{
+    Properties
+    {
+        _SunDirection ("Sun Direction", Vector) = (0.80, 0.46, -0.38, 0.0)
+        _NightBrightness ("Night Brightness", Range(0.0, 1.0)) = 0.045
+        _TerminatorStart ("Terminator Start", Range(-1.0, 1.0)) = -0.10
+        _TerminatorEnd ("Full Daylight", Range(-1.0, 1.0)) = 0.85
+    }
+
+    SubShader
+    {
+        Tags { "Queue" = "Overlay" "RenderType" = "Transparent" "IgnoreProjector" = "True" }
+        Blend DstColor Zero
+        ZWrite Off
+        ZTest LEqual
+        Cull Back
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+            };
+
+            struct v2f
+            {
+                float4 position : SV_POSITION;
+                float3 worldNormal : TEXCOORD0;
+            };
+
+            float4 _SunDirection;
+            float _NightBrightness;
+            float _TerminatorStart;
+            float _TerminatorEnd;
+
+            v2f vert(appdata input)
+            {
+                v2f output;
+                output.position = UnityObjectToClipPos(input.vertex);
+                output.worldNormal = UnityObjectToWorldNormal(input.normal);
+                return output;
+            }
+
+            fixed4 frag(v2f input) : SV_Target
+            {
+                float sunlight = dot(
+                    normalize(input.worldNormal),
+                    normalize(_SunDirection.xyz)
+                );
+                float daylight = smoothstep(_TerminatorStart, _TerminatorEnd, sunlight);
+                float brightness = lerp(_NightBrightness, 1.0, daylight);
+                return fixed4(brightness, brightness, brightness, 1.0);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/PlanetDayNightShade.shader.meta
+++ b/Assets/Shaders/PlanetDayNightShade.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1c49192d230a4330a900eb2c73db4cc7
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
@@ -1456,7 +1456,7 @@ namespace Rebellion.Tests.Game.Messages
             RecruitmentMission mission = new RecruitmentMission
             {
                 OwnerInstanceID = alliance.InstanceID,
-                TargetOfficerInstanceID = recruit.InstanceID,
+                RecruitedOfficerInstanceID = recruit.InstanceID,
             };
             game.AttachNode(recruit, origin);
             game.AttachNode(mission, origin);
@@ -2002,7 +2002,7 @@ namespace Rebellion.Tests.Game.Messages
                 ConfigKey = MissionTypeIDs.Recruitment,
                 DisplayName = "Recruitment",
                 OwnerInstanceID = alliance.InstanceID,
-                TargetOfficerInstanceID = "target-officer",
+                RecruitedOfficerInstanceID = "target-officer",
             };
             Officer participant = new Officer
             {

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/AbductionMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/AbductionMissionTests.cs
@@ -255,7 +255,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetOnEnemyPlanet_SetsTargetCaptured()
+        public void ResolveObjective_TargetOnEnemyPlanet_SetsTargetCaptured()
         {
             (
                 GameRoot game,
@@ -290,7 +290,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetOnEnemyPlanet_ReturnsCharacterCapturedResult()
+        public void ResolveObjective_TargetOnEnemyPlanet_ReturnsCharacterCapturedResult()
         {
             (
                 GameRoot game,
@@ -317,7 +317,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             OfficerCaptureStateResult captured = results
                 .OfType<OfficerCaptureStateResult>()
@@ -331,7 +331,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MinorTargetDiesFromCaptureInjury_DoesNotCaptureTarget()
+        public void ResolveObjective_MinorTargetDiesFromCaptureInjury_DoesNotCaptureTarget()
         {
             (
                 GameRoot game,
@@ -353,7 +353,7 @@ namespace Rebellion.Tests.Game.Missions
             );
             game.AttachNode(mission, enemyPlanet);
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0));
 
             Assert.IsNotEmpty(results.OfType<OfficerInjuredResult>());
             Assert.IsNotEmpty(results.OfType<OfficerKilledResult>());
@@ -366,7 +366,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetAvoidsCaptureInjury_IsCapturedWithoutInjury()
+        public void ResolveObjective_TargetAvoidsCaptureInjury_IsCapturedWithoutInjury()
         {
             (
                 GameRoot game,
@@ -389,7 +389,7 @@ namespace Rebellion.Tests.Game.Missions
             );
             game.AttachNode(mission, enemyPlanet);
 
-            List<GameResult> results = mission.Execute(
+            List<GameResult> results = mission.ResolveObjective(
                 game,
                 new SequenceRNG(intValues: new[] { 50 }, doubleValues: new[] { 0.0 })
             );
@@ -400,7 +400,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MultipleSuccessfulParticipants_EachAttemptsCapture()
+        public void ResolveObjective_MultipleSuccessfulParticipants_EachAttemptsCapture()
         {
             var (game, empirePlanet, enemyPlanet, officer, _) = MissionSceneBuilder.Build();
             Officer secondOfficer = EntityFactory.CreateOfficer("officer2", "empire");
@@ -419,7 +419,7 @@ namespace Rebellion.Tests.Game.Missions
             );
             game.AttachNode(mission, enemyPlanet);
 
-            List<GameResult> results = mission.Execute(
+            List<GameResult> results = mission.ResolveObjective(
                 game,
                 new SequenceRNG(intValues: new[] { 50, 50 }, doubleValues: new[] { 0.0, 0.0 })
             );
@@ -429,7 +429,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetAlreadyCaptured_ReturnsFailed()
+        public void UpdateMission_TargetAlreadyCaptured_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -456,9 +456,14 @@ namespace Rebellion.Tests.Game.Missions
             // Target is captured after mission creation but before execution
             target.IsCaptured = true;
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.0),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(
@@ -469,7 +474,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetMovedToDifferentPlanet_DoesNotRollOrImproveParticipant()
+        public void UpdateMission_TargetMovedToDifferentPlanet_DoesNotRollOrImproveParticipant()
         {
             (
                 GameRoot game,
@@ -509,9 +514,14 @@ namespace Rebellion.Tests.Game.Missions
             // Target moves to a different planet before mission executes
             game.MoveNode(target, anotherEnemyPlanet);
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new ThrowingRNG());
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new ThrowingRNG(),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(MissionOutcome.Failed, completed.Outcome);
@@ -520,7 +530,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetRemovedFromScene_ReturnsFailed()
+        public void ResolveObjective_TargetRemovedFromScene_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -548,7 +558,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/AbductionMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/AbductionMissionTests.cs
@@ -469,7 +469,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetMovedToDifferentPlanet_ReturnsFailed()
+        public void Execute_TargetMovedToDifferentPlanet_DoesNotRollOrImproveParticipant()
         {
             (
                 GameRoot game,
@@ -504,20 +504,19 @@ namespace Rebellion.Tests.Game.Missions
             );
             game.AttachNode(mission, enemyPlanet);
             mission.Initiate(0);
+            int originalCombat = officer.GetBaseRating(OfficerRating.Combat);
 
             // Target moves to a different planet before mission executes
             game.MoveNode(target, anotherEnemyPlanet);
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.Execute(game, new ThrowingRNG());
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
-            Assert.AreEqual(
-                MissionOutcome.Failed,
-                completed.Outcome,
-                "Mission should fail when target officer has moved to a different planet before execution"
-            );
+            Assert.AreEqual(MissionOutcome.Failed, completed.Outcome);
+            Assert.AreEqual(MissionCompletionReason.TargetUnavailable, completed.CompletionReason);
+            Assert.AreEqual(originalCombat, officer.GetBaseRating(OfficerRating.Combat));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/AssassinationMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/AssassinationMissionTests.cs
@@ -200,7 +200,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_FirstHitSurvivedAndSecondHitKills_CreditsSecondAssassin()
+        public void ResolveObjective_FirstHitSurvivedAndSecondHitKills_CreditsSecondAssassin()
         {
             (
                 GameRoot game,
@@ -238,7 +238,7 @@ namespace Rebellion.Tests.Game.Missions
             while (!mission.IsComplete())
                 mission.IncrementProgress();
 
-            List<GameResult> results = mission.Execute(
+            List<GameResult> results = mission.ResolveObjective(
                 game,
                 new SequenceRNG(
                     intValues: new[] { 0, 0, 99, 0, 0, 0 },
@@ -312,7 +312,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SpecialForcesSucceedsAndKillCheckPasses_CreditsSpecialForces()
+        public void ResolveObjective_SpecialForcesSucceedsAndKillCheckPasses_CreditsSpecialForces()
         {
             (
                 GameRoot game,
@@ -352,7 +352,7 @@ namespace Rebellion.Tests.Game.Missions
             while (!mission.IsComplete())
                 mission.IncrementProgress();
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             Assert.IsTrue(
                 results.Any(r => r is OfficerInjuredResult),
@@ -373,7 +373,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SuccessKillCheckFails_TargetSurvivesWithInjury()
+        public void ResolveObjective_SuccessKillCheckFails_TargetSurvivesWithInjury()
         {
             (
                 GameRoot game,
@@ -405,7 +405,7 @@ namespace Rebellion.Tests.Game.Missions
             while (!mission.IsComplete())
                 mission.IncrementProgress();
 
-            List<GameResult> results = mission.Execute(
+            List<GameResult> results = mission.ResolveObjective(
                 game,
                 new SequenceRNG(intValues: new[] { 0, 0, 99 }, doubleValues: new[] { 0.0 })
             );
@@ -432,7 +432,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MainCharacterHit_TargetSurvivesAndMissionFails()
+        public void ResolveObjective_MainCharacterHit_TargetSurvivesAndMissionFails()
         {
             (
                 GameRoot game,
@@ -458,7 +458,7 @@ namespace Rebellion.Tests.Game.Missions
             );
             game.AttachNode(mission, enemyPlanet);
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0));
 
             Assert.IsNotEmpty(results.OfType<OfficerInjuredResult>());
             Assert.IsEmpty(results.OfType<OfficerKilledResult>());
@@ -469,7 +469,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MinorCharacterKilled_ImprovesSuccessfulAssassinCombat()
+        public void ResolveObjective_MinorCharacterKilled_ImprovesSuccessfulAssassinCombat()
         {
             (
                 GameRoot game,
@@ -495,7 +495,7 @@ namespace Rebellion.Tests.Game.Missions
             );
             game.AttachNode(mission, enemyPlanet);
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0));
 
             Assert.IsNotEmpty(results.OfType<OfficerKilledResult>());
             Assert.AreEqual(
@@ -506,7 +506,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetAlreadyKilled_ReturnsFailed()
+        public void UpdateMission_TargetAlreadyKilled_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -533,9 +533,14 @@ namespace Rebellion.Tests.Game.Missions
             // Target is killed after mission creation but before execution
             target.IsKilled = true;
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.0),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(
@@ -546,7 +551,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetMovedToDifferentPlanet_DoesNotRollOrImproveParticipant()
+        public void UpdateMission_TargetMovedToDifferentPlanet_DoesNotRollOrImproveParticipant()
         {
             (
                 GameRoot game,
@@ -586,9 +591,14 @@ namespace Rebellion.Tests.Game.Missions
             // Target moves to a different planet before mission executes
             game.MoveNode(target, anotherEnemyPlanet);
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new ThrowingRNG());
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new ThrowingRNG(),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(MissionOutcome.Failed, completed.Outcome);
@@ -597,7 +607,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetRemovedFromScene_ReturnsFailed()
+        public void ResolveObjective_TargetRemovedFromScene_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -625,7 +635,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/AssassinationMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/AssassinationMissionTests.cs
@@ -546,7 +546,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetMovedToDifferentPlanet_ReturnsFailed()
+        public void Execute_TargetMovedToDifferentPlanet_DoesNotRollOrImproveParticipant()
         {
             (
                 GameRoot game,
@@ -581,20 +581,19 @@ namespace Rebellion.Tests.Game.Missions
             );
             game.AttachNode(mission, enemyPlanet);
             mission.Initiate(0);
+            int originalCombat = officer.GetBaseRating(OfficerRating.Combat);
 
             // Target moves to a different planet before mission executes
             game.MoveNode(target, anotherEnemyPlanet);
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.Execute(game, new ThrowingRNG());
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
-            Assert.AreEqual(
-                MissionOutcome.Failed,
-                completed.Outcome,
-                "Mission should fail when target officer has moved to a different planet before execution"
-            );
+            Assert.AreEqual(MissionOutcome.Failed, completed.Outcome);
+            Assert.AreEqual(MissionCompletionReason.TargetUnavailable, completed.CompletionReason);
+            Assert.AreEqual(originalCombat, officer.GetBaseRating(OfficerRating.Combat));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/DiplomacyMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/DiplomacyMissionTests.cs
@@ -16,7 +16,7 @@ namespace Rebellion.Tests.Game.Missions
     public class DiplomacyMissionTests
     {
         [Test]
-        public void Execute_SupportBelowThreshold_NoOwnershipChange()
+        public void ResolveObjective_SupportBelowThreshold_NoOwnershipChange()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 50);
             Mission mission = CreateAndAttachMission(game, planet);
@@ -31,7 +31,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SupportCrossesThreshold_NoOwnershipChangeEmitted()
+        public void ResolveObjective_SupportCrossesThreshold_NoOwnershipChangeEmitted()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 60, planetOwner: null);
             Mission mission = CreateAndAttachMission(game, planet);
@@ -50,7 +50,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_PlanetAlreadyOwned_NoOwnershipChangeEmitted()
+        public void ResolveObjective_PlanetAlreadyOwned_NoOwnershipChangeEmitted()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 61, planetOwner: "empire");
             Mission mission = CreateAndAttachMission(game, planet);
@@ -64,7 +64,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_PlanetAlreadyOwned_IncrementsSupportWithoutChangingOwner()
+        public void ResolveObjective_PlanetAlreadyOwned_IncrementsSupportWithoutChangingOwner()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 61, planetOwner: "empire");
             Mission mission = CreateAndAttachMission(game, planet);
@@ -80,7 +80,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SuccessProbability_DoesNotAffectSupportGain()
+        public void ResolveObjective_SuccessProbability_DoesNotAffectSupportGain()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 50, planetOwner: "empire");
             Officer officer = EntityFactory.CreateOfficer("o1", "empire");
@@ -106,7 +106,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_OwnedPlanet_UsesDiplomacySupportConfig()
+        public void ResolveObjective_OwnedPlanet_UsesDiplomacySupportConfig()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 50, planetOwner: "empire");
             Mission mission = CreateAndAttachMission(game, planet);
@@ -119,7 +119,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_NeutralPlanet_UsesNeutralDiplomacySupportConfig()
+        public void ResolveObjective_NeutralPlanet_UsesNeutralDiplomacySupportConfig()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 50, planetOwner: null);
             Mission mission = CreateAndAttachMission(game, planet);
@@ -132,7 +132,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_CoreSectorWeakSupport_AppliesConfiguredDivisor()
+        public void ResolveObjective_CoreSectorWeakSupport_AppliesConfiguredDivisor()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 50, planetOwner: "empire");
             planet.GetParentOfType<PlanetSector>().SectorType = PlanetSectorType.Core;
@@ -149,7 +149,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SuccessProbability_UsesResistanceTroopCountMinusOpposingSupportPlusDiplomacyRating()
+        public void ResolveObjective_SuccessProbability_UsesResistanceTroopCountMinusOpposingSupportPlusDiplomacyRating()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 80, planetOwner: "empire");
             Officer officer = EntityFactory.CreateOfficer("o1", "empire");
@@ -181,14 +181,14 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.99));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.99));
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(MissionOutcome.Success, completed.Outcome);
         }
 
         [Test]
-        public void Execute_SupportAlreadyAtMax_ReturnsSuccess()
+        public void ResolveObjective_SupportAlreadyAtMax_ReturnsSuccess()
         {
             GameRoot game = BuildGame(out Planet planet, empireSupport: 99, planetOwner: "empire");
 
@@ -208,7 +208,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(
@@ -471,7 +471,7 @@ namespace Rebellion.Tests.Game.Missions
                 { -10000, 100 },
             };
             mission.Initiate(0);
-            return mission.Execute(game, rng);
+            return mission.ResolveObjective(game, rng);
         }
     }
 }

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/EspionageMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/EspionageMissionTests.cs
@@ -17,7 +17,7 @@ namespace Rebellion.Tests.Game.Missions
     public class EspionageMissionTests
     {
         [Test]
-        public void Execute_EnemyPlanetTarget_CapturesSnapshotForFaction()
+        public void ResolveObjective_EnemyPlanetTarget_CapturesSnapshotForFaction()
         {
             (
                 GameRoot game,
@@ -54,7 +54,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_EnemyPlanetTarget_CapturesCurrentPlanetContents()
+        public void ResolveObjective_EnemyPlanetTarget_CapturesCurrentPlanetContents()
         {
             (
                 GameRoot game,
@@ -90,7 +90,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_EnemyPlanetTarget_RevealsEnemyMissions()
+        public void ResolveObjective_EnemyPlanetTarget_RevealsEnemyMissions()
         {
             (
                 GameRoot game,
@@ -127,7 +127,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_CoreTarget_RevealsSameAllegianceCorePlanets()
+        public void ResolveObjective_CoreTarget_RevealsSameAllegianceCorePlanets()
         {
             (
                 GameRoot game,
@@ -168,7 +168,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_CoreTarget_ReportsEveryAdditionalSectorRevealed()
+        public void ResolveObjective_CoreTarget_ReportsEveryAdditionalSectorRevealed()
         {
             (
                 GameRoot game,
@@ -202,7 +202,7 @@ namespace Rebellion.Tests.Game.Missions
             while (!mission.IsComplete())
                 mission.IncrementProgress();
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             PlanetSectorsRevealedResult intelligence = results
                 .OfType<PlanetSectorsRevealedResult>()
@@ -215,7 +215,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_OuterRimTarget_DoesNotRevealBonusPlanets()
+        public void ResolveObjective_OuterRimTarget_DoesNotRevealBonusPlanets()
         {
             (
                 GameRoot game,
@@ -247,7 +247,9 @@ namespace Rebellion.Tests.Game.Missions
 
         [TestCase("empire")]
         [TestCase(null)]
-        public void Execute_NonEnemyCoreTarget_DoesNotRevealBonusPlanets(string targetOwnerId)
+        public void ResolveObjective_NonEnemyCoreTarget_DoesNotRevealBonusPlanets(
+            string targetOwnerId
+        )
         {
             var (game, _, enemyPlanet, officer, _) = MissionSceneBuilder.Build();
             enemyPlanet.OwnerInstanceID = targetOwnerId;
@@ -273,7 +275,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MobileHeadquartersTarget_CanRevealCoreAndOuterRimPlanets()
+        public void ResolveObjective_MobileHeadquartersTarget_CanRevealCoreAndOuterRimPlanets()
         {
             (
                 GameRoot game,
@@ -315,7 +317,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_CapitalTarget_CanRevealCoreAndOuterRimPlanets()
+        public void ResolveObjective_CapitalTarget_CanRevealCoreAndOuterRimPlanets()
         {
             (
                 GameRoot game,
@@ -348,7 +350,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_WithoutFogSystem_DoesNotThrow()
+        public void ResolveObjective_WithoutFogSystem_DoesNotThrow()
         {
             (
                 GameRoot game,
@@ -374,7 +376,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_PlanetBecameOwnedByMissionFaction_StillSucceeds()
+        public void ResolveObjective_PlanetBecameOwnedByMissionFaction_StillSucceeds()
         {
             (
                 GameRoot game,
@@ -401,7 +403,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(
@@ -412,7 +414,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_ForeignPlanetTarget_ImprovesSuccessfulOfficerEspionageRating()
+        public void ResolveObjective_ForeignPlanetTarget_ImprovesSuccessfulOfficerEspionageRating()
         {
             (
                 GameRoot game,
@@ -445,7 +447,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MultipleOfficers_TriesNextOfficerWhenLowestScoreOfficerFails()
+        public void ResolveObjective_MultipleOfficers_TriesNextOfficerWhenLowestScoreOfficerFails()
         {
             (
                 GameRoot game,
@@ -477,7 +479,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0));
 
             Assert.AreEqual(
                 MissionOutcome.Success,
@@ -486,7 +488,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MultipleOfficersSucceed_ImprovesEverySuccessfulOfficer()
+        public void ResolveObjective_MultipleOfficersSucceed_ImprovesEverySuccessfulOfficer()
         {
             (
                 GameRoot game,
@@ -532,7 +534,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_DecoyParticipant_DoesNotImproveOfficerEspionageRating()
+        public void ResolveObjective_DecoyParticipant_DoesNotImproveOfficerEspionageRating()
         {
             (
                 GameRoot game,
@@ -566,7 +568,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_OwnPlanetTarget_DoesNotImproveOfficerEspionageRating()
+        public void ResolveObjective_OwnPlanetTarget_DoesNotImproveOfficerEspionageRating()
         {
             (
                 GameRoot game,
@@ -599,7 +601,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_NeutralPlanetTarget_DoesNotImproveOfficerEspionageRating()
+        public void ResolveObjective_NeutralPlanetTarget_DoesNotImproveOfficerEspionageRating()
         {
             var (game, _, enemyPlanet, officer, _) = MissionSceneBuilder.Build();
             enemyPlanet.OwnerInstanceID = null;

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/JediTrainingMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/JediTrainingMissionTests.cs
@@ -147,14 +147,14 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_ClosestRankedStudentAttemptsFirst_TrainsOnlySuccessfulParticipant()
+        public void ResolveObjective_ClosestRankedStudentAttemptsFirst_TrainsOnlySuccessfulParticipant()
         {
             Officer secondStudent = CreateJedi("student2", 100);
             JediTrainingMission mission = CreateMission(
                 new List<IMissionParticipant> { _trainer, _student, secondStudent }
             );
 
-            List<GameResult> results = mission.Execute(
+            List<GameResult> results = mission.ResolveObjective(
                 _game,
                 new SequenceRNG(intValues: new[] { 0, 99, 0, 20 })
             );
@@ -171,11 +171,11 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_PassedTrainingRollWithZeroProgress_ReturnsFailedReport()
+        public void ResolveObjective_PassedTrainingRollWithZeroProgress_ReturnsFailedReport()
         {
             JediTrainingMission mission = CreateMission();
 
-            List<GameResult> results = mission.Execute(
+            List<GameResult> results = mission.ResolveObjective(
                 _game,
                 new SequenceRNG(intValues: new[] { 0, 0, 0 })
             );
@@ -189,11 +189,11 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_FailedTrainingRoll_ReturnsFailedReport()
+        public void ResolveObjective_FailedTrainingRoll_ReturnsFailedReport()
         {
             JediTrainingMission mission = CreateMission();
 
-            List<GameResult> results = mission.Execute(
+            List<GameResult> results = mission.ResolveObjective(
                 _game,
                 new SequenceRNG(intValues: new[] { 0, 99 })
             );
@@ -206,13 +206,13 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TrainingProgress_DoesNotImproveDiplomacyRating()
+        public void ResolveObjective_TrainingProgress_DoesNotImproveDiplomacyRating()
         {
             int trainerDiplomacy = _trainer.GetBaseRating(OfficerRating.Diplomacy);
             int studentDiplomacy = _student.GetBaseRating(OfficerRating.Diplomacy);
             JediTrainingMission mission = CreateMission();
 
-            mission.Execute(_game, new SequenceRNG(intValues: new[] { 0, 0, 20 }));
+            mission.ResolveObjective(_game, new SequenceRNG(intValues: new[] { 0, 0, 20 }));
 
             Assert.AreEqual(trainerDiplomacy, _trainer.GetBaseRating(OfficerRating.Diplomacy));
             Assert.AreEqual(studentDiplomacy, _student.GetBaseRating(OfficerRating.Diplomacy));

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/MissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/MissionTests.cs
@@ -180,7 +180,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SuccessOutcome_IncludesMissionCompletedResultWithMissionInstanceID()
+        public void ResolveObjective_SuccessOutcome_IncludesMissionCompletedResultWithMissionInstanceID()
         {
             (
                 GameRoot game,
@@ -203,14 +203,14 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().Single();
 
             Assert.AreEqual(mission.InstanceID, completed.MissionInstanceID);
         }
 
         [Test]
-        public void Execute_FailOutcome_AlwaysIncludesMissionCompletedResult()
+        public void ResolveObjective_FailOutcome_AlwaysIncludesMissionCompletedResult()
         {
             (
                 GameRoot game,
@@ -233,7 +233,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.99));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.99));
 
             Assert.IsTrue(
                 results.OfType<MissionCompletedResult>().Any(),
@@ -242,7 +242,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SuccessfulMission_ImprovesOnlySuccessfulParticipantRating()
+        public void ResolveObjective_SuccessfulMission_ImprovesOnlySuccessfulParticipantRating()
         {
             (
                 GameRoot game,
@@ -264,7 +264,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            mission.Execute(game, new FixedRNG(0.0));
+            mission.ResolveObjective(game, new FixedRNG(0.0));
 
             Assert.AreEqual(
                 ratingBefore + 1,
@@ -279,7 +279,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_FailedSuccessRoll_ReturnsFailed()
+        public void ResolveObjective_FailedSuccessRoll_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -304,7 +304,7 @@ namespace Rebellion.Tests.Game.Missions
             while (!mission.IsComplete())
                 mission.IncrementProgress();
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.99));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.99));
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(
@@ -315,7 +315,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_OfficerAttemptFails_SpecialForcesCanSucceed()
+        public void ResolveObjective_OfficerAttemptFails_SpecialForcesCanSucceed()
         {
             (
                 GameRoot game,
@@ -350,7 +350,7 @@ namespace Rebellion.Tests.Game.Missions
             game.AttachNode(mission, enemyPlanet);
             mission.Initiate(0);
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.5));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.5));
 
             Assert.AreEqual(
                 MissionOutcome.Success,
@@ -363,7 +363,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MultipleOfficers_TriesStrongerOfficerAfterWeakestFails()
+        public void ResolveObjective_MultipleOfficers_TriesStrongerOfficerAfterWeakestFails()
         {
             (
                 GameRoot game,
@@ -394,7 +394,7 @@ namespace Rebellion.Tests.Game.Missions
             game.AttachNode(mission, enemyPlanet);
             mission.Initiate(0);
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0));
 
             Assert.AreEqual(
                 MissionOutcome.Success,
@@ -408,7 +408,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_OfficersOnSameProbabilityPlateau_PreservesSelectionOrder()
+        public void ResolveObjective_OfficersOnSameProbabilityPlateau_PreservesSelectionOrder()
         {
             (
                 GameRoot game,
@@ -439,7 +439,7 @@ namespace Rebellion.Tests.Game.Missions
             game.AttachNode(mission, enemyPlanet);
             mission.Initiate(0);
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0));
 
             Assert.AreSame(
                 highScoreOfficer,

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/MissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/MissionTests.cs
@@ -46,6 +46,35 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
+        public void Constructor_ParticipantListsChangedByCaller_PreservesMissionAssignments()
+        {
+            (
+                GameRoot game,
+                Planet empirePlanet,
+                Planet enemyPlanet,
+                Officer officer,
+                FogOfWarSystem fog
+            ) = MissionSceneBuilder.Build();
+            Officer decoy = EntityFactory.CreateOfficer("decoy", "empire");
+            Regiment target = CreateSabotageTarget(game, enemyPlanet);
+            List<IMissionParticipant> mainParticipants = new List<IMissionParticipant> { officer };
+            List<IMissionParticipant> decoyParticipants = new List<IMissionParticipant> { decoy };
+
+            Mission mission = CreateSabotageMission(
+                "empire",
+                enemyPlanet,
+                mainParticipants,
+                decoyParticipants,
+                target
+            );
+            mainParticipants.Clear();
+            decoyParticipants.Clear();
+
+            CollectionAssert.AreEqual(new[] { officer }, mission.GetMainParticipants());
+            CollectionAssert.AreEqual(new[] { decoy }, mission.GetDecoyParticipants());
+        }
+
+        [Test]
         public void GetAbortReason_MainParticipantRemoved_ReturnsFailure()
         {
             (

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/ReconnaissanceMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/ReconnaissanceMissionTests.cs
@@ -18,7 +18,7 @@ namespace Rebellion.Tests.Game.Missions
     public class ReconnaissanceMissionTests
     {
         [Test]
-        public void Execute_UnvisitedPlanet_CapturesSnapshotWithoutSuccessRoll()
+        public void ResolveObjective_UnvisitedPlanet_CapturesSnapshotWithoutSuccessRoll()
         {
             (
                 GameRoot game,
@@ -41,7 +41,7 @@ namespace Rebellion.Tests.Game.Missions
             game.AttachNode(mission, enemyPlanet);
             mission.Initiate(0);
 
-            List<GameResult> results = mission.Execute(game, new ThrowingRNG());
+            List<GameResult> results = mission.ResolveObjective(game, new ThrowingRNG());
 
             Assert.IsTrue(enemyPlanet.WasVisitedBy("empire"));
             Assert.AreEqual(

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/RecruitmentMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/RecruitmentMissionTests.cs
@@ -16,7 +16,7 @@ namespace Rebellion.Tests.Game.Missions
     public class RecruitmentMissionTests
     {
         [Test]
-        public void Execute_TargetInUnrecruitedPool_TransfersOfficerToFaction()
+        public void Execute_AvailableCandidate_TransfersOfficerToFaction()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -31,7 +31,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetInUnrecruitedPool_AttachesOfficerToPlanet()
+        public void Execute_AvailableCandidate_AttachesOfficerToPlanet()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -46,7 +46,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetInUnrecruitedPool_RemovesOfficerFromUnrecruitedPool()
+        public void Execute_AvailableCandidate_RemovesOfficerFromUnrecruitedPool()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -83,11 +83,14 @@ namespace Rebellion.Tests.Game.Missions
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(MissionOutcome.Success, completed.Outcome);
             Assert.AreEqual("empire", replacementTarget.OwnerInstanceID);
-            Assert.AreEqual("replacement", ((RecruitmentMission)mission).TargetOfficerInstanceID);
+            Assert.AreEqual(
+                "replacement",
+                ((RecruitmentMission)mission).RecruitedOfficerInstanceID
+            );
         }
 
         [Test]
-        public void Execute_TargetRemovedFromPool_ReturnsFailed()
+        public void Execute_NoCandidatesRemain_DoesNotRollOrImproveRecruiter()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -96,16 +99,20 @@ namespace Rebellion.Tests.Game.Missions
             game.GetUnrecruitedOfficers().Add(target);
 
             Mission mission = CreateMission(game, empirePlanet, officer);
+            int originalLeadership = officer.GetBaseRating(OfficerRating.Leadership);
 
-            // Officer leaves the unrecruited pool before the mission executes
+            // The candidate pool empties before the mission executes.
             game.GetUnrecruitedOfficers().Remove(target);
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.Execute(game, new ThrowingRNG());
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(MissionOutcome.Failed, completed.Outcome);
+            Assert.AreEqual(MissionCompletionReason.TargetUnavailable, completed.CompletionReason);
+            Assert.IsFalse(completed.CanContinue);
+            Assert.AreEqual(originalLeadership, officer.GetBaseRating(OfficerRating.Leadership));
         }
 
         [Test]
@@ -156,7 +163,7 @@ namespace Rebellion.Tests.Game.Missions
             Assert.AreEqual("empire", secondTarget.OwnerInstanceID);
             Assert.IsFalse(game.GetUnrecruitedOfficers().Contains(firstTarget));
             Assert.IsFalse(game.GetUnrecruitedOfficers().Contains(secondTarget));
-            Assert.AreEqual("second", ((RecruitmentMission)mission).TargetOfficerInstanceID);
+            Assert.AreEqual("second", ((RecruitmentMission)mission).RecruitedOfficerInstanceID);
         }
 
         [Test]
@@ -199,7 +206,10 @@ namespace Rebellion.Tests.Game.Missions
                 new SequenceRNG(intValues: new[] { 0 }, doubleValues: new[] { 0.0, 0.0 })
             );
 
-            Assert.AreEqual("first-target", ((RecruitmentMission)mission).TargetOfficerInstanceID);
+            Assert.AreEqual(
+                "first-target",
+                ((RecruitmentMission)mission).RecruitedOfficerInstanceID
+            );
             Assert.AreEqual("empire", firstTarget.OwnerInstanceID);
             Assert.IsTrue(game.GetUnrecruitedOfficers().Contains(secondTarget));
             Assert.AreEqual(
@@ -290,11 +300,11 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void TryCreate_NoValidTarget_ReturnsNull()
+        public void TryCreate_NoAvailableCandidates_ReturnsNull()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
-            // No unrecruited officers — TryCreate has no valid target
+            // No unrecruited officers are available at the target planet.
             Mission mission = CreateRecruitmentMission(
                 game,
                 "empire",
@@ -305,7 +315,7 @@ namespace Rebellion.Tests.Game.Missions
 
             Assert.IsNull(
                 mission,
-                "TryCreate should return null when no unrecruited officers exist"
+                "TryCreate should return null when no recruitment candidates exist"
             );
         }
 
@@ -320,7 +330,7 @@ namespace Rebellion.Tests.Game.Missions
                 DisplayName = "Recruitment",
                 LocationInstanceID = "PLANET1",
                 ParticipantRating = OfficerRating.Diplomacy,
-                TargetOfficerInstanceID = "OFFICER4",
+                RecruitedOfficerInstanceID = "OFFICER4",
             };
 
             string xml = SerializationHelper.Serialize(mission);
@@ -328,7 +338,10 @@ namespace Rebellion.Tests.Game.Missions
 
             Assert.AreEqual("MISSION1", deserialized.InstanceID);
             Assert.AreEqual("Recruitment", deserialized.ConfigKey);
-            Assert.AreEqual("OFFICER4", ((RecruitmentMission)deserialized).TargetOfficerInstanceID);
+            Assert.AreEqual(
+                "OFFICER4",
+                ((RecruitmentMission)deserialized).RecruitedOfficerInstanceID
+            );
             Assert.AreEqual(OfficerRating.Diplomacy, deserialized.ParticipantRating);
         }
 

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/RecruitmentMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/RecruitmentMissionTests.cs
@@ -16,7 +16,7 @@ namespace Rebellion.Tests.Game.Missions
     public class RecruitmentMissionTests
     {
         [Test]
-        public void Execute_AvailableCandidate_TransfersOfficerToFaction()
+        public void ResolveObjective_AvailableCandidate_TransfersOfficerToFaction()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -31,7 +31,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_AvailableCandidate_AttachesOfficerToPlanet()
+        public void ResolveObjective_AvailableCandidate_AttachesOfficerToPlanet()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -46,7 +46,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_AvailableCandidate_RemovesOfficerFromUnrecruitedPool()
+        public void ResolveObjective_AvailableCandidate_RemovesOfficerFromUnrecruitedPool()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -61,7 +61,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_CreatedBeforePoolChanges_RecruitsCurrentAvailableOfficer()
+        public void ResolveObjective_CreatedBeforePoolChanges_RecruitsCurrentAvailableOfficer()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -78,7 +78,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(MissionOutcome.Success, completed.Outcome);
@@ -90,7 +90,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_NoCandidatesRemain_DoesNotRollOrImproveRecruiter()
+        public void UpdateMission_NoCandidatesRemain_DoesNotRollOrImproveRecruiter()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -104,9 +104,15 @@ namespace Rebellion.Tests.Game.Missions
             // The candidate pool empties before the mission executes.
             game.GetUnrecruitedOfficers().Remove(target);
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new ThrowingRNG());
+            FogOfWarSystem fog = new FogOfWarSystem(game);
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new ThrowingRNG(),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(MissionOutcome.Failed, completed.Outcome);
@@ -116,7 +122,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SuccessProbability_UsesOpposingSupportAndLeadershipRating()
+        public void ResolveObjective_SuccessProbability_UsesOpposingSupportAndLeadershipRating()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -135,14 +141,14 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.99));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.99));
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(MissionOutcome.Success, completed.Outcome);
         }
 
         [Test]
-        public void Execute_SecondSuccess_SelectsNextOfficerFromCurrentPool()
+        public void ResolveObjective_SecondSuccess_SelectsNextOfficerFromCurrentPool()
         {
             (GameRoot game, Planet empirePlanet, Officer officer) = BuildScene();
 
@@ -167,7 +173,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MultipleRecruitersSucceed_FirstSuccessStopsFurtherAttempts()
+        public void ResolveObjective_MultipleRecruitersSucceed_FirstSuccessStopsFurtherAttempts()
         {
             (GameRoot game, Planet empirePlanet, Officer firstRecruiter) = BuildScene();
             Officer secondRecruiter = EntityFactory.CreateOfficer("second-recruiter", "empire");
@@ -201,7 +207,7 @@ namespace Rebellion.Tests.Game.Missions
             while (!mission.IsComplete())
                 mission.IncrementProgress();
 
-            List<GameResult> results = mission.Execute(
+            List<GameResult> results = mission.ResolveObjective(
                 game,
                 new SequenceRNG(intValues: new[] { 0 }, doubleValues: new[] { 0.0, 0.0 })
             );

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/RescueMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/RescueMissionTests.cs
@@ -231,7 +231,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_CapturedOfficerOnTargetPlanet_FreesOfficer()
+        public void ResolveObjective_CapturedOfficerOnTargetPlanet_FreesOfficer()
         {
             (
                 GameRoot game,
@@ -262,7 +262,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_CapturedOfficerOnTargetPlanet_ReturnsOfficerRescuedResult()
+        public void ResolveObjective_CapturedOfficerOnTargetPlanet_ReturnsOfficerRescuedResult()
         {
             (
                 GameRoot game,
@@ -289,7 +289,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             OfficerRescuedResult rescueResult = results
                 .OfType<OfficerRescuedResult>()
@@ -299,7 +299,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_CapturedOfficerOnTargetPlanet_EmitsCaptureStateReleased()
+        public void ResolveObjective_CapturedOfficerOnTargetPlanet_EmitsCaptureStateReleased()
         {
             (
                 GameRoot game,
@@ -326,7 +326,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             OfficerCaptureStateResult captureState = results
                 .OfType<OfficerCaptureStateResult>()
@@ -337,7 +337,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_OfficerNotCaptured_ReturnsFailed()
+        public void UpdateMission_OfficerNotCaptured_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -366,9 +366,14 @@ namespace Rebellion.Tests.Game.Missions
             // Officer is freed after mission creation but before execution
             captive.IsCaptured = false;
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.0),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(
@@ -379,7 +384,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetOfficerAlreadyFreed_ReturnsFailed()
+        public void UpdateMission_TargetOfficerAlreadyFreed_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -407,9 +412,14 @@ namespace Rebellion.Tests.Game.Missions
             // Captive is freed before mission executes
             captive.IsCaptured = false;
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.0),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(
@@ -420,7 +430,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetMovedToDifferentPlanet_ReturnsFailed()
+        public void UpdateMission_TargetMovedToDifferentPlanet_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -448,9 +458,14 @@ namespace Rebellion.Tests.Game.Missions
             // Captive is moved to a different planet before mission executes
             game.MoveNode(captive, empirePlanet);
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.0),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(
@@ -461,7 +476,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TargetRemovedFromScene_ReturnsFailed()
+        public void UpdateMission_TargetRemovedFromScene_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -489,9 +504,14 @@ namespace Rebellion.Tests.Game.Missions
             // Captive removed from scene before mission executes
             game.DetachNode(captive);
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.0),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/ResearchMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/ResearchMissionTests.cs
@@ -120,36 +120,36 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_PositiveResearchSkillAndMinimumRoll_AwardsResearchCapacity()
+        public void ResolveObjective_PositiveResearchSkillAndMinimumRoll_AwardsResearchCapacity()
         {
             Officer officer = CreateOfficer(shipSkill: 75);
             Mission mission = CreateMission(officer, ResearchDiscipline.ShipDesign);
 
-            mission.Execute(_game, new FixedRNG(0.0));
+            mission.ResolveObjective(_game, new FixedRNG(0.0));
 
             Assert.Greater(_faction.GetResearchCapacityRemaining(ResearchDiscipline.ShipDesign), 0);
         }
 
         [Test]
-        public void Execute_Success_AwardsResearchCapacity()
+        public void ResolveObjective_Success_AwardsResearchCapacity()
         {
             Officer officer = CreateOfficer(shipSkill: 100);
             Mission mission = CreateMission(officer);
 
             int before = _faction.GetResearchCapacityRemaining(ResearchDiscipline.ShipDesign);
-            mission.Execute(_game, new FixedRNG(0.0));
+            mission.ResolveObjective(_game, new FixedRNG(0.0));
             int after = _faction.GetResearchCapacityRemaining(ResearchDiscipline.ShipDesign);
 
             Assert.Greater(after, before, "Successful research mission should award capacity");
         }
 
         [Test]
-        public void Execute_Success_IncrementsMatchingResearchSkill()
+        public void ResolveObjective_Success_IncrementsMatchingResearchSkill()
         {
             Officer officer = CreateOfficer(shipSkill: 50);
             Mission mission = CreateMission(officer);
 
-            mission.Execute(_game, new FixedRNG(0.0));
+            mission.ResolveObjective(_game, new FixedRNG(0.0));
 
             Assert.AreEqual(
                 51,
@@ -159,12 +159,12 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_Failure_NoCapacityAwarded()
+        public void ResolveObjective_Failure_NoCapacityAwarded()
         {
             Officer officer = CreateOfficer(shipSkill: 10);
             Mission mission = CreateMission(officer);
 
-            mission.Execute(_game, new FixedRNG(0.99));
+            mission.ResolveObjective(_game, new FixedRNG(0.99));
 
             Assert.AreEqual(
                 0,
@@ -173,12 +173,12 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_RollEqualsResearchChance_DoesNotAwardCapacity()
+        public void ResolveObjective_RollEqualsResearchChance_DoesNotAwardCapacity()
         {
             Officer officer = CreateOfficer(shipSkill: 50);
             Mission mission = CreateMission(officer);
 
-            mission.Execute(_game, new FixedRNG(0.5));
+            mission.ResolveObjective(_game, new FixedRNG(0.5));
 
             Assert.AreEqual(
                 0,
@@ -188,14 +188,14 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_AfterResearchFacilityDestroyed_ContinuesResearch()
+        public void ResolveObjective_AfterResearchFacilityDestroyed_ContinuesResearch()
         {
             Officer officer = CreateOfficer(shipSkill: 100);
             Mission mission = CreateMission(officer);
             foreach (Building building in _planet.GetAllBuildings().ToList())
                 _game.DetachNode(building);
 
-            List<GameResult> results = mission.Execute(_game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(_game, new FixedRNG(0.0));
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().Single();
             Assert.AreEqual(MissionOutcome.Success, completed.Outcome);
@@ -230,18 +230,18 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_Failure_SkillUnchanged()
+        public void ResolveObjective_Failure_SkillUnchanged()
         {
             Officer officer = CreateOfficer(shipSkill: 10);
             Mission mission = CreateMission(officer);
 
-            mission.Execute(_game, new FixedRNG(0.99));
+            mission.ResolveObjective(_game, new FixedRNG(0.99));
 
             Assert.AreEqual(10, officer.ShipResearch, "Skill should not change on failure");
         }
 
         [Test]
-        public void Execute_SecondParticipantSucceeds_AwardsResearchCapacity()
+        public void ResolveObjective_SecondParticipantSucceeds_AwardsResearchCapacity()
         {
             Officer firstOfficer = CreateOfficer(shipSkill: 10);
             Officer secondOfficer = new Officer
@@ -263,7 +263,7 @@ namespace Rebellion.Tests.Game.Missions
             );
             _game.AttachNode(mission, _planet);
 
-            mission.Execute(_game, new FixedRNG(0.5));
+            mission.ResolveObjective(_game, new FixedRNG(0.5));
 
             Assert.Greater(_faction.GetResearchCapacityRemaining(ResearchDiscipline.ShipDesign), 0);
             Assert.AreEqual(10, firstOfficer.ShipResearch);
@@ -271,12 +271,12 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_TroopTrainingDiscipline_AwardsTroopCapacity()
+        public void ResolveObjective_TroopTrainingDiscipline_AwardsTroopCapacity()
         {
             Officer officer = CreateOfficer(troopSkill: 100);
             Mission mission = CreateMission(officer, ResearchDiscipline.TroopTraining);
 
-            mission.Execute(_game, new FixedRNG(0.0));
+            mission.ResolveObjective(_game, new FixedRNG(0.0));
 
             Assert.Greater(
                 _faction.GetResearchCapacityRemaining(ResearchDiscipline.TroopTraining),
@@ -289,24 +289,24 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_MaxSkillOfficer_AwardsResearchCapacity()
+        public void ResolveObjective_MaxSkillOfficer_AwardsResearchCapacity()
         {
             Officer officer = CreateOfficer(shipSkill: 100);
             Mission mission = CreateMission(officer);
 
-            mission.Execute(_game, new FixedRNG(0.99));
+            mission.ResolveObjective(_game, new FixedRNG(0.99));
 
             Assert.Greater(_faction.GetResearchCapacityRemaining(ResearchDiscipline.ShipDesign), 0);
         }
 
         [Test]
-        public void Execute_Success_DoesNotIncrementLeadership()
+        public void ResolveObjective_Success_DoesNotIncrementLeadership()
         {
             Officer officer = CreateOfficer(shipSkill: 100);
             int leadershipBefore = officer.GetBaseRating(OfficerRating.Leadership);
             Mission mission = CreateMission(officer);
 
-            mission.Execute(_game, new FixedRNG(0.0));
+            mission.ResolveObjective(_game, new FixedRNG(0.0));
 
             Assert.AreEqual(
                 leadershipBefore,
@@ -341,7 +341,7 @@ namespace Rebellion.Tests.Game.Missions
             Officer officer = CreateOfficer(shipSkill: 100);
             Mission mission = CreateMission(officer);
 
-            mission.Execute(_game, new FixedRNG(0.0));
+            mission.ResolveObjective(_game, new FixedRNG(0.0));
 
             Assert.IsTrue(
                 mission.ShouldRepeatAfterCompletion(_game),
@@ -355,7 +355,7 @@ namespace Rebellion.Tests.Game.Missions
             Officer officer = CreateOfficer(shipSkill: 10);
             Mission mission = CreateMission(officer);
 
-            mission.Execute(_game, new FixedRNG(0.99));
+            mission.ResolveObjective(_game, new FixedRNG(0.99));
 
             Assert.IsTrue(
                 mission.ShouldRepeatAfterCompletion(_game),

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/SabotageMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/SabotageMissionTests.cs
@@ -80,7 +80,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_BuildingOnEnemyPlanet_RemovesBuilding()
+        public void ResolveObjective_BuildingOnEnemyPlanet_RemovesBuilding()
         {
             (
                 GameRoot game,
@@ -119,7 +119,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_BuildingOnEnemyPlanet_ReturnsBuildingSabotagedResult()
+        public void ResolveObjective_BuildingOnEnemyPlanet_ReturnsBuildingSabotagedResult()
         {
             (
                 GameRoot game,
@@ -150,7 +150,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             Assert.IsTrue(
                 results.OfType<GameObjectSabotagedResult>().Any(),
@@ -159,7 +159,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_BuildingOnEnemyPlanet_SetsSaboteurOnResult()
+        public void ResolveObjective_BuildingOnEnemyPlanet_SetsSaboteurOnResult()
         {
             (
                 GameRoot game,
@@ -190,7 +190,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             GameObjectSabotagedResult sabotaged = results
                 .OfType<GameObjectSabotagedResult>()
@@ -203,7 +203,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SurfaceRegiment_ReturnsGarrisonChange()
+        public void ResolveObjective_SurfaceRegiment_ReturnsGarrisonChange()
         {
             (
                 GameRoot game,
@@ -233,7 +233,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             Assert.IsNull(game.GetSceneNodeByInstanceID<Regiment>(regiment.InstanceID));
             Assert.AreSame(
@@ -243,7 +243,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_BuildingRemovedBeforeExecution_ReturnsFailed()
+        public void UpdateMission_BuildingRemovedBeforeExecution_ReturnsFailed()
         {
             (
                 GameRoot game,
@@ -274,9 +274,14 @@ namespace Rebellion.Tests.Game.Missions
 
             game.DetachNode(building);
 
-            while (!mission.IsComplete())
-                mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            MovementSystem movement = new MovementSystem(game, fog, new FleetSystem(game));
+            MissionSystem missionSystem = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.0),
+                movement
+            );
+
+            List<GameResult> results = missionSystem.UpdateMission(mission);
 
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().First();
             Assert.AreEqual(
@@ -287,7 +292,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SpecificBuildingTarget_RemovesSelectedBuilding()
+        public void ResolveObjective_SpecificBuildingTarget_RemovesSelectedBuilding()
         {
             (
                 GameRoot game,
@@ -326,7 +331,7 @@ namespace Rebellion.Tests.Game.Missions
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.0));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.0));
 
             Assert.AreEqual(enemyPlanet.InstanceID, mission.LocationInstanceID);
             Assert.AreEqual(
@@ -342,7 +347,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_PlanetDestroyingShip_UsesDedicatedSuccessTable()
+        public void ResolveObjective_PlanetDestroyingShip_UsesDedicatedSuccessTable()
         {
             (
                 GameRoot game,
@@ -378,7 +383,7 @@ namespace Rebellion.Tests.Game.Missions
             game.AttachNode(mission, enemyPlanet);
             mission.Initiate(0);
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.5));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.5));
 
             Assert.AreEqual(
                 MissionOutcome.Success,
@@ -466,7 +471,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void Execute_SuccessfulOfficer_ImprovesEspionageAndCombatRatings()
+        public void ResolveObjective_SuccessfulOfficer_ImprovesEspionageAndCombatRatings()
         {
             (
                 GameRoot game,
@@ -494,7 +499,7 @@ namespace Rebellion.Tests.Game.Missions
             game.AttachNode(mission, enemyPlanet);
             mission.Initiate(0);
 
-            List<GameResult> results = mission.Execute(game, new FixedRNG(0.5));
+            List<GameResult> results = mission.ResolveObjective(game, new FixedRNG(0.5));
 
             Assert.AreEqual(
                 MissionOutcome.Success,

--- a/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
+++ b/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
@@ -405,7 +405,7 @@ public static class MissionSceneBuilder
     {
         while (!mission.IsComplete())
             mission.IncrementProgress();
-        mission.Execute(game, new FixedRNG(0.0));
+        mission.ResolveObjective(game, new FixedRNG(0.0));
     }
 }
 

--- a/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
+++ b/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
@@ -117,6 +117,17 @@ public class FixedRNG : IRandomNumberProvider
 }
 
 /// <summary>
+/// Fails when code unexpectedly requests a random value.
+/// </summary>
+public sealed class ThrowingRNG : IRandomNumberProvider
+{
+    public double NextDouble() => throw new InvalidOperationException("Unexpected random roll.");
+
+    public int NextInt(int min, int max) =>
+        throw new InvalidOperationException("Unexpected random roll.");
+}
+
+/// <summary>
 /// Returns the highest value permitted by each random-number request.
 /// </summary>
 public sealed class MaximumRNG : IRandomNumberProvider
@@ -450,10 +461,9 @@ public static class MissionTestFactory
             MissionTypeID = missionTypeId,
             OwnerInstanceId = ownerInstanceId,
             Location = target,
-            SelectedTarget = selectedTarget,
             MainParticipants = mainParticipants ?? new List<IMissionParticipant>(),
             DecoyParticipants = decoyParticipants ?? new List<IMissionParticipant>(),
-            TargetOfficer = targetOfficer ?? selectedTarget as Officer,
+            SelectedTarget = targetOfficer ?? selectedTarget,
             Discipline = discipline,
         };
 

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -687,14 +687,25 @@ namespace Rebellion.Tests.Managers
 
             Assert.AreEqual(0, game.CurrentTick);
             Assert.IsTrue(planet.IsInUprising);
-            Assert.IsEmpty(game.GetSceneNodesByType<Mission>());
-            Assert.AreSame(planet, diplomat.GetParent());
-            Assert.IsNull(diplomat.Movement);
+            Mission diplomacyMission = game.GetSceneNodesByType<Mission>().Single();
+            Assert.AreSame(diplomacyMission, diplomat.GetParent());
+            Assert.IsNotNull(diplomat.Movement);
             Assert.IsTrue(
                 owner
                     .Messages[MessageType.PopularSupport]
                     .Any(message => message.ResultType == MessageResultType.UprisingStarted)
             );
+
+            diplomat.Movement = null;
+            List<GameResult> missionResults = manager.MissionSystem.ProcessTick();
+
+            Assert.AreEqual(
+                MissionCompletionReason.Failure,
+                missionResults.OfType<MissionCompletedResult>().Single().CompletionReason
+            );
+            Assert.IsEmpty(game.GetSceneNodesByType<Mission>());
+            Assert.AreSame(planet, diplomat.GetParent());
+            Assert.IsNull(diplomat.Movement);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -2314,7 +2314,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void Execute_WithSpecialForcesParticipant_AppearsInParticipants()
+        public void UpdateMission_WithSpecialForcesParticipant_AppearsInParticipants()
         {
             (GameRoot game, Planet planet, Officer officer, MovementSystem movement) = BuildScene(
                 factionOwnsPlanet: true
@@ -2329,12 +2329,13 @@ namespace Rebellion.Tests.Sectors
 
             StubMission mission = new StubMission("empire", planet.InstanceID);
             game.AttachNode(mission, planet);
-            mission.AddChild(sf);
+            game.AttachNode(sf, mission);
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
 
-            List<GameResult> results = mission.Execute(game, new StubRNG());
+            MissionSystem system = TestSystems.CreateMissionSystem(game, new StubRNG(), movement);
+            List<GameResult> results = system.UpdateMission(mission);
             MissionCompletedResult completedResult = results
                 .OfType<MissionCompletedResult>()
                 .First();
@@ -2346,7 +2347,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void Execute_WithDecoyParticipant_DecoyAppearsInParticipants()
+        public void UpdateMission_WithDecoyParticipant_DecoyAppearsInParticipants()
         {
             // Both main and decoy participants should appear in MissionCompletedResult.Participants.
             (GameRoot game, Planet planet, Officer officer, MovementSystem movement) = BuildScene(
@@ -2363,13 +2364,15 @@ namespace Rebellion.Tests.Sectors
 
             StubMission mission = new StubMission("empire", planet.InstanceID);
             game.AttachNode(mission, planet);
-            mission.AddChild(officer);
+            game.MoveNode(officer, mission);
             mission.AddDecoyParticipant(decoy);
+            game.AttachNode(decoy, mission);
 
             while (!mission.IsComplete())
                 mission.IncrementProgress();
 
-            List<GameResult> results = mission.Execute(game, new StubRNG());
+            MissionSystem system = TestSystems.CreateMissionSystem(game, new StubRNG(), movement);
+            List<GameResult> results = system.UpdateMission(mission);
             MissionCompletedResult completedResult = results
                 .OfType<MissionCompletedResult>()
                 .First();

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -246,7 +246,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_DiploBeforeIncite_DiploCanceledAfterUprisingFires()
+        public void UpdateMission_DiploBeforeIncite_DiploAbortsOnNextLifecycleStep()
         {
             (
                 GameRoot game,
@@ -264,16 +264,24 @@ namespace Rebellion.Tests.Sectors
             MissionCompletedResult completed = results.OfType<MissionCompletedResult>().Last();
             Assert.AreEqual(MissionOutcome.Failed, completed.Outcome);
             Assert.IsTrue(results.OfType<PlanetUprisingStartedResult>().Any());
-            Assert.IsNull(diplomacyMission.GetParent());
+            Assert.AreEqual(planet, diplomacyMission.GetParent());
             Assert.IsTrue(planet.IsInUprising);
             Assert.AreEqual(
                 leadershipBefore,
                 participant.GetEffectiveRating(OfficerRating.Leadership)
             );
+
+            List<GameResult> diplomacyResults = missionSystem.UpdateMission(diplomacyMission);
+
+            Assert.AreEqual(
+                MissionCompletionReason.Failure,
+                diplomacyResults.OfType<MissionCompletedResult>().Single().CompletionReason
+            );
+            Assert.IsNull(diplomacyMission.GetParent());
         }
 
         [Test]
-        public void UpdateMission_InciteBeforeDiplo_DiploCanceledImmediately()
+        public void UpdateMission_InciteBeforeDiplo_DiploAbortsWhenAdvanced()
         {
             (
                 GameRoot game,
@@ -285,8 +293,15 @@ namespace Rebellion.Tests.Sectors
             List<GameResult> results = missionSystem.UpdateMission(inciteMission);
 
             Assert.IsTrue(results.OfType<PlanetUprisingStartedResult>().Any());
+            Assert.IsNotNull(diplomacyMission.GetParent());
+
+            List<GameResult> diplomacyResults = missionSystem.UpdateMission(diplomacyMission);
+
+            Assert.AreEqual(
+                MissionCompletionReason.Failure,
+                diplomacyResults.OfType<MissionCompletedResult>().Single().CompletionReason
+            );
             Assert.IsNull(diplomacyMission.GetParent());
-            Assert.IsEmpty(missionSystem.UpdateMission(diplomacyMission));
         }
 
         [Test]
@@ -1706,7 +1721,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void HandleResults_TravellingMissionWithUnavailableTarget_DoesNotResolveBeforeArrival()
+        public void UpdateMission_TargetPlanetDestroyedDuringTravel_WaitsForArrivalThenFails()
         {
             (
                 GameRoot game,
@@ -1716,27 +1731,32 @@ namespace Rebellion.Tests.Sectors
                 Officer target,
                 MissionSystem missions
             ) = BuildOfficerTargetMissionScene(friendlyTarget: false, capturedTarget: false);
-            Planet viewPlanet = new Planet { InstanceID = targetPlanet.InstanceID };
-            Officer viewTarget = EntityFactory.CreateOfficer(target.InstanceID, "rebels");
-            viewTarget.SetParent(viewPlanet);
-            game.DetachNode(target);
             missions.InitiateMission(
                 CreateRequest(
                     MissionTypeIDs.Assassination,
                     participant,
-                    viewPlanet,
-                    selectedTarget: viewTarget
+                    targetPlanet,
+                    selectedTarget: target
                 )
             );
             Mission mission = game.GetSceneNodesByType<Mission>().Single();
+            targetPlanet.IsDestroyed = true;
 
-            List<GameResult> results = missions.HandleResults(
-                new[] { new PlanetUprisingStartedResult { Planet = targetPlanet } }
-            );
+            List<GameResult> travellingResults = missions.UpdateMission(mission);
 
             Assert.IsTrue(participant.Movement != null);
-            Assert.IsEmpty(results);
+            Assert.IsEmpty(travellingResults);
             Assert.AreEqual(mission, game.GetSceneNodesByType<Mission>().Single());
+
+            participant.Movement = null;
+            List<GameResult> arrivalResults = missions.UpdateMission(mission);
+
+            MissionCompletedResult completed = arrivalResults
+                .OfType<MissionCompletedResult>()
+                .Single();
+            Assert.AreEqual(MissionOutcome.Failed, completed.Outcome);
+            Assert.AreEqual(MissionCompletionReason.TargetUnavailable, completed.CompletionReason);
+            Assert.IsEmpty(game.GetSceneNodesByType<Mission>());
         }
 
         [Test]
@@ -1916,7 +1936,6 @@ namespace Rebellion.Tests.Sectors
 
             StubMission mission = CreateMission(game, planet, officer);
 
-            mission.OriginInstanceID = ship.InstanceID;
             officer.MissionReturnParentInstanceID = ship.InstanceID;
             officer.MissionReturnLocationInstanceID = planet.InstanceID;
             game.DetachNode(officer);
@@ -2007,7 +2026,6 @@ namespace Rebellion.Tests.Sectors
             game.AttachNode(officer, ship);
 
             StubMission mission = CreateMission(game, planetA, officer);
-            mission.OriginInstanceID = ship.InstanceID;
             officer.MissionReturnParentInstanceID = ship.InstanceID;
             officer.MissionReturnLocationInstanceID = planetA.InstanceID;
             game.DetachNode(officer);
@@ -2369,7 +2387,6 @@ namespace Rebellion.Tests.Sectors
                 factionOwnsPlanet: true
             );
             StubMission mission = CreateMission(game, planet, officer);
-            mission.OriginInstanceID = planet.InstanceID;
             game.MoveNode(officer, mission);
             mission.Initiate(1);
             MissionSystem system = TestSystems.CreateMissionSystem(game, new StubRNG(), movement);
@@ -3172,9 +3189,8 @@ namespace Rebellion.Tests.Sectors
             {
                 MissionTypeID = missionTypeId,
                 Location = target,
-                TargetOfficer = targetOfficer,
                 Discipline = discipline,
-                SelectedTarget = selectedTarget,
+                SelectedTarget = targetOfficer ?? selectedTarget,
                 MainParticipants = mainParticipants,
                 DecoyParticipants = decoyParticipants,
             };

--- a/Assets/Tests/EditMode/GameTests/Systems/PlanetaryControlSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/PlanetaryControlSystemTests.cs
@@ -217,7 +217,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void TransferPlanet_PlanetWithActiveMissions_CancelsCompetingMissions()
+        public void TransferPlanet_PlanetWithActiveMissions_PreservesMissionsForLifecycleValidation()
         {
             StubMission empireMission = EntityFactory.CreateMission(
                 "m1",
@@ -228,11 +228,11 @@ namespace Rebellion.Tests.Systems
 
             _ownershipSystem.TransferPlanet(_targetPlanet, _rebels);
 
-            Assert.IsNull(empireMission.GetParent(), "Competing mission should be detached");
+            Assert.AreEqual(_targetPlanet, empireMission.GetParent());
         }
 
         [Test]
-        public void TransferPlanet_PlanetWithCanceledMission_ReturnsParticipants()
+        public void TransferPlanet_PlanetWithActiveMission_DoesNotMoveMissionParticipants()
         {
             _game.ChangeOwnership(_targetPlanet, "empire");
 
@@ -245,15 +245,12 @@ namespace Rebellion.Tests.Systems
                 _targetPlanet.InstanceID
             );
             _game.AttachNode(empireMission, _targetPlanet);
-            empireMission.AddChild(officer);
+            _game.MoveNode(officer, empireMission);
 
             _ownershipSystem.TransferPlanet(_targetPlanet, _rebels);
 
-            Assert.IsNotNull(
-                officer.Movement,
-                "Participant should be in transit after mission canceled"
-            );
-            Assert.AreEqual(_empirePlanet, officer.GetParentOfType<Planet>());
+            Assert.IsNull(officer.Movement);
+            Assert.AreEqual(empireMission, officer.GetParent());
         }
 
         [Test]
@@ -295,24 +292,6 @@ namespace Rebellion.Tests.Systems
 
             Assert.AreEqual(_targetPlanet, diplomacyMission.GetParent());
             Assert.IsTrue(diplomacyMission.ShouldRepeatAfterCompletion(_game));
-        }
-
-        [Test]
-        public void TransferPlanet_PlanetWithUncancelableMissions_PreservesThem()
-        {
-            UncancelableMission mission = new UncancelableMission(
-                "empire",
-                _targetPlanet.InstanceID
-            );
-            mission.InstanceID = "m1";
-            _game.AttachNode(mission, _targetPlanet);
-
-            _ownershipSystem.TransferPlanet(_targetPlanet, _rebels);
-
-            Assert.IsNotNull(
-                mission.GetParent(),
-                "Mission with CanceledOnOwnershipChange=false should survive"
-            );
         }
 
         [Test]
@@ -544,7 +523,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ClearPlanetOwnership_ActiveDiplomacyMission_CancelsMission()
+        public void ClearPlanetOwnership_ActiveDiplomacyMission_PreservesMission()
         {
             _game.ChangeOwnership(_targetPlanet, _rebels.InstanceID);
             _targetPlanet.PopularSupport = new Dictionary<string, int>
@@ -552,16 +531,6 @@ namespace Rebellion.Tests.Systems
                 { _rebels.InstanceID, 70 },
             };
             _targetPlanet.AddVisitor(_rebels.InstanceID);
-
-            Planet returnPlanet = new Planet
-            {
-                InstanceID = "rebel-home",
-                OwnerInstanceID = _rebels.InstanceID,
-                IsColonized = true,
-                PositionX = 200,
-                PositionY = 0,
-            };
-            _game.AttachNode(returnPlanet, _targetPlanet.GetParent());
 
             Officer officer = EntityFactory.CreateOfficer("diplomat", _rebels.InstanceID);
             Mission diplomacyMission = MissionTestFactory.TryCreate(
@@ -577,9 +546,9 @@ namespace Rebellion.Tests.Systems
 
             _ownershipSystem.ClearPlanetOwnership(_targetPlanet);
 
-            Assert.IsNull(diplomacyMission.GetParent());
-            Assert.IsNotNull(officer.Movement);
-            Assert.AreSame(returnPlanet, officer.GetParent());
+            Assert.AreSame(_targetPlanet, diplomacyMission.GetParent());
+            Assert.IsNull(officer.Movement);
+            Assert.AreSame(diplomacyMission, officer.GetParent());
         }
 
         [Test]
@@ -667,7 +636,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void HandleResults_LastStationedRegiment_CancelsFormerOwnerDiplomacyMission()
+        public void HandleResults_LastStationedRegiment_PreservesMissionForLifecycleValidation()
         {
             _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
             _targetPlanet.PopularSupport = new Dictionary<string, int>
@@ -711,9 +680,9 @@ namespace Rebellion.Tests.Systems
             );
 
             Assert.AreEqual(_rebels.InstanceID, _targetPlanet.GetOwnerInstanceID());
-            Assert.IsNull(diplomacyMission.GetParent());
-            Assert.IsNotNull(officer.Movement);
-            Assert.AreSame(_empirePlanet, officer.GetParent());
+            Assert.AreSame(_targetPlanet, diplomacyMission.GetParent());
+            Assert.IsNull(officer.Movement);
+            Assert.AreSame(diplomacyMission, officer.GetParent());
         }
 
         [Test]
@@ -1066,14 +1035,6 @@ namespace Rebellion.Tests.Systems
         {
             PlanetSector planetSector = planet.GetParentOfType<PlanetSector>();
             return faction.Fog.Snapshots[planetSector.InstanceID].Planets[planet.InstanceID];
-        }
-
-        private class UncancelableMission : StubMission
-        {
-            public UncancelableMission(string ownerInstanceId, string locationInstanceId)
-                : base(ownerInstanceId, locationInstanceId) { }
-
-            public override bool CanceledOnOwnershipChange => false;
         }
     }
 }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/MainMenu/MainMenuViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/MainMenu/MainMenuViewTests.cs
@@ -138,6 +138,26 @@ namespace Rebellion.Tests.UI.SceneUI.MainMenu
         }
 
         /// <summary>
+        /// Verifies the planet rig composites its authored day/night terminator after other layers.
+        /// </summary>
+        [Test]
+        public void AuthoredPrefab_PlanetRig_UsesDayNightShade()
+        {
+            Transform shade = _prefabRoot.transform.Find("PlanetRig/DayNightShade");
+            Assert.IsNotNull(shade);
+            Assert.AreEqual(Vector3.one * 2.04f, shade.localScale);
+
+            RuntimeMaterialBinding binding = shade.GetComponent<RuntimeMaterialBinding>();
+            Assert.IsNotNull(binding);
+            Assert.AreEqual(
+                "Custom/PlanetDayNightShade",
+                typeof(RuntimeMaterialBinding)
+                    .GetField("shaderName", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(binding)
+            );
+        }
+
+        /// <summary>
         /// Verifies the view exclusively controls Options overlay visibility.
         /// </summary>
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsMenuViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsMenuViewTests.cs
@@ -130,6 +130,35 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
         }
 
         /// <summary>
+        /// Verifies Awake permits content-backed sprites to be restored after instantiation.
+        /// </summary>
+        [Test]
+        public void Awake_ContentNotInitialized_DoesNotThrow()
+        {
+            GameObject root = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            try
+            {
+                OptionsMenuView view = root.GetComponent<OptionsMenuView>();
+                OptionsSaveListView saveListView = root.GetComponentInChildren<OptionsSaveListView>(
+                    true
+                );
+                SetField(view, "_rowIdleSprite", null);
+                SetField(view, "_rowActiveSprite", null);
+                SetField(saveListView, "_rowIdleSprite", null);
+                SetField(saveListView, "_rowActiveSprite", null);
+
+                Assert.DoesNotThrow(() =>
+                    UIComponentTestHelper.InvokeLifecycle(saveListView, "Awake")
+                );
+                Assert.DoesNotThrow(() => UIComponentTestHelper.InvokeLifecycle(view, "Awake"));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        /// <summary>
         /// Verifies entering Save/Load starts at the top without pinning later renders there.
         /// </summary>
         [Test]
@@ -729,6 +758,14 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 typeof(OptionsMenuView)
                     .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(_view);
+        }
+
+        private static void SetField(object target, string fieldName, object value)
+        {
+            target
+                .GetType()
+                .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(target, value);
         }
 
         /// <summary>

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsSettingsSessionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsSettingsSessionTests.cs
@@ -12,6 +12,9 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
     {
         private AudioManager _audioManager;
         private DisplayManager _displayManager;
+        private int _displayApplicationCount;
+        private Vector2Int _appliedResolution;
+        private FullScreenMode _appliedFullScreenMode;
         private GameObject _inputRoot;
         private InputManager _inputManager;
         private string _settingsPath;
@@ -31,7 +34,12 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 () =>
                     new List<Vector2Int> { new Vector2Int(1280, 720), new Vector2Int(1920, 1080) },
                 () => new Vector2Int(1920, 1080),
-                (_, _, _) => { }
+                (width, height, mode) =>
+                {
+                    _displayApplicationCount++;
+                    _appliedResolution = new Vector2Int(width, height);
+                    _appliedFullScreenMode = mode;
+                }
             );
             _settingsPath = Path.Combine(
                 Path.GetTempPath(),
@@ -51,6 +59,7 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 _inputManager
             );
             _session.Begin();
+            _displayApplicationCount = 0;
         }
 
         /// <summary>
@@ -100,6 +109,30 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
             Assert.IsTrue(_session.IsDirty);
             _session.ToggleTactical(UserTacticalOption.Starfield);
             Assert.IsFalse(_session.IsDirty);
+        }
+
+        /// <summary>
+        /// Verifies display selections remain staged until the settings session is committed.
+        /// </summary>
+        [Test]
+        public void DisplayChanges_ApplyOnlyWhenCommitted()
+        {
+            _session.StepResolution(-1);
+            _session.StepFullScreen(1);
+
+            Assert.AreEqual(0, _displayApplicationCount);
+
+            _session.Revert();
+
+            Assert.AreEqual(0, _displayApplicationCount);
+
+            _session.StepResolution(-1);
+            _session.StepFullScreen(1);
+            _session.Commit();
+
+            Assert.AreEqual(1, _displayApplicationCount);
+            Assert.AreEqual(new Vector2Int(1280, 720), _appliedResolution);
+            Assert.AreEqual(FullScreenMode.FullScreenWindow, _appliedFullScreenMode);
         }
 
         /// <summary>

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowProjectorTests.cs
@@ -255,7 +255,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
                 DisplayName = "Recruitment Mission",
                 OwnerInstanceID = _playerFactionId,
                 LocationInstanceID = _planet.Planet.InstanceID,
-                TargetOfficerInstanceID = _target.InstanceID,
+                RecruitedOfficerInstanceID = _target.InstanceID,
             };
             mission.AddChild(CreateOfficer("recruiter", "Recruiter", false));
             _planet.Planet.RemoveChildren<Mission>(_ => true);

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Status/StrategyStatusInfoBuilderTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Status/StrategyStatusInfoBuilderTests.cs
@@ -890,7 +890,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Status
                 DisplayName = "Recruitment Mission",
                 OwnerInstanceID = _ownerId,
                 LocationInstanceID = _planet.InstanceID,
-                TargetOfficerInstanceID = recruitedOfficer.InstanceID,
+                RecruitedOfficerInstanceID = recruitedOfficer.InstanceID,
             };
             _game.AttachNode(mission, _planet);
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Targeting/StrategyMissionTargetTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Targeting/StrategyMissionTargetTests.cs
@@ -132,39 +132,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Targeting
             Assert.IsNull(locationTarget);
         }
 
-        [TestCase(MissionTypeIDs.Abduction)]
-        [TestCase(MissionTypeIDs.Assassination)]
-        [TestCase(MissionTypeIDs.Rescue)]
-        public void GetMissionTargetOfficer_OfficerDirectedMission_ReturnsOfficer(
-            string missionTypeId
-        )
-        {
-            Officer officer = new Officer();
-            StrategyMissionTarget target = new StrategyMissionTarget(null, officer);
-
-            Officer missionOfficer = target.GetMissionTargetOfficer(missionTypeId);
-
-            Assert.AreSame(officer, missionOfficer);
-        }
-
-        [Test]
-        public void GetMissionTargetOfficer_NonOfficerItemOrMission_ReturnsNull()
-        {
-            StrategyMissionTarget nonOfficer = new StrategyMissionTarget(null, new SpecialForces());
-            StrategyMissionTarget nonOfficerMission = new StrategyMissionTarget(
-                null,
-                new Officer()
-            );
-
-            Officer wrongItem = nonOfficer.GetMissionTargetOfficer(MissionTypeIDs.Abduction);
-            Officer wrongMission = nonOfficerMission.GetMissionTargetOfficer(
-                MissionTypeIDs.Sabotage
-            );
-
-            Assert.IsNull(wrongItem);
-            Assert.IsNull(wrongMission);
-        }
-
         private static GalaxyMapPlanet CreateMapPlanet(string instanceId, string ownerId)
         {
             Planet planet = new Planet { InstanceID = instanceId, OwnerInstanceID = ownerId };

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -34,6 +34,7 @@ GraphicsSettings:
   - {fileID: 15104, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 15105, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 15106, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 10750, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10783, guid: 0000000000000000f000000000000000, type: 0}
@@ -41,6 +42,8 @@ GraphicsSettings:
   - {fileID: 4800000, guid: f853aafa0bc764a138f572608a37a73c, type: 3}
   - {fileID: 4800000, guid: 4340a3cf1cde6416d957808a6ac79eed, type: 3}
   - {fileID: 4800000, guid: 82139792283fbb749823837b1a28e5e0, type: 3}
+  - {fileID: 4800000, guid: 1c49192d230a4330a900eb2c73db4cc7, type: 3}
+  - {fileID: 4800000, guid: 8081047f7041463c9648031eee9666ce, type: 3}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
   m_CustomRenderPipeline: {fileID: 0}


### PR DESCRIPTION
## Summary
- centralize mission target invalidation in the mission lifecycle and evaluate it after participants arrive
- remove ownership/result-system mission cancellation coupling
- centralize participant rating improvements while preserving mission-specific mechanics and RNG ordering
- make Recruitment explicitly planet-targeted and store the recruited officer only as its successful outcome
- remove redundant mission request/context state, dead origin state, and redundant UI target resolution
- give missions independent participant-list containers without cloning live participants
- stage resolution and display-mode changes until Apply is selected
- allow content-backed Options views to initialize correctly in standalone builds
- add the main-menu planet day/night terminator and correct cloud polar/alpha rendering

## Behavior
- unavailable or destroyed mission targets terminate before detection, success rolls, or participant improvement
- traveling missions remain intact until arrival before target validity is evaluated
- valid missions retain their existing probability, improvement, repeat, and teardown behavior
- invalid mission completions cannot repeat
- changing resolution or display mode no longer affects the game before Apply
- the main-menu planet retains opaque coverage while clouds drift without polar artifacts

## Verification
- focused EditMode coverage accompanies mission lifecycle, Options staging, standalone initialization, and planet-rig composition changes
- GitHub CI runs lint, EditMode tests, and the standalone player build