### PR TITLE
Cleaning up game event API documentation

### DIFF
--- a/Assets/GameIcon.meta
+++ b/Assets/GameIcon.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 192aca8c2d191d64f8d5a31f4e6fc231
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Game/Events/GameConditionals.cs
+++ b/Assets/Scripts/Game/Events/GameConditionals.cs
@@ -187,7 +187,9 @@ namespace Rebellion.Game.Events
         [PersistableAttribute]
         public string EventInstanceID { get; set; }
 
-        /// <summary>Checks the persisted completion state for the referenced event.</summary>
+        /// <summary>
+        /// Checks the persisted completion state for the referenced event.
+        /// </summary>
         /// <param name="context">The context providing event runtime state.</param>
         /// <returns>True when the referenced event is permanently complete.</returns>
         public override bool IsMet(GameConditionContext context)
@@ -211,7 +213,11 @@ namespace Rebellion.Game.Events
         [PersistableAttribute]
         public int CompareTo { get; set; }
 
-        /// <summary>Compares the current event variable value with the authored integer.</summary>
+        /// <summary>
+        /// Compares the current event variable value with the authored integer.
+        /// </summary>
+        /// <param name="context">The context providing event runtime state.</param>
+        /// <returns>True when the variable comparison succeeds.</returns>
         public override bool IsMet(GameConditionContext context)
         {
             int current = context.Game.EventRuntime.GetVariable(Key);
@@ -400,7 +406,11 @@ namespace Rebellion.Game.Events
         [PersistableAttribute]
         public ForceRankLabel Rank { get; set; }
 
-        /// <summary>Compares the officer's Force rank with the configured rank threshold.</summary>
+        /// <summary>
+        /// Compares the officer's Force rank with the configured rank threshold.
+        /// </summary>
+        /// <param name="context">The context providing the current game state.</param>
+        /// <returns>True when the Force-rank comparison succeeds.</returns>
         public override bool IsMet(GameConditionContext context)
         {
             Officer officer = context.Game.GetSceneNodeByInstanceID<Officer>(OfficerInstanceID);
@@ -737,7 +747,11 @@ namespace Rebellion.Game.Events
         [PersistableAttribute]
         public string NodeInstanceID { get; set; }
 
-        /// <summary>Returns whether the referenced node is active in its hierarchy.</summary>
+        /// <summary>
+        /// Checks whether the referenced node is active in its hierarchy.
+        /// </summary>
+        /// <param name="context">The context providing the current game state.</param>
+        /// <returns>True when the node and its ancestors are active.</returns>
         public override bool IsMet(GameConditionContext context)
         {
             ISceneNode node = context.Game.GetSceneNodeByInstanceID<ISceneNode>(
@@ -771,7 +785,11 @@ namespace Rebellion.Game.Events
         public string UnitInstanceID { get; set; }
         public string LocationInstanceID { get; set; }
 
-        /// <summary>Returns whether the configured unit is contained by the configured location.</summary>
+        /// <summary>
+        /// Checks whether the configured unit is contained by the configured location.
+        /// </summary>
+        /// <param name="context">The context providing the current game state.</param>
+        /// <returns>True when the unit is contained by the location.</returns>
         public override bool IsMet(GameConditionContext context)
         {
             GameRoot game = context.Game;

--- a/Assets/Scripts/Game/Events/GameEvent.cs
+++ b/Assets/Scripts/Game/Events/GameEvent.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Rebellion.Game.Units;
 using Rebellion.Util.Common;

--- a/Assets/Scripts/Game/Events/GameEvent.cs
+++ b/Assets/Scripts/Game/Events/GameEvent.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Rebellion.Game.Units;
-using Rebellion.SceneGraph;
 using Rebellion.Util.Common;
 using Rebellion.Util.Serialization;
 
@@ -22,44 +20,6 @@ namespace Rebellion.Game.Events
     }
 
     /// <summary>
-    /// Assigns an explicitly selected value to an event-local binding name.
-    /// </summary>
-    [PersistableObject(Name = "Bind")]
-    public sealed class GameEventBinding
-    {
-        /// <summary>Gets or sets the stable trigger argument to expose.</summary>
-        [PersistableAttribute]
-        public string Argument { get; set; }
-
-        /// <summary>Gets or sets the event-local name assigned to the value.</summary>
-        [PersistableAttribute]
-        public string As { get; set; }
-
-        [PersistableMember(Name = "From")]
-        public List<GameEventSelector> Selectors { get; set; } = new List<GameEventSelector>();
-
-        /// <summary>Selects exactly one scene node and stores it in the evaluation context.</summary>
-        internal void Bind(
-            GameRoot game,
-            IRandomNumberProvider provider,
-            GameEventEvaluationContext context
-        )
-        {
-            if (Selectors.Count != 1)
-                throw new InvalidOperationException(
-                    $"Selection binding '{As}' requires exactly one selector."
-                );
-
-            ISceneNode[] values = Selectors[0].Select(game, provider, context).Distinct().ToArray();
-            if (values.Length != 1)
-                throw new InvalidOperationException(
-                    $"Selection binding '{As}' must resolve exactly one object but resolved {values.Length}."
-                );
-            context.Bind(As, values[0]);
-        }
-    }
-
-    /// <summary>
     /// Defines one scheduled or triggered event and the actions performed when it activates.
     /// </summary>
     [PersistableObject]
@@ -76,7 +36,11 @@ namespace Rebellion.Game.Events
         public List<GameConditional> Conditionals { get; set; } = new List<GameConditional>();
         public List<GameAction> Actions { get; set; } = new List<GameAction>();
 
-        /// <summary>Returns whether the event remains below its authored activation limit.</summary>
+        /// <summary>
+        /// Checks whether the event remains below its authored activation limit.
+        /// </summary>
+        /// <param name="state">The event's current runtime state.</param>
+        /// <returns>True when the event can activate.</returns>
         internal bool CanActivate(GameEventState state) =>
             !state.IsComplete
             && (!MaximumActivations.HasValue || state.ActivationCount < MaximumActivations.Value);

--- a/Assets/Scripts/Game/Events/GameEventBinding.cs
+++ b/Assets/Scripts/Game/Events/GameEventBinding.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Rebellion.SceneGraph;
+using Rebellion.Util.Common;
+using Rebellion.Util.Serialization;
+
+namespace Rebellion.Game.Events
+{
+    /// <summary>
+    /// Assigns an explicitly selected value to an event-local binding name.
+    /// </summary>
+    [PersistableObject(Name = "Bind")]
+    public sealed class GameEventBinding
+    {
+        // Binding Configuration.
+        [PersistableAttribute]
+        public string Argument { get; set; }
+
+        [PersistableAttribute]
+        public string As { get; set; }
+
+        [PersistableMember(Name = "From")]
+        public List<GameEventSelector> Selectors { get; set; } = new List<GameEventSelector>();
+
+        /// <summary>
+        /// Resolves the selected scene node and adds it to the evaluation context.
+        /// </summary>
+        /// <param name="game">The current game state.</param>
+        /// <param name="provider">The random number provider used by selectors.</param>
+        /// <param name="context">The event evaluation context receiving the binding.</param>
+        internal void Bind(
+            GameRoot game,
+            IRandomNumberProvider provider,
+            GameEventEvaluationContext context
+        )
+        {
+            if (Selectors.Count != 1)
+                throw new InvalidOperationException(
+                    $"Selection binding '{As}' requires exactly one selector."
+                );
+
+            ISceneNode[] values = Selectors[0].Select(game, provider, context).Distinct().ToArray();
+            if (values.Length != 1)
+                throw new InvalidOperationException(
+                    $"Selection binding '{As}' must resolve exactly one object but resolved {values.Length}."
+                );
+            context.Bind(As, values[0]);
+        }
+    }
+}

--- a/Assets/Scripts/Game/Events/GameEventBinding.cs.meta
+++ b/Assets/Scripts/Game/Events/GameEventBinding.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 15152d22cf284de69f81f7953831486e

--- a/Assets/Scripts/Game/Events/GameEventEvaluationContext.cs
+++ b/Assets/Scripts/Game/Events/GameEventEvaluationContext.cs
@@ -86,7 +86,13 @@ namespace Rebellion.Game.Events
         public bool TryGetBinding(string name, out object value) =>
             _bindings.TryGetValue(name, out value);
 
-        /// <summary>Attempts to resolve one explicit binding reference as the requested type.</summary>
+        /// <summary>
+        /// Attempts to resolve a binding reference as the requested type.
+        /// </summary>
+        /// <typeparam name="T">The expected binding type.</typeparam>
+        /// <param name="reference">The dollar-prefixed binding reference.</param>
+        /// <param name="value">Receives the typed binding when found.</param>
+        /// <returns>True when a compatible binding exists.</returns>
         public bool TryGetBindingReference<T>(string reference, out T value)
         {
             if (TryResolveBindingReference(reference, out object resolved) && resolved is T typed)
@@ -98,17 +104,31 @@ namespace Rebellion.Game.Events
             return false;
         }
 
-        /// <summary>Attempts to resolve one explicit binding reference without a type constraint.</summary>
+        /// <summary>
+        /// Attempts to resolve a binding reference without a type constraint.
+        /// </summary>
+        /// <param name="reference">The dollar-prefixed binding reference.</param>
+        /// <param name="value">Receives the binding when found.</param>
+        /// <returns>True when the binding exists.</returns>
         public bool TryGetBindingReference(string reference, out object value) =>
             TryResolveBindingReference(reference, out value);
 
-        /// <summary>Gets one explicit binding reference as the requested type.</summary>
+        /// <summary>
+        /// Resolves a binding reference as the requested type.
+        /// </summary>
+        /// <typeparam name="T">The expected binding type.</typeparam>
+        /// <param name="reference">The dollar-prefixed binding reference.</param>
+        /// <returns>The typed binding, or the default value when it is absent or incompatible.</returns>
         public T GetBindingReference<T>(string reference)
         {
             return TryGetBindingReference(reference, out T value) ? value : default;
         }
 
-        /// <summary>Removes the required dollar-sign prefix from a binding reference.</summary>
+        /// <summary>
+        /// Removes the required dollar-sign prefix from a binding reference.
+        /// </summary>
+        /// <param name="reference">The dollar-prefixed binding reference.</param>
+        /// <returns>The binding name.</returns>
         private static string GetBindingName(string reference)
         {
             if (string.IsNullOrWhiteSpace(reference) || reference[0] != '$')
@@ -116,7 +136,12 @@ namespace Rebellion.Game.Events
             return reference.Substring(1);
         }
 
-        /// <summary>Attempts to resolve one explicitly authored binding from the evaluation context.</summary>
+        /// <summary>
+        /// Attempts to resolve an authored binding from the evaluation context.
+        /// </summary>
+        /// <param name="reference">The dollar-prefixed binding reference.</param>
+        /// <param name="value">Receives the binding when found.</param>
+        /// <returns>True when the binding exists.</returns>
         private bool TryResolveBindingReference(string reference, out object value)
         {
             string name = GetBindingName(reference);

--- a/Assets/Scripts/Game/Events/GameEventScheduler.cs
+++ b/Assets/Scripts/Game/Events/GameEventScheduler.cs
@@ -142,7 +142,7 @@ namespace Rebellion.Game.Events
         [PersistableAttribute]
         public int InitialDelayTicks { get; set; }
 
-        /// <summary>Gets the conditions that permanently end this recurring schedule.</summary>
+        // Completion Conditions.
         public List<GameConditional> Until { get; set; } = new List<GameConditional>();
     }
 
@@ -182,7 +182,7 @@ namespace Rebellion.Game.Events
         [PersistableAttribute]
         public int MaximumTicks { get; set; }
 
-        /// <summary>Gets the conditions that permanently end this recurring schedule.</summary>
+        // Completion Conditions.
         public List<GameConditional> Until { get; set; } = new List<GameConditional>();
 
         /// <summary>

--- a/Assets/Scripts/Game/Events/GameEventTrigger.cs
+++ b/Assets/Scripts/Game/Events/GameEventTrigger.cs
@@ -19,16 +19,26 @@ namespace Rebellion.Game.Events
     [PersistableObject]
     public abstract class GameEventTrigger
     {
-        /// <summary>Gets or sets the trigger arguments explicitly exposed to the event.</summary>
+        // Trigger Bindings.
         public List<GameEventBinding> Bindings { get; set; } = new List<GameEventBinding>();
 
-        /// <summary>Gets the concrete simulation-result type consumed by this trigger.</summary>
+        /// <summary>
+        /// Identifies the simulation result consumed by the trigger.
+        /// </summary>
         internal abstract Type ResultType { get; }
 
-        /// <summary>Returns whether the supplied result satisfies the authored predicate.</summary>
+        /// <summary>
+        /// Checks whether a simulation result satisfies the trigger criteria.
+        /// </summary>
+        /// <param name="result">The simulation result being evaluated.</param>
+        /// <returns>True when the result satisfies the trigger criteria.</returns>
         internal abstract bool Matches(GameResult result);
 
-        /// <summary>Exposes the explicitly authored result arguments under their binding names.</summary>
+        /// <summary>
+        /// Adds the authored result arguments to the event evaluation context.
+        /// </summary>
+        /// <param name="context">The event evaluation context receiving the bindings.</param>
+        /// <param name="result">The matched simulation result.</param>
         internal void Bind(GameEventEvaluationContext context, GameResult result)
         {
             foreach (GameEventBinding binding in Bindings)
@@ -41,16 +51,30 @@ namespace Rebellion.Game.Events
             }
         }
 
-        /// <summary>Gets the declared value type for one authored trigger argument.</summary>
+        /// <summary>
+        /// Resolves the declared value type for an authored trigger argument.
+        /// </summary>
+        /// <param name="argument">The authored trigger argument name.</param>
+        /// <returns>The declared argument type.</returns>
         internal Type GetBindingType(string argument) =>
             GameEventTriggerArguments.Get(ResultType, argument).ValueType;
 
-        /// <summary>Matches an optional authored instance ID against an actual value.</summary>
+        /// <summary>
+        /// Compares an optional authored instance ID with an actual instance ID.
+        /// </summary>
+        /// <param name="expected">The optional authored instance ID.</param>
+        /// <param name="actual">The actual instance ID.</param>
+        /// <returns>True when no value was authored or the instance IDs match.</returns>
         protected static bool MatchesInstanceID(string expected, string actual) =>
             string.IsNullOrWhiteSpace(expected)
             || string.Equals(expected, actual, StringComparison.Ordinal);
 
-        /// <summary>Matches an optional authored source-event ID against a result.</summary>
+        /// <summary>
+        /// Compares an optional authored source-event ID with a simulation result.
+        /// </summary>
+        /// <param name="expected">The optional authored source-event ID.</param>
+        /// <param name="result">The simulation result.</param>
+        /// <returns>True when no source was authored or the source IDs match.</returns>
         protected static bool MatchesSource(string expected, GameResult result) =>
             MatchesInstanceID(expected, result?.SourceEventInstanceID);
     }
@@ -62,6 +86,7 @@ namespace Rebellion.Game.Events
     {
         private readonly Func<GameResult, object> _resolve;
 
+        // Argument Type.
         internal Type ValueType { get; }
 
         private GameEventTriggerArgument(Type valueType, Func<GameResult, object> resolve)
@@ -70,10 +95,20 @@ namespace Rebellion.Game.Events
             _resolve = resolve;
         }
 
-        /// <summary>Resolves the argument value from the matched result.</summary>
+        /// <summary>
+        /// Resolves the argument value from a matched simulation result.
+        /// </summary>
+        /// <param name="result">The matched simulation result.</param>
+        /// <returns>The exposed argument value.</returns>
         internal object Resolve(GameResult result) => _resolve(result);
 
-        /// <summary>Creates a strongly typed trigger-argument accessor.</summary>
+        /// <summary>
+        /// Creates a strongly typed trigger-argument accessor.
+        /// </summary>
+        /// <typeparam name="TResult">The supported simulation-result type.</typeparam>
+        /// <typeparam name="TValue">The exposed argument type.</typeparam>
+        /// <param name="resolve">The function that resolves the argument value.</param>
+        /// <returns>The trigger-argument accessor.</returns>
         internal static GameEventTriggerArgument Create<TResult, TValue>(
             Func<TResult, TValue> resolve
         )
@@ -89,7 +124,12 @@ namespace Rebellion.Game.Events
         private static readonly IReadOnlyDictionary<(Type, string), GameEventTriggerArgument> _all =
             Build();
 
-        /// <summary>Gets one declared argument or rejects the unsupported authoring request.</summary>
+        /// <summary>
+        /// Resolves a declared trigger argument.
+        /// </summary>
+        /// <param name="resultType">The simulation-result type.</param>
+        /// <param name="argument">The authored argument name.</param>
+        /// <returns>The declared trigger argument.</returns>
         internal static GameEventTriggerArgument Get(Type resultType, string argument)
         {
             if (
@@ -102,7 +142,10 @@ namespace Rebellion.Game.Events
             return value;
         }
 
-        /// <summary>Builds the explicit result-to-argument contract used by event bindings.</summary>
+        /// <summary>
+        /// Builds the result-to-argument contracts used by event bindings.
+        /// </summary>
+        /// <returns>The supported trigger arguments indexed by result type and argument name.</returns>
         private static IReadOnlyDictionary<(Type, string), GameEventTriggerArgument> Build()
         {
             Dictionary<(Type, string), GameEventTriggerArgument> arguments = new();
@@ -392,7 +435,14 @@ namespace Rebellion.Game.Events
             return arguments;
         }
 
-        /// <summary>Adds one strongly typed argument to the trigger contract.</summary>
+        /// <summary>
+        /// Adds a strongly typed argument to the trigger contract.
+        /// </summary>
+        /// <typeparam name="TResult">The supported simulation-result type.</typeparam>
+        /// <typeparam name="TValue">The exposed argument type.</typeparam>
+        /// <param name="arguments">The trigger contract being built.</param>
+        /// <param name="name">The authored argument name.</param>
+        /// <param name="resolve">The function that resolves the argument value.</param>
         private static void Add<TResult, TValue>(
             IDictionary<(Type, string), GameEventTriggerArgument> arguments,
             string name,
@@ -404,7 +454,9 @@ namespace Rebellion.Game.Events
 
     #region Planet
 
-    /// <summary>Activates when ownership of a planet changes.</summary>
+    /// <summary>
+    /// Activates when ownership of a planet changes.
+    /// </summary>
     [PersistableObject(Name = "PlanetOwnershipChanged")]
     public sealed class PlanetOwnershipChangedTrigger : GameEventTrigger
     {
@@ -434,7 +486,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, changed);
     }
 
-    /// <summary>Activates when a recorded planet statistic changes.</summary>
+    /// <summary>
+    /// Activates when a recorded planet statistic changes.
+    /// </summary>
     [PersistableObject(Name = "PlanetStatChanged")]
     public sealed class PlanetStatChangedTrigger : GameEventTrigger
     {
@@ -460,7 +514,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, changed);
     }
 
-    /// <summary>Activates when a planet's blockade state changes.</summary>
+    /// <summary>
+    /// Activates when a planet's blockade state changes.
+    /// </summary>
     [PersistableObject(Name = "BlockadeChanged")]
     public sealed class BlockadeChangedTrigger : GameEventTrigger
     {
@@ -482,7 +538,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, changed);
     }
 
-    /// <summary>Activates when an uprising begins on a planet.</summary>
+    /// <summary>
+    /// Activates when an uprising begins on a planet.
+    /// </summary>
     [PersistableObject(Name = "UprisingStarted")]
     public sealed class UprisingStartedTrigger : GameEventTrigger
     {
@@ -504,7 +562,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, started);
     }
 
-    /// <summary>Activates when an uprising ends on a planet.</summary>
+    /// <summary>
+    /// Activates when an uprising ends on a planet.
+    /// </summary>
     [PersistableObject(Name = "UprisingEnded")]
     public sealed class UprisingEndedTrigger : GameEventTrigger
     {
@@ -526,7 +586,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, ended);
     }
 
-    /// <summary>Activates when intelligence is revealed to a faction.</summary>
+    /// <summary>
+    /// Activates when intelligence is revealed to a faction.
+    /// </summary>
     [PersistableObject(Name = "IntelligenceRevealed")]
     public sealed class IntelligenceRevealedTrigger : GameEventTrigger
     {
@@ -553,7 +615,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, revealed);
     }
 
-    /// <summary>Activates when a faction cannot meet a maintenance obligation.</summary>
+    /// <summary>
+    /// Activates when a faction cannot meet a maintenance obligation.
+    /// </summary>
     [PersistableObject(Name = "MaintenanceRequired")]
     public sealed class MaintenanceRequiredTrigger : GameEventTrigger
     {
@@ -575,7 +639,9 @@ namespace Rebellion.Game.Events
 
     #region Faction
 
-    /// <summary>Activates when a faction advances one research discipline.</summary>
+    /// <summary>
+    /// Activates when a faction advances one research discipline.
+    /// </summary>
     [PersistableObject(Name = "ResearchAdvanced")]
     public sealed class ResearchAdvancedTrigger : GameEventTrigger
     {
@@ -620,14 +686,17 @@ namespace Rebellion.Game.Events
     [PersistableObject(Name = "Participants")]
     public sealed class MissionParticipantFilter
     {
-        /// <summary>Gets or sets whether any or all authored units must participate.</summary>
+        // Participant Matching.
         [PersistableAttribute]
         public ParticipantMatch Match { get; set; } = ParticipantMatch.Any;
 
-        /// <summary>Gets the authored unit identities tested against the result.</summary>
         public List<EventUnitReference> Units { get; set; } = new List<EventUnitReference>();
 
-        /// <summary>Returns whether the completed mission contains the authored participants.</summary>
+        /// <summary>
+        /// Checks whether a completed mission contains the authored participants.
+        /// </summary>
+        /// <param name="participants">The completed mission's participants.</param>
+        /// <returns>True when the participant filter is satisfied.</returns>
         internal bool Matches(IReadOnlyCollection<IMissionParticipant> participants)
         {
             if (Units.Count == 0)
@@ -684,7 +753,9 @@ namespace Rebellion.Game.Events
 
     #region Officer
 
-    /// <summary>Activates when an officer's capture state changes.</summary>
+    /// <summary>
+    /// Activates when an officer's capture state changes.
+    /// </summary>
     [PersistableObject(Name = "OfficerCaptureChanged")]
     public sealed class OfficerCaptureChangedTrigger : GameEventTrigger
     {
@@ -710,7 +781,9 @@ namespace Rebellion.Game.Events
         }
     }
 
-    /// <summary>Activates when an officer is killed.</summary>
+    /// <summary>
+    /// Activates when an officer is killed.
+    /// </summary>
     [PersistableObject(Name = "OfficerKilled")]
     public sealed class OfficerKilledTrigger : GameEventTrigger
     {
@@ -728,7 +801,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, killed);
     }
 
-    /// <summary>Activates when an officer is injured.</summary>
+    /// <summary>
+    /// Activates when an officer is injured.
+    /// </summary>
     [PersistableObject(Name = "OfficerInjured")]
     public sealed class OfficerInjuredTrigger : GameEventTrigger
     {
@@ -746,7 +821,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, injured);
     }
 
-    /// <summary>Activates when an officer recruitment result is produced.</summary>
+    /// <summary>
+    /// Activates when an officer recruitment result is produced.
+    /// </summary>
     [PersistableObject(Name = "OfficerRecruited")]
     public sealed class OfficerRecruitedTrigger : GameEventTrigger
     {
@@ -772,7 +849,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, recruited);
     }
 
-    /// <summary>Activates when an officer's Force discovery state changes.</summary>
+    /// <summary>
+    /// Activates when an officer's Force discovery state changes.
+    /// </summary>
     [PersistableObject(Name = "ForceDiscoveryChanged")]
     public sealed class ForceDiscoveryChangedTrigger : GameEventTrigger
     {
@@ -802,7 +881,9 @@ namespace Rebellion.Game.Events
 
     #region Unit Lifecycle
 
-    /// <summary>Activates when ownership of a unit changes.</summary>
+    /// <summary>
+    /// Activates when ownership of a unit changes.
+    /// </summary>
     [PersistableObject(Name = "UnitOwnershipChanged")]
     public sealed class UnitOwnershipChangedTrigger : GameEventTrigger
     {
@@ -828,7 +909,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, changed);
     }
 
-    /// <summary>Activates when a game unit is created.</summary>
+    /// <summary>
+    /// Activates when a game unit is created.
+    /// </summary>
     [PersistableObject(Name = "UnitCreated")]
     public sealed class UnitCreatedTrigger : GameEventTrigger
     {
@@ -846,7 +929,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, created);
     }
 
-    /// <summary>Activates when a game unit is destroyed.</summary>
+    /// <summary>
+    /// Activates when a game unit is destroyed.
+    /// </summary>
     [PersistableObject(Name = "UnitDestroyed")]
     public sealed class UnitDestroyedTrigger : GameEventTrigger
     {
@@ -899,7 +984,9 @@ namespace Rebellion.Game.Events
 
     #region Combat
 
-    /// <summary>Activates when a space battle is resolved.</summary>
+    /// <summary>
+    /// Activates when a space battle is resolved.
+    /// </summary>
     [PersistableObject(Name = "SpaceCombatCompleted")]
     public sealed class SpaceCombatCompletedTrigger : GameEventTrigger
     {
@@ -929,7 +1016,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, combat);
     }
 
-    /// <summary>Activates when orbital bombardment is resolved.</summary>
+    /// <summary>
+    /// Activates when orbital bombardment is resolved.
+    /// </summary>
     [PersistableObject(Name = "BombardmentCompleted")]
     public sealed class BombardmentCompletedTrigger : GameEventTrigger
     {
@@ -963,7 +1052,9 @@ namespace Rebellion.Game.Events
             && MatchesSource(SourceEventInstanceID, bombardment);
     }
 
-    /// <summary>Activates when a planetary assault is resolved.</summary>
+    /// <summary>
+    /// Activates when a planetary assault is resolved.
+    /// </summary>
     [PersistableObject(Name = "PlanetaryAssaultCompleted")]
     public sealed class PlanetaryAssaultCompletedTrigger : GameEventTrigger
     {
@@ -1028,7 +1119,9 @@ namespace Rebellion.Game.Events
 
     #region Manufacturing
 
-    /// <summary>Activates when a manufactured unit is deployed.</summary>
+    /// <summary>
+    /// Activates when a manufactured unit is deployed.
+    /// </summary>
     [PersistableObject(Name = "ManufacturingCompleted")]
     public sealed class ManufacturingCompletedTrigger : GameEventTrigger
     {

--- a/Assets/Scripts/Systems/GameEventSystem.cs
+++ b/Assets/Scripts/Systems/GameEventSystem.cs
@@ -152,7 +152,12 @@ namespace Rebellion.Systems
             }
         }
 
-        /// <summary>Returns whether two alternative triggers expose the same binding contract.</summary>
+        /// <summary>
+        /// Checks whether two triggers expose the same binding contract.
+        /// </summary>
+        /// <param name="first">The first binding contract.</param>
+        /// <param name="second">The second binding contract.</param>
+        /// <returns>True when both contracts expose the same names and value types.</returns>
         private static bool HaveSameBindings(
             IReadOnlyDictionary<string, Type> first,
             IReadOnlyDictionary<string, Type> second
@@ -445,7 +450,11 @@ namespace Rebellion.Systems
             return state.IsComplete;
         }
 
-        /// <summary>Marks an event complete after it reaches its authored activation limit.</summary>
+        /// <summary>
+        /// Marks an event complete after it reaches its authored activation limit.
+        /// </summary>
+        /// <param name="gameEvent">The event definition.</param>
+        /// <param name="state">The event's current runtime state.</param>
         private static bool HasReachedMaximumActivations(GameEvent gameEvent, GameEventState state)
         {
             int? maximum = gameEvent.MaximumActivations;


### PR DESCRIPTION
## Summary

- Move `GameEventBinding` into its own source file.
- Align event API property comments with the established grouped-property convention.
- Expand event method documentation with parameters and return behavior.
- Clean up the same compressed comment pattern across the merged event trigger code.

## Validation

- `./build.sh format`
- `dotnet build GameAssembly.Lint.csproj --no-restore --verbosity:minimal -p:FrameworkPathOverride=/Applications/Unity/Hub/Editor/6000.4.0f1/Unity.app/Contents/Resources/Scripting/MonoBleedingEdge/lib/mono/4.7.1-api`
- `LOG_LEVEL=none ./build.sh test` (4,067 passed)
- GitHub CI: lint, standalone Linux build, and tests passed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable; this PR does not change UI builders.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable; this PR changes source organization and documentation comments only.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable; this PR does not change behavior or setup.)
