### PR TITLE
Restore manufacturing reservations

### DIFF
--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -103,6 +103,8 @@ namespace Rebellion.Game.Galaxy
         private List<Building> _buildings = new List<Building>();
 
         // Manufacturing Status.
+        public bool IsConstructionYardReserved { get; set; }
+
         [PersistableIgnore]
         public Dictionary<ManufacturingType, List<IManufacturable>> ManufacturingQueue
         {
@@ -152,6 +154,7 @@ namespace Rebellion.Game.Galaxy
             copy.UprisingClearTimerOrder = UprisingClearTimerOrder;
             copy.NextUprisingTimerOrder = NextUprisingTimerOrder;
             copy.PopularSupport = new Dictionary<string, int>(PopularSupport);
+            copy.IsConstructionYardReserved = IsConstructionYardReserved;
             copy.ManufacturingQueue = ManufacturingQueue.Keys.ToDictionary(
                 type => type,
                 _ => new List<IManufacturable>()

--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -103,7 +103,9 @@ namespace Rebellion.Game.Galaxy
         private List<Building> _buildings = new List<Building>();
 
         // Manufacturing Status.
-        public bool IsConstructionYardReserved { get; set; }
+        [PersistableMember(Name = "ReservedManufacturingTypes")]
+        private HashSet<ManufacturingType> _reservedManufacturingTypes =
+            new HashSet<ManufacturingType>();
 
         [PersistableIgnore]
         public Dictionary<ManufacturingType, List<IManufacturable>> ManufacturingQueue
@@ -154,7 +156,9 @@ namespace Rebellion.Game.Galaxy
             copy.UprisingClearTimerOrder = UprisingClearTimerOrder;
             copy.NextUprisingTimerOrder = NextUprisingTimerOrder;
             copy.PopularSupport = new Dictionary<string, int>(PopularSupport);
-            copy.IsConstructionYardReserved = IsConstructionYardReserved;
+            copy._reservedManufacturingTypes = new HashSet<ManufacturingType>(
+                _reservedManufacturingTypes
+            );
             copy.ManufacturingQueue = ManufacturingQueue.Keys.ToDictionary(
                 type => type,
                 _ => new List<IManufacturable>()
@@ -568,6 +572,32 @@ namespace Rebellion.Game.Galaxy
         public double GetProductionRate(ManufacturingType type)
         {
             return GetCombinedProductionRate(type);
+        }
+
+        /// <summary>
+        /// Returns whether advisor automation may use a manufacturing lane on this planet.
+        /// </summary>
+        /// <param name="type">The manufacturing lane to inspect.</param>
+        /// <returns>True when the lane is reserved for manual orders.</returns>
+        public bool IsManufacturingReserved(ManufacturingType type)
+        {
+            return type != ManufacturingType.None && _reservedManufacturingTypes.Contains(type);
+        }
+
+        /// <summary>
+        /// Sets whether a manufacturing lane is reserved for manual orders.
+        /// </summary>
+        /// <param name="type">The manufacturing lane to update.</param>
+        /// <param name="reserved">Whether advisor automation must leave the lane available.</param>
+        public void SetManufacturingReserved(ManufacturingType type, bool reserved)
+        {
+            if (type == ManufacturingType.None)
+                throw new ArgumentOutOfRangeException(nameof(type));
+
+            if (reserved)
+                _reservedManufacturingTypes.Add(type);
+            else
+                _reservedManufacturingTypes.Remove(type);
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/FactionAutomationSystem.cs
+++ b/Assets/Scripts/Systems/FactionAutomationSystem.cs
@@ -68,9 +68,9 @@ namespace Rebellion.Systems
         private void FillGarrisonManufacturingCapacity(Faction faction)
         {
             List<Planet> ownedPlanets = GetOwnedPlanets(faction);
-            int availableCapacity = ownedPlanets.Sum(planet =>
-                planet.GetAvailableManufacturingCapacity(ManufacturingType.Troop)
-            );
+            int availableCapacity = ownedPlanets
+                .Where(planet => !planet.IsManufacturingReserved(ManufacturingType.Troop))
+                .Sum(planet => planet.GetAvailableManufacturingCapacity(ManufacturingType.Troop));
 
             for (int orderIndex = 0; orderIndex < availableCapacity; orderIndex++)
             {
@@ -125,7 +125,7 @@ namespace Rebellion.Systems
         {
             List<Planet> ownedPlanets = GetOwnedPlanets(faction);
             int availableCapacity = ownedPlanets
-                .Where(planet => !planet.IsConstructionYardReserved)
+                .Where(planet => !planet.IsManufacturingReserved(ManufacturingType.Building))
                 .Sum(planet =>
                     planet.GetAvailableManufacturingCapacity(ManufacturingType.Building)
                 );
@@ -257,7 +257,10 @@ namespace Rebellion.Systems
         )
         {
             return planets
-                .Where(planet => planet.GetAvailableManufacturingCapacity(manufacturingType) > 0)
+                .Where(planet =>
+                    !planet.IsManufacturingReserved(manufacturingType)
+                    && planet.GetAvailableManufacturingCapacity(manufacturingType) > 0
+                )
                 .OrderByDescending(planet =>
                     planet.GetAvailableManufacturingCapacity(manufacturingType)
                 )
@@ -282,7 +285,7 @@ namespace Rebellion.Systems
         {
             List<Planet> producers = planets
                 .Where(planet =>
-                    !planet.IsConstructionYardReserved
+                    !planet.IsManufacturingReserved(ManufacturingType.Building)
                     && planet.GetAvailableManufacturingCapacity(ManufacturingType.Building) > 0
                 )
                 .ToList();

--- a/Assets/Scripts/Systems/FactionAutomationSystem.cs
+++ b/Assets/Scripts/Systems/FactionAutomationSystem.cs
@@ -124,9 +124,11 @@ namespace Rebellion.Systems
         private void FillProductionManufacturingCapacity(Faction faction)
         {
             List<Planet> ownedPlanets = GetOwnedPlanets(faction);
-            int availableCapacity = ownedPlanets.Sum(planet =>
-                planet.GetAvailableManufacturingCapacity(ManufacturingType.Building)
-            );
+            int availableCapacity = ownedPlanets
+                .Where(planet => !planet.IsConstructionYardReserved)
+                .Sum(planet =>
+                    planet.GetAvailableManufacturingCapacity(ManufacturingType.Building)
+                );
 
             for (int orderIndex = 0; orderIndex < availableCapacity; orderIndex++)
             {
@@ -280,7 +282,8 @@ namespace Rebellion.Systems
         {
             List<Planet> producers = planets
                 .Where(planet =>
-                    planet.GetAvailableManufacturingCapacity(ManufacturingType.Building) > 0
+                    !planet.IsConstructionYardReserved
+                    && planet.GetAvailableManufacturingCapacity(ManufacturingType.Building) > 0
                 )
                 .ToList();
             IEnumerable<Planet> destinations = planets.Where(planet =>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
@@ -81,6 +81,7 @@ public enum StrategyMenuAction
     Stop,
     CreateMission,
     Destination,
+    Reserve,
     Scrap,
     Move,
     Retire,

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
@@ -57,7 +57,7 @@ internal static class FacilityWindowContextMenuBuilder
         bool playerControlsPlanet
     )
     {
-        return new List<StrategyMenuCommand>
+        List<StrategyMenuCommand> commands = new List<StrategyMenuCommand>
         {
             new StrategyMenuCommand(
                 StrategyMenuAction.Build,
@@ -77,8 +77,24 @@ internal static class FacilityWindowContextMenuBuilder
             new StrategyMenuCommand(StrategyMenuAction.None, "Rename", false),
             new StrategyMenuCommand(StrategyMenuAction.Encyclopedia, "Encyclopedia", true),
             new StrategyMenuCommand(StrategyMenuAction.Status, "Status", true),
-            new StrategyMenuCommand(StrategyMenuAction.None, "Reserved", false),
         };
+
+        if (manufacturingTab == FacilityWindowTab.Construction)
+        {
+            commands.Add(
+                new StrategyMenuCommand(
+                    StrategyMenuAction.Reserve,
+                    "Reserved",
+                    playerControlsPlanet,
+                    planet?.IsConstructionYardReserved == true
+                        ? StrategyContextMenuIconKeys.CheckMark
+                        : StrategyContextMenuIconKeys.None,
+                    usesIconColumn: true
+                )
+            );
+        }
+
+        return commands;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
@@ -79,14 +79,17 @@ internal static class FacilityWindowContextMenuBuilder
             new StrategyMenuCommand(StrategyMenuAction.Status, "Status", true),
         };
 
-        if (manufacturingTab == FacilityWindowTab.Construction)
+        ManufacturingType? manufacturingType = ConstructionOrderController.GetManufacturingType(
+            manufacturingTab
+        );
+        if (manufacturingType.HasValue)
         {
             commands.Add(
                 new StrategyMenuCommand(
                     StrategyMenuAction.Reserve,
                     "Reserved",
                     playerControlsPlanet,
-                    planet?.IsConstructionYardReserved == true
+                    planet?.IsManufacturingReserved(manufacturingType.Value) == true
                         ? StrategyContextMenuIconKeys.CheckMark
                         : StrategyContextMenuIconKeys.None,
                     usesIconColumn: true

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
@@ -317,6 +317,7 @@ public sealed class FacilityWindowController
         if (
             request?.Source is not StrategyContextMenuProviderContext context
             || command is not StrategyMenuCommand strategyCommand
+            || !strategyCommand.Enabled
             || !windowManager.TryGetWindowView(context.Window, out FacilityWindowView view)
         )
             return;
@@ -335,6 +336,9 @@ public sealed class FacilityWindowController
             case StrategyMenuAction.Destination:
                 BeginContextTargeting(context, strategyCommand.Action);
                 break;
+            case StrategyMenuAction.Reserve:
+                ToggleConstructionYardReservation(view);
+                break;
             case StrategyMenuAction.Encyclopedia:
                 actions.OpenFacilityInfo(GetStatusTarget(view));
                 break;
@@ -352,6 +356,31 @@ public sealed class FacilityWindowController
     /// </summary>
     /// <param name="request">The canceled context-menu request.</param>
     public void OnContextMenuCancelled(ContextMenuRequest request) { }
+
+    /// <summary>
+    /// Toggles whether the advisor may use the represented planet's construction yards.
+    /// </summary>
+    /// <param name="view">The facility view whose construction lane was selected.</param>
+    private void ToggleConstructionYardReservation(FacilityWindowView view)
+    {
+        if (
+            !TryGetSession(view, out FacilityWindowSession session)
+            || session.GetContextManufacturingTab() != FacilityWindowTab.Construction
+        )
+            return;
+
+        Planet planet = GetAuthoritativePlanet(session.Planet?.Planet?.InstanceID);
+        string playerFactionId = getGame()?.GetPlayerFaction()?.InstanceID;
+        if (
+            planet == null
+            || string.IsNullOrEmpty(playerFactionId)
+            || !string.Equals(planet.OwnerInstanceID, playerFactionId, StringComparison.Ordinal)
+        )
+            return;
+
+        planet.IsConstructionYardReserved = !planet.IsConstructionYardReserved;
+        actions.RefreshFacilityState();
+    }
 
     /// <summary>
     /// Begins destination targeting for a facility manufacturing lane.

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
@@ -337,7 +337,7 @@ public sealed class FacilityWindowController
                 BeginContextTargeting(context, strategyCommand.Action);
                 break;
             case StrategyMenuAction.Reserve:
-                ToggleConstructionYardReservation(view);
+                ToggleManufacturingReservation(view);
                 break;
             case StrategyMenuAction.Encyclopedia:
                 actions.OpenFacilityInfo(GetStatusTarget(view));
@@ -358,15 +358,19 @@ public sealed class FacilityWindowController
     public void OnContextMenuCancelled(ContextMenuRequest request) { }
 
     /// <summary>
-    /// Toggles whether the advisor may use the represented planet's construction yards.
+    /// Toggles whether the advisor may use the represented manufacturing lane.
     /// </summary>
-    /// <param name="view">The facility view whose construction lane was selected.</param>
-    private void ToggleConstructionYardReservation(FacilityWindowView view)
+    /// <param name="view">The facility view whose manufacturing lane was selected.</param>
+    private void ToggleManufacturingReservation(FacilityWindowView view)
     {
-        if (
-            !TryGetSession(view, out FacilityWindowSession session)
-            || session.GetContextManufacturingTab() != FacilityWindowTab.Construction
-        )
+        if (!TryGetSession(view, out FacilityWindowSession session))
+            return;
+
+        FacilityWindowTab? manufacturingTab = session.GetContextManufacturingTab();
+        ManufacturingType? manufacturingType = manufacturingTab.HasValue
+            ? ConstructionOrderController.GetManufacturingType(manufacturingTab.Value)
+            : null;
+        if (!manufacturingType.HasValue)
             return;
 
         Planet planet = GetAuthoritativePlanet(session.Planet?.Planet?.InstanceID);
@@ -378,7 +382,10 @@ public sealed class FacilityWindowController
         )
             return;
 
-        planet.IsConstructionYardReserved = !planet.IsConstructionYardReserved;
+        planet.SetManufacturingReserved(
+            manufacturingType.Value,
+            !planet.IsManufacturingReserved(manufacturingType.Value)
+        );
         actions.RefreshFacilityState();
     }
 

--- a/Assets/Tests/EditMode/GameTests/Game/Galaxy/PlanetTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Galaxy/PlanetTests.cs
@@ -366,6 +366,7 @@ namespace Rebellion.Tests.Game.Galaxy
         {
             _planet.SetPopularSupport("FNALL1", 100);
             _planet.IsDestroyed = true;
+            _planet.IsConstructionYardReserved = true;
             _planet.AddChild(new Fleet { OwnerInstanceID = "FNALL1" });
 
             string serialized = SerializationHelper.Serialize(_planet);
@@ -380,6 +381,11 @@ namespace Rebellion.Tests.Game.Galaxy
                 _planet.GetPopularSupport("FNALL1"),
                 deserialized.GetPopularSupport("FNALL1"),
                 "Deserialized planet should retain popular support."
+            );
+            Assert.AreEqual(
+                _planet.IsConstructionYardReserved,
+                deserialized.IsConstructionYardReserved,
+                "Deserialized planet should retain its construction-yard reservation."
             );
             Assert.AreEqual(
                 _planet.GetChildren<Fleet>().Count,

--- a/Assets/Tests/EditMode/GameTests/Game/Galaxy/PlanetTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Galaxy/PlanetTests.cs
@@ -366,7 +366,9 @@ namespace Rebellion.Tests.Game.Galaxy
         {
             _planet.SetPopularSupport("FNALL1", 100);
             _planet.IsDestroyed = true;
-            _planet.IsConstructionYardReserved = true;
+            _planet.SetManufacturingReserved(ManufacturingType.Ship, true);
+            _planet.SetManufacturingReserved(ManufacturingType.Building, true);
+            _planet.SetManufacturingReserved(ManufacturingType.Troop, true);
             _planet.AddChild(new Fleet { OwnerInstanceID = "FNALL1" });
 
             string serialized = SerializationHelper.Serialize(_planet);
@@ -382,15 +384,35 @@ namespace Rebellion.Tests.Game.Galaxy
                 deserialized.GetPopularSupport("FNALL1"),
                 "Deserialized planet should retain popular support."
             );
-            Assert.AreEqual(
-                _planet.IsConstructionYardReserved,
-                deserialized.IsConstructionYardReserved,
-                "Deserialized planet should retain its construction-yard reservation."
-            );
+            Assert.IsTrue(deserialized.IsManufacturingReserved(ManufacturingType.Ship));
+            Assert.IsTrue(deserialized.IsManufacturingReserved(ManufacturingType.Building));
+            Assert.IsTrue(deserialized.IsManufacturingReserved(ManufacturingType.Troop));
             Assert.AreEqual(
                 _planet.GetChildren<Fleet>().Count,
                 deserialized.GetChildren<Fleet>().Count,
                 "Deserialized planet should retain fleets."
+            );
+        }
+
+        [Test]
+        public void SetManufacturingReserved_ReservedThenReleased_UpdatesSelectedLaneOnly()
+        {
+            _planet.SetManufacturingReserved(ManufacturingType.Troop, true);
+
+            Assert.IsTrue(_planet.IsManufacturingReserved(ManufacturingType.Troop));
+            Assert.IsFalse(_planet.IsManufacturingReserved(ManufacturingType.Ship));
+            Assert.IsFalse(_planet.IsManufacturingReserved(ManufacturingType.Building));
+
+            _planet.SetManufacturingReserved(ManufacturingType.Troop, false);
+
+            Assert.IsFalse(_planet.IsManufacturingReserved(ManufacturingType.Troop));
+        }
+
+        [Test]
+        public void SetManufacturingReserved_None_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                _planet.SetManufacturingReserved(ManufacturingType.None, true)
             );
         }
 

--- a/Assets/Tests/EditMode/GameTests/Systems/FactionAutomationSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FactionAutomationSystemTests.cs
@@ -111,6 +111,17 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_ManageGarrisonsWithReservedTrainingFacility_DoesNotQueueWork()
+        {
+            _faction.ManageProduction = false;
+            _producer.SetManufacturingReserved(ManufacturingType.Troop, true);
+
+            _automation.ProcessTick();
+
+            Assert.IsEmpty(_destination.GetAllRegiments());
+        }
+
+        [Test]
         public void ProcessTick_ManageProduction_FillsCapacityWithMatchedPair()
         {
             _faction.ManageGarrisons = false;
@@ -137,10 +148,10 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_ManageProductionWithReservedConstructionYard_DoesNotQueueWork()
+        public void ProcessTick_ManageProductionWithReservedBuildingLane_DoesNotQueueWork()
         {
             _faction.ManageGarrisons = false;
-            _producer.IsConstructionYardReserved = true;
+            _producer.SetManufacturingReserved(ManufacturingType.Building, true);
             int mineCount = CountResourceFacilities(BuildingType.Mine);
             int refineryCount = CountResourceFacilities(BuildingType.Refinery);
 
@@ -154,7 +165,7 @@ namespace Rebellion.Tests.Systems
         public void ProcessTick_ReservedDestination_RemainsAvailableForAutomatedDelivery()
         {
             _faction.ManageGarrisons = false;
-            _destination.IsConstructionYardReserved = true;
+            _destination.SetManufacturingReserved(ManufacturingType.Building, true);
             _destination.PositionX = 1;
 
             _automation.ProcessTick();

--- a/Assets/Tests/EditMode/GameTests/Systems/FactionAutomationSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FactionAutomationSystemTests.cs
@@ -1,9 +1,15 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Rebellion.Game;
+using Rebellion.Game.Encyclopedia;
+using Rebellion.Game.Events;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
+using Rebellion.Game.Messages;
 using Rebellion.Game.Units;
+using Rebellion.Generation;
 using Rebellion.Systems;
 
 namespace Rebellion.Tests.Systems
@@ -11,6 +17,9 @@ namespace Rebellion.Tests.Systems
     [TestFixture]
     public class FactionAutomationSystemTests
     {
+        private const string _factionId = "faction";
+        private const string _garrisonTypeId = "garrison";
+
         private GameRoot _game;
         private Faction _faction;
         private Planet _producer;
@@ -20,10 +29,12 @@ namespace Rebellion.Tests.Systems
         [SetUp]
         public void SetUp()
         {
-            _game = new GameRoot(TestContent.Data.GameConfig);
+            GameConfig config = CreateGameConfig();
+            GameDataCatalog gameData = CreateGameData(config);
+            _game = new GameRoot(config);
             _faction = new Faction
             {
-                InstanceID = "FNALL1",
+                InstanceID = _factionId,
                 ManageGarrisons = true,
                 ManageProduction = true,
             };
@@ -46,7 +57,7 @@ namespace Rebellion.Tests.Systems
                 _game,
                 new FleetSystem(_game)
             );
-            _automation = new FactionAutomationSystem(_game, TestContent.Data, manufacturing);
+            _automation = new FactionAutomationSystem(_game, gameData, manufacturing);
         }
 
         [Test]
@@ -64,7 +75,7 @@ namespace Rebellion.Tests.Systems
                 ManufacturingStatus.Building,
                 _destination.GetAllRegiments().Single().ManufacturingStatus
             );
-            Assert.AreEqual("REAL002", _destination.GetAllRegiments().Single().TypeID);
+            Assert.AreEqual(_garrisonTypeId, _destination.GetAllRegiments().Single().TypeID);
         }
 
         [Test]
@@ -126,6 +137,32 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_ManageProductionWithReservedConstructionYard_DoesNotQueueWork()
+        {
+            _faction.ManageGarrisons = false;
+            _producer.IsConstructionYardReserved = true;
+            int mineCount = CountResourceFacilities(BuildingType.Mine);
+            int refineryCount = CountResourceFacilities(BuildingType.Refinery);
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(mineCount, CountResourceFacilities(BuildingType.Mine));
+            Assert.AreEqual(refineryCount, CountResourceFacilities(BuildingType.Refinery));
+        }
+
+        [Test]
+        public void ProcessTick_ReservedDestination_RemainsAvailableForAutomatedDelivery()
+        {
+            _faction.ManageGarrisons = false;
+            _destination.IsConstructionYardReserved = true;
+            _destination.PositionX = 1;
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(1, _destination.GetTotalBuildingTypeCount(BuildingType.Mine));
+        }
+
+        [Test]
         public void ProcessTick_ManageProductionWithoutMineCapacity_DoesNotAddRefinery()
         {
             _faction.ManageGarrisons = false;
@@ -161,6 +198,73 @@ namespace Rebellion.Tests.Systems
             };
             planet.SetFullPopularSupport(_faction.InstanceID);
             return planet;
+        }
+
+        private static GameConfig CreateGameConfig()
+        {
+            GameConfig config = new GameConfig();
+            config.AI.Garrison.SupportThreshold = 50;
+            config.AI.Garrison.GarrisonDivisor = 10;
+            config.AI.Garrison.UprisingMultiplier = 2;
+            return config;
+        }
+
+        private static GameDataCatalog CreateGameData(GameConfig config)
+        {
+            GameGenerationConfig generationConfig = new GameGenerationConfig
+            {
+                GalaxyClassification = new GalaxyClassificationSection
+                {
+                    FactionSetups = new List<FactionSetup>
+                    {
+                        new FactionSetup
+                        {
+                            FactionID = _factionId,
+                            GarrisonTroopTypeID = _garrisonTypeId,
+                        },
+                    },
+                },
+            };
+            List<string> manufacturingFactionIds = new List<string> { _factionId };
+            Building mine = new Building
+            {
+                TypeID = "mine",
+                BuildingType = BuildingType.Mine,
+                ConstructionCost = 1,
+                BaseBuildSpeed = 1,
+                ManufacturingFactionInstanceIDs = manufacturingFactionIds,
+            };
+            Building refinery = new Building
+            {
+                TypeID = "refinery",
+                BuildingType = BuildingType.Refinery,
+                ConstructionCost = 1,
+                BaseBuildSpeed = 1,
+                ManufacturingFactionInstanceIDs = manufacturingFactionIds,
+            };
+            Regiment garrison = new Regiment
+            {
+                TypeID = _garrisonTypeId,
+                ConstructionCost = 1,
+                BaseBuildSpeed = 1,
+                ManufacturingFactionInstanceIDs = manufacturingFactionIds,
+            };
+            return new GameDataCatalog(
+                config,
+                generationConfig,
+                Array.Empty<Faction>(),
+                Array.Empty<PlanetSector>(),
+                new[] { mine, refinery },
+                Array.Empty<CapitalShip>(),
+                Array.Empty<Starfighter>(),
+                new[] { garrison },
+                Array.Empty<SpecialForces>(),
+                Array.Empty<Officer>(),
+                Array.Empty<GameEvent>(),
+                Array.Empty<MessageDefinition>(),
+                new EncyclopediaEntries(),
+                new FactionThemes()
+            );
         }
 
         private void AddProductionFacility(Planet planet, string instanceId, ManufacturingType type)

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
@@ -67,6 +67,63 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
         }
 
         [Test]
+        public void Build_UnreservedConstructionLane_ReturnsUncheckedReservationCommand()
+        {
+            Planet planet = CreatePlanet(withBuildingQueue: false);
+
+            List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
+                planet,
+                FacilityWindowTab.Manufacturing,
+                FacilityWindowTab.Construction,
+                null,
+                "owner"
+            );
+
+            StrategyMenuCommand reserve = commands.Single(command =>
+                command.Action == StrategyMenuAction.Reserve
+            );
+            Assert.IsTrue(reserve.Enabled);
+            Assert.AreEqual(StrategyContextMenuIconKeys.None, reserve.IconKey);
+            Assert.IsTrue(reserve.UsesIconColumn);
+        }
+
+        [Test]
+        public void Build_ReservedConstructionLane_ReturnsCheckedReservationCommand()
+        {
+            Planet planet = CreatePlanet(withBuildingQueue: false);
+            planet.IsConstructionYardReserved = true;
+
+            List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
+                planet,
+                FacilityWindowTab.Manufacturing,
+                FacilityWindowTab.Construction,
+                null,
+                "owner"
+            );
+
+            StrategyMenuCommand reserve = commands.Single(command =>
+                command.Action == StrategyMenuAction.Reserve
+            );
+            Assert.AreEqual(StrategyContextMenuIconKeys.CheckMark, reserve.IconKey);
+        }
+
+        [Test]
+        public void Build_NonConstructionManufacturingLane_OmitsReservationCommand()
+        {
+            Planet planet = CreatePlanet(withBuildingQueue: false);
+
+            List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
+                planet,
+                FacilityWindowTab.Manufacturing,
+                FacilityWindowTab.Shipyards,
+                null,
+                "owner"
+            );
+
+            Assert.IsFalse(commands.Any(command => command.Action == StrategyMenuAction.Reserve));
+        }
+
+        [Test]
         public void Build_InventoryItemUnderConstruction_ReturnsEnabledStopCommand()
         {
             Planet planet = CreatePlanet(withBuildingQueue: false);

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
@@ -66,15 +66,19 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
             Assert.IsFalse(stop.Enabled);
         }
 
-        [Test]
-        public void Build_UnreservedConstructionLane_ReturnsUncheckedReservationCommand()
+        [TestCase(FacilityWindowTab.Shipyards)]
+        [TestCase(FacilityWindowTab.Training)]
+        [TestCase(FacilityWindowTab.Construction)]
+        public void Build_UnreservedManufacturingLane_ReturnsUncheckedReservationCommand(
+            FacilityWindowTab manufacturingTab
+        )
         {
             Planet planet = CreatePlanet(withBuildingQueue: false);
 
             List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
                 planet,
                 FacilityWindowTab.Manufacturing,
-                FacilityWindowTab.Construction,
+                manufacturingTab,
                 null,
                 "owner"
             );
@@ -87,16 +91,21 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
             Assert.IsTrue(reserve.UsesIconColumn);
         }
 
-        [Test]
-        public void Build_ReservedConstructionLane_ReturnsCheckedReservationCommand()
+        [TestCase(FacilityWindowTab.Shipyards, ManufacturingType.Ship)]
+        [TestCase(FacilityWindowTab.Training, ManufacturingType.Troop)]
+        [TestCase(FacilityWindowTab.Construction, ManufacturingType.Building)]
+        public void Build_ReservedManufacturingLane_ReturnsCheckedReservationCommand(
+            FacilityWindowTab manufacturingTab,
+            ManufacturingType manufacturingType
+        )
         {
             Planet planet = CreatePlanet(withBuildingQueue: false);
-            planet.IsConstructionYardReserved = true;
+            planet.SetManufacturingReserved(manufacturingType, true);
 
             List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
                 planet,
                 FacilityWindowTab.Manufacturing,
-                FacilityWindowTab.Construction,
+                manufacturingTab,
                 null,
                 "owner"
             );
@@ -105,22 +114,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
                 command.Action == StrategyMenuAction.Reserve
             );
             Assert.AreEqual(StrategyContextMenuIconKeys.CheckMark, reserve.IconKey);
-        }
-
-        [Test]
-        public void Build_NonConstructionManufacturingLane_OmitsReservationCommand()
-        {
-            Planet planet = CreatePlanet(withBuildingQueue: false);
-
-            List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
-                planet,
-                FacilityWindowTab.Manufacturing,
-                FacilityWindowTab.Shipyards,
-                null,
-                "owner"
-            );
-
-            Assert.IsFalse(commands.Any(command => command.Action == StrategyMenuAction.Reserve));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowControllerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using Rebellion.Game;
 using Rebellion.Game.Encyclopedia;
@@ -9,6 +10,7 @@ using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 using Rebellion.Systems;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using GalaxyPlanetSector = Rebellion.Game.Galaxy.PlanetSector;
 
 namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
@@ -249,6 +251,47 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
 
             Assert.IsNull(_controller.GetStatusTarget(view));
             Assert.IsEmpty(_controller.GetScrapItems(view));
+        }
+
+        [Test]
+        public void OnContextMenuCommandSelected_ConstructionReservation_TogglesPlanetReservation()
+        {
+            FacilityWindowView view = OpenWindow(out UIWindow window);
+            ManufacturingLaneCardView card =
+                view.GetComponentsInChildren<ManufacturingLaneCardView>(true)
+                    .Single(candidate => candidate.name == "ConstructionManufacturingLaneCard");
+            UIComponentTestHelper.InvokeLifecycle(card, "Awake");
+            UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+            PointerEventData pointer = new PointerEventData(null)
+            {
+                button = PointerEventData.InputButton.Right,
+            };
+            card.GetComponent<UIPointerGestureRelay>().OnPointerDown(pointer);
+            StrategyContextMenuProviderContext context = new StrategyContextMenuProviderContext(
+                window,
+                new StrategyContextMenuLayout(1, 2, 3, 4, 5, 6, 7),
+                pointer,
+                10,
+                20
+            );
+            StrategyMenuCommand reserve = FacilityWindowContextMenuBuilder
+                .Build(
+                    _planet.Planet,
+                    FacilityWindowTab.Manufacturing,
+                    FacilityWindowTab.Construction,
+                    null,
+                    _playerFactionId
+                )
+                .Single(command => command.Action == StrategyMenuAction.Reserve);
+            ContextMenuRequest request = new ContextMenuRequest(
+                context,
+                new IContextMenuCommand[] { reserve },
+                _controller
+            );
+
+            _controller.OnContextMenuCommandSelected(request, reserve);
+
+            Assert.IsTrue(_planet.Planet.IsConstructionYardReserved);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowControllerTests.cs
@@ -254,7 +254,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
         }
 
         [Test]
-        public void OnContextMenuCommandSelected_ConstructionReservation_TogglesPlanetReservation()
+        public void OnContextMenuCommandSelected_ManufacturingReservation_TogglesSelectedLane()
         {
             FacilityWindowView view = OpenWindow(out UIWindow window);
             ManufacturingLaneCardView card =
@@ -291,7 +291,9 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
 
             _controller.OnContextMenuCommandSelected(request, reserve);
 
-            Assert.IsTrue(_planet.Planet.IsConstructionYardReserved);
+            Assert.IsTrue(_planet.Planet.IsManufacturingReserved(ManufacturingType.Building));
+            Assert.IsFalse(_planet.Planet.IsManufacturingReserved(ManufacturingType.Ship));
+            Assert.IsFalse(_planet.Planet.IsManufacturingReserved(ManufacturingType.Troop));
         }
 
         [Test]


### PR DESCRIPTION
## Summary

- restore the original per-lane manufacturing reservation behavior as persistent planet state
- add a checked Reserved command to the Shipyards, Training, and Construction manufacturing-lane context menus
- prevent advisor-managed troop and resource-facility production from using their corresponding reserved lanes while preserving manual orders and delivery destinations
- retain shipyard reservations for source parity and future advisor automation
- replace shipped-content dependencies in the affected automation fixture with synthetic test data

## Validation

- Unity EditMode focused suite: 110 passed, 0 failed
- `dotnet build GameTests.csproj`: succeeded with 0 warnings and 0 errors
- CSharpier check passed for all changed C# files
- `git diff --check` passed
- UI builder rebuild not required because no builder, prefab, scene, or media asset changed

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.