### PR TITLE
Render unallocated popular support as black

### DIFF
--- a/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
@@ -7235,6 +7235,7 @@ public static class StrategyViewPrefabBuilder
         AssignReferenceArray(planetView, "rawBarCellImages", rawBar.Cells);
         AssignReference(planetView, "supportBarBackgroundImage", supportBar.Background);
         AssignReference(planetView, "supportBarFillImage", supportBar.Fill);
+        AssignReference(planetView, "supportBarSecondaryFillImage", supportBar.SecondaryFill);
 
         root.SetActive(true);
         GameObject saved = SaveGeneratedPrefabAsset(root, _planetSectorPlanetPrefabPath);
@@ -7974,7 +7975,7 @@ public static class StrategyViewPrefabBuilder
             cells.Add(cell);
         }
 
-        return new BarPrefabParts(root, background, fill, cells);
+        return new BarPrefabParts(root, background, fill, null, cells);
     }
 
     /// <summary>
@@ -8037,13 +8038,16 @@ public static class StrategyViewPrefabBuilder
         RectTransform root = CreateChildLayer(name, parent);
         SetSourceRect(root, 10, y, _planetPreviewWidth, 3);
         Image background = CreateImage("BackgroundImage", root);
-        background.color = Color.green;
+        background.color = Color.black;
         SetSourceRect(background.rectTransform, 0, 0, _planetPreviewWidth, 3);
 
         Image fill = CreateImage("FillImage", root);
         fill.color = color;
         SetSourceRect(fill.rectTransform, 0, 0, 24, 3);
-        return new BarPrefabParts(root, background, fill, new List<Image>());
+
+        Image secondaryFill = CreateImage("SecondaryFillImage", root);
+        SetSourceRect(secondaryFill.rectTransform, 0, 0, 24, 3);
+        return new BarPrefabParts(root, background, fill, secondaryFill, new List<Image>());
     }
 
     /// <summary>
@@ -8525,17 +8529,20 @@ public static class StrategyViewPrefabBuilder
         /// <param name="root">The bar root.</param>
         /// <param name="background">The background image.</param>
         /// <param name="fill">The fill image.</param>
+        /// <param name="secondaryFill">The optional secondary fill image.</param>
         /// <param name="cells">The optional segmented cell images.</param>
         public BarPrefabParts(
             RectTransform root,
             Image background,
             Image fill,
+            Image secondaryFill,
             IReadOnlyList<Image> cells
         )
         {
             Root = root;
             Background = background;
             Fill = fill;
+            SecondaryFill = secondaryFill;
             Cells = cells;
         }
 
@@ -8544,6 +8551,8 @@ public static class StrategyViewPrefabBuilder
         public Image Background { get; }
 
         public Image Fill { get; }
+
+        public Image SecondaryFill { get; }
 
         public IReadOnlyList<Image> Cells { get; }
     }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorPlanetView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorPlanetView.cs
@@ -85,6 +85,9 @@ public sealed class PlanetSectorPlanetView
     [SerializeField]
     private Image supportBarFillImage;
 
+    [SerializeField]
+    private Image supportBarSecondaryFillImage;
+
     private PlanetSectorBarView energyBar;
     private PlanetSectorPlanetRenderData lastRenderData;
     private PlanetSectorBarView rawBar;
@@ -587,7 +590,8 @@ public sealed class PlanetSectorPlanetView
             supportBarRoot,
             supportBarBackgroundImage,
             supportBarFillImage,
-            Array.Empty<Image>()
+            Array.Empty<Image>(),
+            supportBarSecondaryFillImage
         );
     }
 
@@ -626,7 +630,11 @@ public sealed class PlanetSectorPlanetView
         if (rawBarBackgroundImage == null || rawBarFillImage == null)
             throw new MissingReferenceException($"{name}/RawBar images are missing.");
         VerifySegmentedBarReferences("RawBar", rawBarCellImages);
-        if (supportBarBackgroundImage == null || supportBarFillImage == null)
+        if (
+            supportBarBackgroundImage == null
+            || supportBarFillImage == null
+            || supportBarSecondaryFillImage == null
+        )
             throw new MissingReferenceException($"{name}/SupportBar images are missing.");
     }
 
@@ -665,6 +673,8 @@ public sealed class PlanetSectorPlanetView
         private readonly RectInt fillTemplate;
         private readonly RectTransform root;
         private readonly RectInt rootTemplate;
+        private readonly Image secondaryFill;
+        private readonly RectInt secondaryFillTemplate;
 
         /// <summary>
         /// Creates a bar renderer from authored child components.
@@ -673,20 +683,27 @@ public sealed class PlanetSectorPlanetView
         /// <param name="background">The authored background image.</param>
         /// <param name="fill">The authored continuous fill image.</param>
         /// <param name="cells">The authored segmented cells.</param>
+        /// <param name="secondaryFill">The optional secondary continuous fill image.</param>
         public PlanetSectorBarView(
             RectTransform root,
             Image background,
             Image fill,
-            IReadOnlyList<Image> cells
+            IReadOnlyList<Image> cells,
+            Image secondaryFill = null
         )
         {
             this.root = root;
             this.background = background;
             this.fill = fill;
             this.cells = cells ?? Array.Empty<Image>();
+            this.secondaryFill = secondaryFill;
             rootTemplate = UILayout.GetSourceRect(root);
             backgroundTemplate = UILayout.GetSourceRect(background.rectTransform);
             fillTemplate = UILayout.GetSourceRect(fill.rectTransform);
+            secondaryFillTemplate =
+                secondaryFill == null
+                    ? default
+                    : UILayout.GetSourceRect(secondaryFill.rectTransform);
             cellTemplate = default;
             cellStride = 0;
             if (this.cells.Count >= 2)
@@ -758,16 +775,38 @@ public sealed class PlanetSectorPlanetView
             int fillWidth = Mathf.RoundToInt(Mathf.Clamp01(data.FillRatio) * continuousWidth);
             bool visible = fillWidth > 0 && data.FillColor.a > 0;
             fill.gameObject.SetActive(visible);
-            if (!visible)
+            if (visible)
+            {
+                fill.color = data.FillColor;
+                UILayout.SetSourceRect(
+                    fill.rectTransform,
+                    fillTemplate.x,
+                    fillTemplate.y,
+                    fillWidth,
+                    fillTemplate.height
+                );
+            }
+
+            if (secondaryFill == null)
                 return;
 
-            fill.color = data.FillColor;
+            int maximumSecondaryWidth = continuousWidth - fillWidth;
+            int secondaryFillWidth = Mathf.Min(
+                Mathf.RoundToInt(Mathf.Clamp01(data.SecondaryFillRatio) * continuousWidth),
+                maximumSecondaryWidth
+            );
+            bool secondaryVisible = secondaryFillWidth > 0 && data.SecondaryFillColor.a > 0;
+            secondaryFill.gameObject.SetActive(secondaryVisible);
+            if (!secondaryVisible)
+                return;
+
+            secondaryFill.color = data.SecondaryFillColor;
             UILayout.SetSourceRect(
-                fill.rectTransform,
-                fillTemplate.x,
-                fillTemplate.y,
-                fillWidth,
-                fillTemplate.height
+                secondaryFill.rectTransform,
+                secondaryFillTemplate.x + continuousWidth - secondaryFillWidth,
+                secondaryFillTemplate.y,
+                secondaryFillWidth,
+                secondaryFillTemplate.height
             );
         }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowProjector.cs
@@ -294,6 +294,11 @@ internal sealed class PlanetSectorWindowProjector
         if (planet?.IsPopulated() != true)
             return CreateHiddenBar();
 
+        string opposingFactionId = GetOpposingFactionID(uiContext);
+        int opposingSupport = string.IsNullOrEmpty(opposingFactionId)
+            ? 0
+            : planet.GetPopularSupport(opposingFactionId);
+
         return new PlanetSectorBarRenderData(
             true,
             0,
@@ -301,6 +306,8 @@ internal sealed class PlanetSectorWindowProjector
             support / 100f,
             uiContext.GetPlayerFactionTheme()?.GetPrimaryColor() ?? Color.white,
             Color.clear,
+            Color.black,
+            opposingSupport / 100f,
             GetOpposingSupportColor(uiContext)
         );
     }
@@ -343,14 +350,24 @@ internal sealed class PlanetSectorWindowProjector
     /// <returns>The opposing faction color.</returns>
     private static Color32 GetOpposingSupportColor(UIContext uiContext)
     {
+        string opposingFactionId = GetOpposingFactionID(uiContext);
+        return uiContext.GetTheme(opposingFactionId)?.GetPrimaryColor() ?? Color.white;
+    }
+
+    /// <summary>
+    /// Gets the faction displayed opposite the player in the popular-support bar.
+    /// </summary>
+    /// <param name="uiContext">The current strategy presentation context.</param>
+    /// <returns>The opposing faction instance ID, or null when none exists.</returns>
+    private static string GetOpposingFactionID(UIContext uiContext)
+    {
         string playerFactionId = uiContext.GetPlayerFactionInstanceID();
-        string opposingFactionId = uiContext
+        return uiContext
             .Game?.GetFactions()
             ?.FirstOrDefault(faction =>
                 !string.Equals(faction.InstanceID, playerFactionId, StringComparison.Ordinal)
             )
             ?.InstanceID;
-        return uiContext.GetTheme(opposingFactionId)?.GetPrimaryColor() ?? Color.white;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowRenderData.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowRenderData.cs
@@ -158,6 +158,8 @@ public sealed class PlanetSectorBarRenderData
     /// <param name="fillColor">The occupied or continuous fill color.</param>
     /// <param name="emptyColor">The unoccupied segmented cell color.</param>
     /// <param name="backgroundColor">The bar background color.</param>
+    /// <param name="secondaryFillRatio">The normalized secondary continuous fill ratio.</param>
+    /// <param name="secondaryFillColor">The secondary continuous fill color.</param>
     public PlanetSectorBarRenderData(
         bool visible,
         int cellCount,
@@ -165,7 +167,9 @@ public sealed class PlanetSectorBarRenderData
         float fillRatio,
         Color32 fillColor,
         Color32 emptyColor,
-        Color32 backgroundColor
+        Color32 backgroundColor,
+        float secondaryFillRatio = 0f,
+        Color32 secondaryFillColor = default
     )
     {
         Visible = visible;
@@ -175,6 +179,8 @@ public sealed class PlanetSectorBarRenderData
         FillColor = fillColor;
         EmptyColor = emptyColor;
         BackgroundColor = backgroundColor;
+        SecondaryFillRatio = secondaryFillRatio;
+        SecondaryFillColor = secondaryFillColor;
     }
 
     public Color32 BackgroundColor { get; }
@@ -188,6 +194,10 @@ public sealed class PlanetSectorBarRenderData
     public float FillRatio { get; }
 
     public int LitCells { get; }
+
+    public Color32 SecondaryFillColor { get; }
+
+    public float SecondaryFillRatio { get; }
 
     public bool Visible { get; }
 }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorPlanetViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorPlanetViewTests.cs
@@ -61,7 +61,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
                 PlanetIcon.Mission,
                 CreateSegmentedBar(true, 4, 2),
                 CreateSegmentedBar(false, 0, 0),
-                CreateContinuousBar(true, 0.5f)
+                CreateContinuousBar(true, 0.5f, 0.25f)
             );
             RectInt planetTemplate = GetSourceRect(GetField<RawImage>("planetImage").transform);
 
@@ -108,11 +108,25 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
 
             RawImage planetImage = GetField<RawImage>("planetImage");
             Image supportFill = GetField<Image>("supportBarFillImage");
+            Image supportSecondaryFill = GetField<Image>("supportBarSecondaryFillImage");
+            RectInt supportBarBounds = GetSourceRect(
+                GetField<Image>("supportBarBackgroundImage").transform
+            );
             Assert.IsTrue(GetField<RectTransform>("supportBarRoot").gameObject.activeSelf);
             Assert.IsTrue(supportFill.gameObject.activeSelf);
+            Assert.IsTrue(supportSecondaryFill.gameObject.activeSelf);
             Assert.AreEqual(
                 Mathf.RoundToInt(planetTemplate.width * 0.5f),
                 GetSourceRect(supportFill.transform).width
+            );
+            RectInt secondaryFillBounds = GetSourceRect(supportSecondaryFill.transform);
+            Assert.AreEqual(
+                Mathf.RoundToInt(planetTemplate.width * 0.25f),
+                secondaryFillBounds.width
+            );
+            Assert.AreEqual(
+                supportBarBounds.xMax - secondaryFillBounds.width,
+                secondaryFillBounds.x
             );
             Assert.IsTrue(_view.gameObject.activeSelf);
             Assert.IsTrue(planetImage.raycastTarget);
@@ -134,6 +148,31 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
             Assert.IsFalse(GetField<Image>("energyBarFillImage").gameObject.activeSelf);
             Assert.IsFalse(GetField<Image>("rawBarFillImage").gameObject.activeSelf);
             Assert.IsFalse(GetField<Image>("supportBarFillImage").gameObject.activeSelf);
+            Assert.IsFalse(GetField<Image>("supportBarSecondaryFillImage").gameObject.activeSelf);
+        }
+
+        [Test]
+        public void Render_SecondaryContinuousFillWithoutPrimaryFill_RendersFromRight()
+        {
+            PlanetSectorPlanetRenderData data = CreateData(
+                PlanetIcon.None,
+                PlanetIcon.None,
+                CreateContinuousBar(true, 0f),
+                CreateContinuousBar(true, 0f),
+                CreateContinuousBar(true, 0f, 0.4f)
+            );
+            RectInt template = GetSourceRect(
+                GetField<Image>("supportBarBackgroundImage").transform
+            );
+
+            _view.Render(data, new Vector2Int(200, 150));
+
+            Assert.IsFalse(GetField<Image>("supportBarFillImage").gameObject.activeSelf);
+            Image secondaryFill = GetField<Image>("supportBarSecondaryFillImage");
+            Assert.IsTrue(secondaryFill.gameObject.activeSelf);
+            RectInt bounds = GetSourceRect(secondaryFill.transform);
+            Assert.AreEqual(Mathf.RoundToInt(template.width * 0.4f), bounds.width);
+            Assert.AreEqual(template.xMax - bounds.width, bounds.x);
         }
 
         [Test]
@@ -335,7 +374,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
             );
         }
 
-        private static PlanetSectorBarRenderData CreateContinuousBar(bool visible, float ratio)
+        private static PlanetSectorBarRenderData CreateContinuousBar(
+            bool visible,
+            float ratio,
+            float secondaryRatio = 0f
+        )
         {
             return new PlanetSectorBarRenderData(
                 visible,
@@ -344,7 +387,9 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
                 ratio,
                 new Color32(0, 255, 0, 255),
                 default,
-                new Color32(0, 0, 0, 255)
+                new Color32(0, 0, 0, 255),
+                secondaryRatio,
+                new Color32(255, 0, 0, 255)
             );
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowProjectorTests.cs
@@ -192,9 +192,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
                 (Color32)playerTheme.GetPrimaryColor(),
                 presentation.SupportBar.FillColor
             );
+            Assert.AreEqual((Color32)Color.black, presentation.SupportBar.BackgroundColor);
+            Assert.AreEqual(0.25f, presentation.SupportBar.SecondaryFillRatio);
             Assert.AreEqual(
                 (Color32)opposingTheme.GetPrimaryColor(),
-                presentation.SupportBar.BackgroundColor
+                presentation.SupportBar.SecondaryFillColor
             );
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowRenderDataTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowRenderDataTests.cs
@@ -21,9 +21,18 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
                 0.5f,
                 new Color32(1, 2, 3, 4),
                 new Color32(5, 6, 7, 8),
-                new Color32(9, 10, 11, 12)
+                new Color32(9, 10, 11, 12),
+                0.25f,
+                new Color32(13, 14, 15, 16)
             );
             _texture = new Texture2D(1, 1);
+        }
+
+        [Test]
+        public void Bar_SecondaryFill_PreservesRatioAndColor()
+        {
+            Assert.AreEqual(0.25f, _bar.SecondaryFillRatio);
+            Assert.AreEqual(new Color32(13, 14, 15, 16), _bar.SecondaryFillColor);
         }
 
         [TearDown]


### PR DESCRIPTION
## Summary
- render each faction's recorded popular support as its own fill
- leave support not assigned to either displayed faction black
- cover partial and opponent-only support rendering

## Validation
- `./build.sh format`
- `./build.sh lint`
- `LOG_LEVEL=none ./build.sh test` (4,069 passed)
- `LOG_LEVEL=none ./build.sh build`