### PR TITLE
Fixing facility construction artwork.

### DIFF
--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowProjector.cs
@@ -200,7 +200,7 @@ internal sealed class FacilityWindowProjector
             uiContext.GetTexture(
                 selected ? stateTheme?.ActiveImagePath : stateTheme?.InactiveImagePath
             ),
-            GetManufacturingTexture(uiContext, ownerFactionId, current),
+            GetManufacturingTexture(uiContext, current),
             current?.GetManufacturingProgress() ?? 0,
             current?.GetConstructionCost() ?? 0,
             GetManufacturingTitle(type),
@@ -213,28 +213,13 @@ internal sealed class FacilityWindowProjector
     }
 
     /// <summary>
-    /// Resolves the artwork for the item currently being manufactured.
+    /// Resolves the compact artwork for the item currently being manufactured.
     /// </summary>
     /// <param name="uiContext">The active presentation context.</param>
-    /// <param name="ownerFactionId">The producing planet owner.</param>
     /// <param name="item">The current queue item.</param>
-    /// <returns>The configured construction artwork or the item's compact artwork.</returns>
-    private static Texture GetManufacturingTexture(
-        UIContext uiContext,
-        string ownerFactionId,
-        IManufacturable item
-    )
+    /// <returns>The item's compact artwork.</returns>
+    private static Texture GetManufacturingTexture(UIContext uiContext, IManufacturable item)
     {
-        if (item is Building building)
-        {
-            string constructionPath = uiContext
-                .GetTheme(ownerFactionId)
-                ?.StrategyWindows?.Facility?.GetConstructionImagePath(building.GetTypeID());
-            Texture constructionTexture = uiContext.GetTexture(constructionPath);
-            if (constructionTexture != null)
-                return constructionTexture;
-        }
-
         return item is ISceneNode node ? uiContext.GetEntityTexture(node, true) : null;
     }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowProjectorTests.cs
@@ -271,7 +271,25 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
         }
 
         [Test]
-        public void CreateRenderData_QueuedBuilding_UsesConfiguredConstructionTexture()
+        public void CreateRenderData_UnderConstructionInventoryBuilding_UsesConstructionTexture()
+        {
+            Building mine = CreateBuilding(
+                "incomplete-mine",
+                "Incomplete Mine",
+                BuildingType.Mine,
+                ManufacturingStatus.Building
+            );
+            _planet.AddTestChild(mine);
+            _session.Reconcile();
+            _session.SetActiveTab(FacilityWindowTab.Mines);
+
+            FacilityWindowRenderData data = _projector.CreateRenderData(_window, _session, null);
+
+            Assert.AreSame(_constructionTexture, data.InventoryItems[0].Texture);
+        }
+
+        [Test]
+        public void CreateRenderData_QueuedBuilding_UsesCompactEntityTexture()
         {
             Building building = CreateBuilding(
                 "queued-building",
@@ -286,7 +304,10 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
 
             FacilityWindowRenderData data = _projector.CreateRenderData(_window, _session, null);
 
-            Assert.AreSame(_constructionTexture, data.ManufacturingCards[2].EntityTexture);
+            Assert.AreSame(
+                _uiContext.GetTexture(building.SmallDisplayImagePath),
+                data.ManufacturingCards[2].EntityTexture
+            );
         }
 
         [Test]


### PR DESCRIPTION
## Summary

- uses each building's compact transparent artwork in Facilities Under Construction manufacturing cards
- preserves faction-specific construction overlays for buildings shown in facility inventory tabs
- adds regression coverage for both presentation paths
- pairs with https://github.com/davidadas/rebellion2-media/pull/57

## Validation

- `dotnet build GameAssembly.Lint.csproj --no-restore` — passed with 0 warnings and 0 errors
- `FacilityWindowProjectorTests` — 10/10 passed in Unity EditMode
- `git diff --check`

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] N/A — no UI builder changes were required.
- [x] Content changes are included in `rebellion2-media` PR #57.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed to this repository.
- [x] N/A — no documentation changes were required.