### PR TITLE
Fixing issue where captured units can reveal fog of war.

### DIFF
--- a/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs
@@ -140,7 +140,6 @@ public static class OptionsMenuPrefabBuilder
         header.color = textColor;
         header.fontSize = 22;
         header.alignment = TextAlignmentOptions.Midline;
-        ApplyOptionsDisplayFont(header);
         SetSourceRect(header.rectTransform, 41, 32, 155, 26);
 
         TextMeshProUGUI pageTitle = CreateTextLabel("PageTitleTextField", contentRoot);
@@ -148,7 +147,6 @@ public static class OptionsMenuPrefabBuilder
         pageTitle.color = accent;
         pageTitle.fontSize = 14;
         pageTitle.alignment = TextAlignmentOptions.Midline;
-        ApplyOptionsDisplayFont(pageTitle);
         SetSourceRect(pageTitle.rectTransform, 240, 36, 357, 22);
 
         BuildTabNavigation(view, contentRoot, textColor);
@@ -254,7 +252,6 @@ public static class OptionsMenuPrefabBuilder
             tabLabel.color = textColor;
             tabLabel.fontSize = 13;
             tabLabel.alignment = TextAlignmentOptions.MidlineLeft;
-            ApplyOptionsDisplayFont(tabLabel);
             SetSourceRect(tabLabel.rectTransform, 14, 5, 140, 20);
             tabLabels[i] = tabLabel;
         }
@@ -573,7 +570,6 @@ public static class OptionsMenuPrefabBuilder
         slotNameTemplate.textWrappingMode = TextWrappingModes.NoWrap;
         slotNameTemplate.overflowMode = TextOverflowModes.Truncate;
         slotNameTemplate.raycastTarget = false;
-        ApplyOptionsDisplayFont(slotNameTemplate);
         SetSourceRect(slotNameTemplate.rectTransform, 34, 0, 271, 20);
         slotNameTemplate.gameObject.SetActive(false);
         TextMeshProUGUI slotMetaTemplate = CreateTextLabel("SlotDateTemplate", slotContent);
@@ -700,7 +696,6 @@ public static class OptionsMenuPrefabBuilder
         primaryColumnHeader.color = textDim;
         primaryColumnHeader.fontSize = 9;
         primaryColumnHeader.alignment = TextAlignmentOptions.Midline;
-        ApplyOptionsDisplayFont(primaryColumnHeader);
         SetSourceRect(primaryColumnHeader.rectTransform, 208, 2, 57, 12);
         TextMeshProUGUI secondaryColumnHeader = CreateTextLabel(
             "SecondaryColumnHeader",
@@ -710,7 +705,6 @@ public static class OptionsMenuPrefabBuilder
         secondaryColumnHeader.color = textDim;
         secondaryColumnHeader.fontSize = 9;
         secondaryColumnHeader.alignment = TextAlignmentOptions.Midline;
-        ApplyOptionsDisplayFont(secondaryColumnHeader);
         SetSourceRect(secondaryColumnHeader.rectTransform, 269, 2, 57, 12);
 
         Image bindingRowTemplate = CreateSlicedImage(
@@ -733,7 +727,6 @@ public static class OptionsMenuPrefabBuilder
         bindingHeaderTemplate.color = accent;
         bindingHeaderTemplate.fontSize = 12;
         bindingHeaderTemplate.alignment = TextAlignmentOptions.TopLeft;
-        ApplyOptionsDisplayFont(bindingHeaderTemplate);
         SetSourceRect(bindingHeaderTemplate.rectTransform, 0, 0, 220, 16);
         bindingHeaderTemplate.gameObject.SetActive(false);
         TextMeshProUGUI bindingActionTemplate = CreateTextLabel(
@@ -977,19 +970,6 @@ public static class OptionsMenuPrefabBuilder
     }
 
     /// <summary>
-    /// Applies the Options menu font.
-    /// </summary>
-    /// <param name="text">The text field to restyle.</param>
-    private static void ApplyOptionsDisplayFont(TextMeshProUGUI text)
-    {
-        TMP_FontAsset font = AssetDatabase.LoadAssetAtPath<TMP_FontAsset>(
-            "Assets/TextMesh Pro/Examples & Extras/Resources/Fonts & Materials/Oswald Bold SDF.asset"
-        );
-        if (font != null)
-            text.font = font;
-    }
-
-    /// <summary>
     /// Creates an Options menu section header.
     /// </summary>
     /// <param name="parent">The page container.</param>
@@ -1011,7 +991,6 @@ public static class OptionsMenuPrefabBuilder
         headerField.color = accent;
         headerField.fontSize = 13;
         headerField.alignment = TextAlignmentOptions.MidlineLeft;
-        ApplyOptionsDisplayFont(headerField);
         SetSourceRect(headerField.rectTransform, 20, y, 200, 16);
         return headerField;
     }
@@ -1049,10 +1028,9 @@ public static class OptionsMenuPrefabBuilder
         TextMeshProUGUI text = CreateTextLabel("Label", button.transform);
         text.text = label;
         text.color = color;
-        text.fontSize = 13;
+        text.fontSize = 12;
         text.alignment = TextAlignmentOptions.MidlineLeft;
-        ApplyOptionsDisplayFont(text);
-        SetSourceRect(text.rectTransform, 14, 5, 140, 20);
+        SetSourceRect(text.rectTransform, 10, 5, 148, 20);
         ApplyOptionsSurfaceButtonFeedback(button, surface);
         AddOptionsButtonBorder(buttonFrame);
         return button;
@@ -1131,7 +1109,6 @@ public static class OptionsMenuPrefabBuilder
         text.color = color;
         text.fontSize = 11;
         text.alignment = TextAlignmentOptions.Midline;
-        ApplyOptionsDisplayFont(text);
         SetSourceRect(text.rectTransform, 0, 4, width, 14);
         ApplyOptionsSurfaceButtonFeedback(button, surface);
         AddOptionsButtonBorder(buttonFrame);

--- a/Assets/Scripts/Game/Messages/MessageFactory.cs
+++ b/Assets/Scripts/Game/Messages/MessageFactory.cs
@@ -1706,7 +1706,9 @@ namespace Rebellion.Game.Messages
                 .ToHashSet();
             UnitArrivedResult[] arrivalResults = arrivals
                 .Where(arrival =>
-                    arrival?.Unit != null && !deployedUnitIds.Contains(arrival.Unit.GetInstanceID())
+                    arrival?.Unit != null
+                    && arrival.Unit is not Officer { IsCaptured: true }
+                    && !deployedUnitIds.Contains(arrival.Unit.GetInstanceID())
                 )
                 .ToArray();
             var shipGroups =

--- a/Assets/Scripts/Systems/FogOfWarSystem.cs
+++ b/Assets/Scripts/Systems/FogOfWarSystem.cs
@@ -167,11 +167,11 @@ namespace Rebellion.Systems
                     else if (planetSnapshot != null)
                     {
                         viewPlanet = BlankPlanetView(masterPlanet);
-                        ApplySnapshotView(viewPlanet, masterPlanet, faction, planetSnapshot);
+                        ApplySnapshotView(viewPlanet, planetSnapshot);
                     }
                     else
                     {
-                        viewPlanet = UnexploredPlanetView(masterPlanet, faction);
+                        viewPlanet = UnexploredPlanetView(masterPlanet);
                     }
 
                     viewPlanet.VisitingFactionIDs = masterPlanet.WasVisitedBy(faction.InstanceID)
@@ -473,19 +473,11 @@ namespace Rebellion.Systems
 
         /// <summary>
         /// Populates a view planet from the last known snapshot. The faction has no current
-        /// visibility but has previously observed this planet. Captured friendly officers are
-        /// always live.
+        /// visibility but has previously observed this planet.
         /// </summary>
         /// <param name="viewPlanet">The view planet to populate.</param>
-        /// <param name="masterPlanet">The authoritative planet data source.</param>
-        /// <param name="faction">The faction whose view is being built.</param>
         /// <param name="planetSnapshot">The prior snapshot for the planet.</param>
-        private void ApplySnapshotView(
-            Planet viewPlanet,
-            Planet masterPlanet,
-            Faction faction,
-            PlanetSnapshot planetSnapshot
-        )
+        private void ApplySnapshotView(Planet viewPlanet, PlanetSnapshot planetSnapshot)
         {
             viewPlanet.OwnerInstanceID = planetSnapshot.OwnerInstanceID;
             viewPlanet.IsColonized = planetSnapshot.IsColonized;
@@ -498,17 +490,9 @@ namespace Rebellion.Systems
 
             viewPlanet.PopularSupport = new Dictionary<string, int>(planetSnapshot.PopularSupport);
 
-            IEnumerable<Officer> officers = planetSnapshot
-                .Officers.Select(FogOfWarRecorder.CopyOfficerForSnapshot)
-                .Concat(
-                    masterPlanet
-                        .GetChildren<Officer>()
-                        .Where(o => o.IsCaptured && o.OwnerInstanceID == faction.InstanceID)
-                        .Select(FogOfWarRecorder.CopyOfficerForSnapshot)
-                );
             viewPlanet.SetChildren(
                 planetSnapshot.Fleets.Select(FogOfWarRecorder.CopyFleetForSnapshot),
-                officers,
+                planetSnapshot.Officers.Select(FogOfWarRecorder.CopyOfficerForSnapshot),
                 planetSnapshot.Regiments.Select(FogOfWarRecorder.CopyEntityForSnapshot),
                 planetSnapshot.SpecialForces.Select(FogOfWarRecorder.CopyEntityForSnapshot),
                 planetSnapshot.Starfighters.Select(FogOfWarRecorder.CopyEntityForSnapshot),
@@ -627,12 +611,11 @@ namespace Rebellion.Systems
 
         /// <summary>
         /// Creates a view planet for a completely unexplored location. No ownership or
-        /// entity data is surfaced. Captured friendly officers remain visible.
+        /// entity data is surfaced.
         /// </summary>
         /// <param name="masterPlanet">The authoritative planet data source.</param>
-        /// <param name="faction">The faction whose view is being built.</param>
         /// <returns>A planet view containing only the data visible for an unexplored planet.</returns>
-        private Planet UnexploredPlanetView(Planet masterPlanet, Faction faction)
+        private Planet UnexploredPlanetView(Planet masterPlanet)
         {
             Planet viewPlanet = new Planet
             {
@@ -647,10 +630,7 @@ namespace Rebellion.Systems
 
             viewPlanet.SetChildren(
                 Enumerable.Empty<Fleet>(),
-                masterPlanet
-                    .GetChildren<Officer>()
-                    .Where(o => o.IsCaptured && o.OwnerInstanceID == faction.InstanceID)
-                    .Select(FogOfWarRecorder.CopyOfficerForSnapshot),
+                Enumerable.Empty<Officer>(),
                 Enumerable.Empty<Regiment>(),
                 Enumerable.Empty<SpecialForces>(),
                 Enumerable.Empty<Starfighter>(),

--- a/Assets/Scripts/UI/Runtime/Themes/FactionTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/FactionTheme.cs
@@ -12,8 +12,6 @@ public class FactionTheme
 
     public string FactionPrimaryColorHex { get; set; }
 
-    public MainMenuFactionTheme MainMenu { get; set; }
-
     public BattleParticipantTheme BattleParticipant { get; set; }
 
     public bool UseUpperButtonLayout { get; set; }
@@ -86,23 +84,3 @@ public class FactionTheme
 /// </summary>
 [PersistableObject]
 public sealed class FactionThemes : List<FactionTheme> { }
-
-[PersistableObject]
-public sealed class MainMenuFactionTheme
-{
-    public string LaunchAnimationRoot { get; set; }
-
-    public int LaunchAnimationFrameCount { get; set; }
-
-    public float LaunchAnimationFrameIntervalSeconds { get; set; }
-
-    /// <summary>
-    /// Builds the content address for one configured launch-animation frame.
-    /// </summary>
-    /// <param name="frameIndex">The one-based animation frame index.</param>
-    /// <returns>The animation frame content address.</returns>
-    public string GetLaunchAnimationFramePath(int frameIndex)
-    {
-        return $"{LaunchAnimationRoot}/frame-{frameIndex:D3}";
-    }
-}

--- a/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
@@ -94,14 +94,7 @@ public sealed class MainMenuController : MonoBehaviour
             ContentPack contentPack = bootstrap.GetContentPack();
             view?.InitializeContent(bootstrap.GetContentAssets());
             view?.RenderVictoryCondition(currentVictoryCondition);
-            FactionThemeLibrary themeLibrary = new FactionThemeLibrary(
-                contentPack.GameData.FactionThemes
-            );
-            view?.RenderFactions(
-                contentPack.Scenario.PlayableFactionIDs,
-                themeLibrary.GetTheme,
-                bootstrap.GetContentAssets().GetTexture
-            );
+            view?.RenderFactions(contentPack.Scenario.PlayableFactionIDs);
             AudioManager audioManager = bootstrap.GetAudioManager();
             audioManager.PreloadSfx(view?.GetAudioCuePaths());
             audioManager.PlayTrack(_menuMusicPath, true);

--- a/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuView.cs
+++ b/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuView.cs
@@ -81,36 +81,18 @@ public sealed class MainMenuView : MonoBehaviour
 
         public string FactionId => factionId;
 
-        public Image Image => button?.targetGraphic as Image;
-
-        public Sprite[] Frames { get; private set; } = Array.Empty<Sprite>();
-
-        public float FrameIntervalSeconds { get; private set; }
-
-        public int FrameIndex { get; set; }
-
-        public float FrameElapsedSeconds { get; set; }
-
         /// <summary>
         /// Gets whether the binding has a button and faction identifier.
         /// </summary>
         public bool IsConfigured => button != null && !string.IsNullOrWhiteSpace(factionId);
 
         /// <summary>
-        /// Applies a faction identifier and loaded launch-animation frames to this binding.
+        /// Applies a faction identifier to this binding.
         /// </summary>
         /// <param name="id">The configured faction identifier.</param>
-        /// <param name="frames">The loaded launch-animation sprites.</param>
-        /// <param name="frameIntervalSeconds">The elapsed time between animation frames.</param>
-        public void Configure(string id, Sprite[] frames, float frameIntervalSeconds)
+        public void Configure(string id)
         {
             factionId = id;
-            Frames = Image == null ? Array.Empty<Sprite>() : frames ?? Array.Empty<Sprite>();
-            FrameIntervalSeconds = frameIntervalSeconds;
-            FrameIndex = 0;
-            FrameElapsedSeconds = 0f;
-            if (Image != null && Frames.Length > 0)
-                Image.sprite = Frames[0];
         }
     }
 
@@ -204,7 +186,6 @@ public sealed class MainMenuView : MonoBehaviour
     private UIWindowManager optionsWindowManager;
 
     private readonly List<Action> removeControlListeners = new List<Action>();
-    private readonly List<Sprite> ownedFactionSprites = new List<Sprite>();
     private Sprite[] exitAnimationFrames = Array.Empty<Sprite>();
     private Sprite[] loadAnimationFrames = Array.Empty<Sprite>();
     private int exitAnimationFrameIndex;
@@ -264,7 +245,7 @@ public sealed class MainMenuView : MonoBehaviour
     public event Action<string> AudioCueRequested;
 
     /// <summary>
-    /// Advances every active faction launch animation.
+    /// Advances the animated command buttons.
     /// </summary>
     private void Update()
     {
@@ -284,22 +265,6 @@ public sealed class MainMenuView : MonoBehaviour
             ref loadAnimationElapsedSeconds,
             Time.unscaledDeltaTime
         );
-        foreach (FactionLaunchBinding binding in factionLaunchBindings)
-            AdvanceFactionAnimation(binding, Time.unscaledDeltaTime);
-    }
-
-    /// <summary>
-    /// Releases sprites created from external content textures.
-    /// </summary>
-    private void OnDestroy()
-    {
-        foreach (Sprite sprite in ownedFactionSprites)
-        {
-            if (sprite != null)
-                Destroy(sprite);
-        }
-
-        ownedFactionSprites.Clear();
     }
 
     /// <summary>
@@ -408,20 +373,10 @@ public sealed class MainMenuView : MonoBehaviour
     /// Populates the authored launch positions from the active scenario's playable factions.
     /// </summary>
     /// <param name="factionIDs">The playable faction identifiers in display order.</param>
-    /// <param name="getTheme">The active faction-theme resolver.</param>
-    /// <param name="getTexture">The active content texture resolver.</param>
-    internal void RenderFactions(
-        IReadOnlyList<string> factionIDs,
-        Func<string, FactionTheme> getTheme,
-        Func<string, Texture2D> getTexture
-    )
+    internal void RenderFactions(IReadOnlyList<string> factionIDs)
     {
         if (factionIDs == null)
             throw new ArgumentNullException(nameof(factionIDs));
-        if (getTheme == null)
-            throw new ArgumentNullException(nameof(getTheme));
-        if (getTexture == null)
-            throw new ArgumentNullException(nameof(getTexture));
         if (factionIDs.Count > factionLaunchBindings.Length)
         {
             throw new InvalidOperationException(
@@ -430,7 +385,6 @@ public sealed class MainMenuView : MonoBehaviour
             );
         }
 
-        ClearFactionSprites();
         for (int index = 0; index < factionLaunchBindings.Length; index++)
         {
             FactionLaunchBinding binding = factionLaunchBindings[index];
@@ -439,17 +393,7 @@ public sealed class MainMenuView : MonoBehaviour
             if (!active)
                 continue;
 
-            string factionID = factionIDs[index];
-            MainMenuFactionTheme mainMenuTheme =
-                getTheme(factionID)?.MainMenu
-                ?? throw new InvalidOperationException(
-                    $"Faction '{factionID}' has no main-menu theme."
-                );
-            Sprite[] frames =
-                binding.Image == null
-                    ? Array.Empty<Sprite>()
-                    : LoadFactionAnimationFrames(mainMenuTheme, getTexture);
-            binding.Configure(factionID, frames, mainMenuTheme.LaunchAnimationFrameIntervalSeconds);
+            binding.Configure(factionIDs[index]);
         }
     }
 
@@ -583,85 +527,6 @@ public sealed class MainMenuView : MonoBehaviour
         }
 
         image.sprite = frames[frameIndex];
-    }
-
-    /// <summary>
-    /// Loads and converts every configured launch-animation texture to a sprite.
-    /// </summary>
-    /// <param name="theme">The faction's main-menu theme.</param>
-    /// <param name="getTexture">The active content texture resolver.</param>
-    /// <returns>The created launch-animation sprites.</returns>
-    private Sprite[] LoadFactionAnimationFrames(
-        MainMenuFactionTheme theme,
-        Func<string, Texture2D> getTexture
-    )
-    {
-        if (
-            string.IsNullOrWhiteSpace(theme.LaunchAnimationRoot)
-            || theme.LaunchAnimationFrameCount <= 0
-            || theme.LaunchAnimationFrameIntervalSeconds <= 0f
-        )
-            throw new InvalidOperationException("A main-menu faction animation is incomplete.");
-
-        Sprite[] frames = new Sprite[theme.LaunchAnimationFrameCount];
-        for (int index = 0; index < frames.Length; index++)
-        {
-            string path = theme.GetLaunchAnimationFramePath(index + 1);
-            Texture2D texture =
-                getTexture(path)
-                ?? throw new InvalidOperationException(
-                    $"Main-menu faction animation frame is missing: {path}"
-                );
-            Sprite sprite = Sprite.Create(
-                texture,
-                new Rect(0f, 0f, texture.width, texture.height),
-                new Vector2(0.5f, 0.5f),
-                100f
-            );
-            sprite.name = texture.name;
-            frames[index] = sprite;
-            ownedFactionSprites.Add(sprite);
-        }
-
-        return frames;
-    }
-
-    /// <summary>
-    /// Releases every faction launch sprite currently owned by this view.
-    /// </summary>
-    private void ClearFactionSprites()
-    {
-        foreach (Sprite sprite in ownedFactionSprites)
-        {
-            if (sprite != null)
-                Destroy(sprite);
-        }
-
-        ownedFactionSprites.Clear();
-    }
-
-    /// <summary>
-    /// Advances one faction launch animation by elapsed unscaled time.
-    /// </summary>
-    /// <param name="binding">The configured faction launch binding.</param>
-    /// <param name="elapsedSeconds">The elapsed unscaled frame time.</param>
-    private static void AdvanceFactionAnimation(FactionLaunchBinding binding, float elapsedSeconds)
-    {
-        if (
-            binding?.Image == null
-            || binding.Frames?.Length < 2
-            || binding.FrameIntervalSeconds <= 0f
-        )
-            return;
-
-        binding.FrameElapsedSeconds += elapsedSeconds;
-        while (binding.FrameElapsedSeconds >= binding.FrameIntervalSeconds)
-        {
-            binding.FrameElapsedSeconds -= binding.FrameIntervalSeconds;
-            binding.FrameIndex = (binding.FrameIndex + 1) % binding.Frames.Length;
-        }
-
-        binding.Image.sprite = binding.Frames[binding.FrameIndex];
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Status/StatusWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Status/StatusWindowController.cs
@@ -326,8 +326,6 @@ public sealed class StatusWindowController
             textures.Add(uiContext.GetTexture(GetImageThemePath(theme, image)));
         foreach (ISceneNode item in info.ImageItems)
             textures.Add(GetPrimaryImageTexture(uiContext, item));
-        foreach (ISceneNode item in info.OverlayImageItems)
-            textures.Add(uiContext.GetEntityCapturedOverlayTexture(item));
         return textures.AsReadOnly();
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Status/StatusWindowView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Status/StatusWindowView.cs
@@ -9,6 +9,8 @@ using UnityEngine.UI;
 /// </summary>
 public sealed class StatusWindowView : MonoBehaviour, IContentInitializable
 {
+    private const int _minimumRowColumnWidth = 24;
+
     private readonly List<TextMeshProUGUI> labelTextFields = new List<TextMeshProUGUI>();
     private readonly List<TextMeshProUGUI> leftRowTextFields = new List<TextMeshProUGUI>();
     private readonly List<TextMeshProUGUI> rightRowTextFields = new List<TextMeshProUGUI>();
@@ -287,12 +289,17 @@ public sealed class StatusWindowView : MonoBehaviour, IContentInitializable
         for (int i = 0; i < safeRows.Count; i++)
         {
             StatusWindowRowRenderData row = safeRows[i];
-            int leftHeight = GetPreferredTextHeight(leftRowTextTemplate, row.Left, leftTemplate);
-            int rightHeight = GetPreferredTextHeight(
+            GetRowRects(
+                leftRowTextTemplate,
                 rightRowTextTemplate,
-                row.Right,
-                rightTemplate
+                leftTemplate,
+                rightTemplate,
+                row,
+                out RectInt leftRect,
+                out RectInt rightRect
             );
+            int leftHeight = GetPreferredTextHeight(leftRowTextTemplate, row.Left, leftRect);
+            int rightHeight = GetPreferredTextHeight(rightRowTextTemplate, row.Right, rightRect);
             int rowHeight = Mathf.Max(leftHeight, rightHeight);
             UILayout.SetTemplateText(
                 GetLeftRowTextField(i),
@@ -300,9 +307,9 @@ public sealed class StatusWindowView : MonoBehaviour, IContentInitializable
                 row.Left,
                 Color.white,
                 new RectInt(
-                    leftTemplate.x,
-                    leftTemplate.y + contentHeight + rowHeight - leftHeight,
-                    leftTemplate.width,
+                    leftRect.x,
+                    leftRect.y + contentHeight + rowHeight - leftHeight,
+                    leftRect.width,
                     leftHeight
                 )
             );
@@ -312,9 +319,9 @@ public sealed class StatusWindowView : MonoBehaviour, IContentInitializable
                 row.Right,
                 Color.white,
                 new RectInt(
-                    rightTemplate.x,
-                    rightTemplate.y + contentHeight + rowHeight - rightHeight,
-                    rightTemplate.width,
+                    rightRect.x,
+                    rightRect.y + contentHeight + rowHeight - rightHeight,
+                    rightRect.width,
                     rightHeight
                 )
             );
@@ -329,6 +336,65 @@ public sealed class StatusWindowView : MonoBehaviour, IContentInitializable
         HideTextFieldsFrom(leftRowTextFields, safeRows.Count);
         HideTextFieldsFrom(rightRowTextFields, safeRows.Count);
         StoreRenderedRows(safeRows);
+    }
+
+    /// <summary>
+    /// Allocates unused row width to whichever column needs it while preserving the authored gap.
+    /// </summary>
+    /// <param name="leftTemplate">The authored left-column text field.</param>
+    /// <param name="rightTemplate">The authored right-column text field.</param>
+    /// <param name="leftRect">The authored left-column bounds.</param>
+    /// <param name="rightRect">The authored right-column bounds.</param>
+    /// <param name="row">The row content to fit.</param>
+    /// <param name="resolvedLeftRect">The allocated left-column bounds.</param>
+    /// <param name="resolvedRightRect">The allocated right-column bounds.</param>
+    private static void GetRowRects(
+        TextMeshProUGUI leftTemplate,
+        TextMeshProUGUI rightTemplate,
+        RectInt leftRect,
+        RectInt rightRect,
+        StatusWindowRowRenderData row,
+        out RectInt resolvedLeftRect,
+        out RectInt resolvedRightRect
+    )
+    {
+        int gap = rightRect.x - leftRect.xMax;
+        int availableWidth = rightRect.xMax - leftRect.x - gap;
+        int preferredLeftWidth = Mathf.Max(
+            _minimumRowColumnWidth,
+            Mathf.CeilToInt(leftTemplate.GetPreferredValues(row.Left ?? string.Empty).x)
+        );
+        int preferredRightWidth = Mathf.Max(
+            _minimumRowColumnWidth,
+            Mathf.CeilToInt(rightTemplate.GetPreferredValues(row.Right ?? string.Empty).x)
+        );
+        int leftWidth;
+        if (preferredLeftWidth + preferredRightWidth <= availableWidth)
+        {
+            leftWidth = Mathf.Clamp(
+                leftRect.width,
+                preferredLeftWidth,
+                availableWidth - preferredRightWidth
+            );
+        }
+        else
+        {
+            float leftShare =
+                (float)preferredLeftWidth / (preferredLeftWidth + preferredRightWidth);
+            leftWidth = Mathf.Clamp(
+                Mathf.RoundToInt(availableWidth * leftShare),
+                _minimumRowColumnWidth,
+                availableWidth - _minimumRowColumnWidth
+            );
+        }
+
+        resolvedLeftRect = new RectInt(leftRect.x, leftRect.y, leftWidth, leftRect.height);
+        resolvedRightRect = new RectInt(
+            leftRect.x + leftWidth + gap,
+            rightRect.y,
+            availableWidth - leftWidth,
+            rightRect.height
+        );
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Status/StrategyStatusInfo.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Status/StrategyStatusInfo.cs
@@ -25,11 +25,6 @@ internal sealed class StrategyStatusInfo
     public List<ISceneNode> ImageItems { get; } = new List<ISceneNode>();
 
     /// <summary>
-    /// Gets the overlay image items.
-    /// </summary>
-    public List<ISceneNode> OverlayImageItems { get; } = new List<ISceneNode>();
-
-    /// <summary>
     /// Gets the rows.
     /// </summary>
     public List<StrategyStatusRow> Rows { get; } = new List<StrategyStatusRow>();

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Status/StrategyStatusInfoBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Status/StrategyStatusInfoBuilder.cs
@@ -123,7 +123,7 @@ internal sealed class StrategyStatusInfoBuilder
                 ManufacturingType.Troop => "Training Facilities",
                 _ => "Construction Yards",
             },
-            CenterImage = false,
+            CenterImage = true,
         };
         info.Images.Add(
             type switch
@@ -709,11 +709,6 @@ internal sealed class StrategyStatusInfoBuilder
         };
 
         info.ImageItems.Add(item);
-        if (
-            item is Officer { IsCaptured: true }
-            && !string.IsNullOrEmpty(item.CapturedOverlayImagePath)
-        )
-            info.OverlayImageItems.Add(item);
         return info;
     }
 

--- a/Assets/Shaders/PlanetClouds.shader
+++ b/Assets/Shaders/PlanetClouds.shader
@@ -3,8 +3,8 @@ Shader "Custom/PlanetClouds"
     Properties
     {
         _MainTex ("Cloud Texture", 2D) = "white" {}
-        _PoleFadeStart ("Pole Fade Start", Range(0.0, 1.0)) = 0.992
-        _PoleFadeEnd ("Pole Fade End", Range(0.0, 1.0)) = 0.9998
+        _PoleFadeStart ("Pole Fade Start", Range(0.0, 1.0)) = 0.965
+        _PoleFadeEnd ("Pole Fade End", Range(0.0, 1.0)) = 0.998
     }
 
     SubShader

--- a/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
@@ -455,6 +455,37 @@ namespace Rebellion.Tests.Game.Messages
         }
 
         [Test]
+        public void CreateMessages_CapturedOfficerArrival_DoesNotCreateDelivery()
+        {
+            (GameRoot game, Faction alliance, _, Planet destination) = BuildMessageScene();
+            Officer captive = new Officer
+            {
+                InstanceID = "captured-officer",
+                DisplayName = "Captured Officer",
+                OwnerInstanceID = alliance.InstanceID,
+                IsCaptured = true,
+                CaptorInstanceID = "empire",
+            };
+            game.AttachNode(captive, destination);
+
+            List<MessageDeliveryRequest> deliveries = CreateMessages(
+                game,
+                new[]
+                {
+                    Definition(
+                        MessageResultType.PersonnelArrived,
+                        MessageType.Mission,
+                        "personnel:{system}",
+                        "body:{personnel}"
+                    ),
+                },
+                new UnitArrivedResult { Unit = captive, Destination = destination }
+            );
+
+            Assert.IsEmpty(deliveries);
+        }
+
+        [Test]
         public void CreateMessages_SpecialForcesArrival_GroupsWithReportingOfficer()
         {
             (GameRoot game, Faction alliance, _, Planet destination) = BuildMessageScene();

--- a/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
@@ -699,10 +699,9 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void BuildFactionView_CapturedFriendlyOfficer_VisibleOnLivePlanet()
+        public void BuildFactionView_CapturedFriendlyOfficerOnVisiblePlanet_ReturnsOfficer()
         {
-            // Leia is captured on Coruscant. Alliance sends a fleet (real-time visibility).
-            // Captured friendly officers are always live data — must appear regardless.
+            // The Alliance fleet supplies visibility independently of the captured officer.
             Fleet allianceFleet = CreateFleet("FLEET1", _alliance);
             _game.AttachNode(allianceFleet, _coruscant);
             AddCapitalShip(allianceFleet, _alliance, "CS1");
@@ -725,10 +724,8 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void BuildFactionView_CapturedFriendlyOfficer_VisibleOnSnapshotPlanet()
+        public void BuildFactionView_CapturedFriendlyOfficerOnSnapshotPlanet_DoesNotRevealOfficer()
         {
-            // Leia is captured on Coruscant. Alliance has a snapshot but no current visibility.
-            // Captured friendly officers are always live data — must appear even via snapshot path.
             Officer vader = CreateOfficer("VADER", _empire);
             _game.AttachNode(vader, _coruscant);
             _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSector, 10);
@@ -744,17 +741,12 @@ namespace Rebellion.Tests.Sectors
                 .GetChildren<Planet>()
                 .First(p => p.InstanceID == "CORUSCANT");
 
-            Assert.IsTrue(
-                viewCoruscant.GetChildren<Officer>().Any(o => o.InstanceID == "LEIA"),
-                "Captured friendly officer must appear as live data even when planet is only known via snapshot"
-            );
+            Assert.IsFalse(viewCoruscant.GetChildren<Officer>().Any(o => o.InstanceID == "LEIA"));
         }
 
         [Test]
-        public void BuildFactionView_CapturedFriendlyOfficer_VisibleOnUnexploredPlanet()
+        public void BuildFactionView_CapturedFriendlyOfficerOnUnexploredPlanet_DoesNotRevealOfficer()
         {
-            // Leia is captured on Coruscant. Alliance has never observed the planet.
-            // Captured friendly officers are always live data — must appear even on unexplored planets.
             Officer leia = CreateOfficer("LEIA", _alliance);
             leia.IsCaptured = true;
             _game.AttachNode(leia, _coruscant);
@@ -766,10 +758,7 @@ namespace Rebellion.Tests.Sectors
                 .GetChildren<Planet>()
                 .First(p => p.InstanceID == "CORUSCANT");
 
-            Assert.IsTrue(
-                viewCoruscant.GetChildren<Officer>().Any(o => o.InstanceID == "LEIA"),
-                "Captured friendly officer must appear as live data even on a completely unexplored planet"
-            );
+            Assert.IsFalse(viewCoruscant.GetChildren<Officer>().Any(o => o.InstanceID == "LEIA"));
         }
 
         [Test]
@@ -2299,6 +2288,19 @@ namespace Rebellion.Tests.Sectors
         public void IsPlanetVisible_NoOwnershipNoFleet_ReturnsFalse()
         {
             bool visible = _fogSystem.IsPlanetVisible(_tatooine, _alliance);
+
+            Assert.IsFalse(visible);
+        }
+
+        [Test]
+        public void IsPlanetVisible_CapturedFriendlyOfficerPresent_ReturnsFalse()
+        {
+            Officer captive = CreateOfficer("CAPTIVE", _alliance);
+            captive.IsCaptured = true;
+            captive.CaptorInstanceID = _empire.InstanceID;
+            _game.AttachNode(captive, _coruscant);
+
+            bool visible = _fogSystem.IsPlanetVisible(_coruscant, _alliance);
 
             Assert.IsFalse(visible);
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Status/StatusWindowViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Status/StatusWindowViewTests.cs
@@ -121,6 +121,32 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Status
         }
 
         [Test]
+        public void Render_LongLeftLabelWithShortValue_AllocatesAdditionalLabelWidth()
+        {
+            _view.Render(
+                CreateRenderData(
+                    false,
+                    false,
+                    "Manufacturing Status",
+                    new[] { _firstTexture },
+                    "Construction Yards",
+                    new[] { new StatusWindowRowRenderData("Estimated Day of Completion:", "140") }
+                )
+            );
+
+            RectInt templateRect = UILayout.GetSourceRect(
+                FindText("LeftRowTextTemplate").rectTransform
+            );
+            RectInt labelRect = UILayout.GetSourceRect(FindText("LeftRowTextField0").rectTransform);
+            RectInt valueRect = UILayout.GetSourceRect(
+                FindText("RightRowTextField0").rectTransform
+            );
+
+            Assert.Greater(labelRect.width, templateRect.width);
+            Assert.LessOrEqual(labelRect.xMax, valueRect.x);
+        }
+
+        [Test]
         public void Render_CenteredImage_CentersFittedImageInAuthoredArea()
         {
             _view.Render(

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Status/StrategyStatusInfoBuilderTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Status/StrategyStatusInfoBuilderTests.cs
@@ -163,7 +163,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Status
 
             Assert.AreEqual("Ship Construction", info.Header);
             Assert.AreEqual("Shipyards", info.Label);
-            Assert.IsFalse(info.CenterImage);
+            Assert.IsTrue(info.CenterImage);
             CollectionAssert.AreEqual(new[] { StatusWindowImage.Shipyard }, info.Images);
             CollectionAssert.AreEqual(
                 new[] { "Location:|Corellia", "Status:|No Facilities" },
@@ -537,7 +537,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Status
         }
 
         [Test]
-        public void Build_CapturedOfficer_ReturnsCapturedOverlayStatus()
+        public void Build_CapturedOfficer_ReturnsCapturedStatusWithPrimaryImageOnly()
         {
             Officer officer = new Officer
             {
@@ -552,7 +552,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Status
             StrategyStatusInfo info = _builder.Build(new StrategyStatusTarget(_mapPlanet, officer));
 
             Assert.AreEqual("Captured", info.Rows.Single(row => row.Left == "Status:").Right);
-            CollectionAssert.AreEqual(new[] { officer }, info.OverlayImageItems);
             CollectionAssert.AreEqual(new[] { officer }, info.ImageItems);
         }
 


### PR DESCRIPTION
## Summary

- prevent captured officers from generating arrival notifications or exposing their live locations through fog of war
- show captured personnel as unobstructed portraits in the status window, improve dynamic status-row layout, and center facility artwork
- restore the standard Options menu typography and remove obsolete faction launch-icon animation code
- suppress the polar cloud-shadow artifacts on the main-menu planet
- add regression coverage for captured-unit messages, fog-of-war views, and status presentation
- pair these engine changes with [rebellion2-media#53](https://github.com/davidadas/rebellion2-media/pull/53), which corrects construction artwork, reorganizes faction-specific tactical UI assets, and removes obsolete media

## Validation

- local `dotnet csharpier check Assets/`
- local analyzer tests: 4 passed
- CI `Lint`: passed
- CI `Test`: passed
- CI `Build (StandaloneLinux64)`: passed; the build rebuilds the generated UI
- CI `Resolve media revision`: passed against the matching `fix-construction-unit-images` media branch

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (No documentation changes were required.)