### PR TITLE
Adding ship naming, reservations, and strategy fixes

### DIFF
--- a/Assets/Scripts/Game/Events/GameActions.cs
+++ b/Assets/Scripts/Game/Events/GameActions.cs
@@ -1319,7 +1319,12 @@ namespace Rebellion.Game.Events
                     "SetDisplayName"
                 )
             )
-                target.DisplayName = Name;
+            {
+                if (target is CapitalShip capitalShip)
+                    capitalShip.AssignName(Name);
+                else
+                    target.DisplayName = Name;
+            }
             return;
         }
     }

--- a/Assets/Scripts/Game/Factions/Faction.cs
+++ b/Assets/Scripts/Game/Factions/Faction.cs
@@ -15,20 +15,6 @@ using Rebellion.Util.Serialization;
 namespace Rebellion.Game.Factions
 {
     /// <summary>
-    /// Defines one faction-specific pool of ship names and its fallback pool.
-    /// </summary>
-    [PersistableObject(Name = "NamePool")]
-    public class FactionNamePool
-    {
-        public string NamePoolID { get; set; }
-        public string FallbackNamePoolID { get; set; }
-
-        [PersistableCollectionItem(Name = "Name")]
-        public List<string> Names { get; set; } = new List<string>();
-        public int NextNameIndex { get; set; }
-    }
-
-    /// <summary>
     /// Represents a faction in the game, managing its resources, technologies, and owned entities.
     /// </summary>
     public class Faction : BaseGameEntity

--- a/Assets/Scripts/Game/Factions/Faction.cs
+++ b/Assets/Scripts/Game/Factions/Faction.cs
@@ -15,12 +15,30 @@ using Rebellion.Util.Serialization;
 namespace Rebellion.Game.Factions
 {
     /// <summary>
+    /// Defines one faction-specific pool of ship names and its fallback pool.
+    /// </summary>
+    [PersistableObject(Name = "NamePool")]
+    public class FactionNamePool
+    {
+        public string NamePoolID { get; set; }
+        public string FallbackNamePoolID { get; set; }
+
+        [PersistableCollectionItem(Name = "Name")]
+        public List<string> Names { get; set; } = new List<string>();
+        public int NextNameIndex { get; set; }
+    }
+
+    /// <summary>
     /// Represents a faction in the game, managing its resources, technologies, and owned entities.
     /// </summary>
     public class Faction : BaseGameEntity
     {
         private FactionSettings _settings = new FactionSettings();
         private int _nextFleetNumber = 1;
+
+        [PersistableMember(Name = "NextGenericShipNameNumbers")]
+        private Dictionary<string, int> _nextGenericShipNameNumbers = new Dictionary<string, int>();
+
         private Dictionary<Type, List<ISceneNode>> _ownedEntities = new Dictionary<
             Type,
             List<ISceneNode>
@@ -38,6 +56,9 @@ namespace Rebellion.Game.Factions
 
         // Faction Info.
         public List<string> DisallowedMissionTypeIDs { get; set; } = new List<string>();
+
+        [PersistableCollectionItem(Name = "NamePool")]
+        public List<FactionNamePool> ShipNamePools { get; set; } = new List<FactionNamePool>();
         public FactionSettings Settings
         {
             get => _settings ??= new FactionSettings();
@@ -69,6 +90,7 @@ namespace Rebellion.Game.Factions
         public bool AgentAdvice { get; set; } = true;
         public bool ManageGarrisons { get; set; }
         public bool ManageProduction { get; set; }
+        public bool ManageNaming { get; set; }
 
         // Research Status.
         public FactionResearchState ResearchState { get; set; } = new FactionResearchState();
@@ -198,6 +220,78 @@ namespace Rebellion.Game.Factions
         /// </summary>
         /// <returns>True if the faction is AI controlled, false otherwise.</returns>
         public bool IsAIControlled() => string.IsNullOrEmpty(PlayerID);
+
+        /// <summary>
+        /// Takes the next available ship name from a pool or one of its configured fallbacks.
+        /// </summary>
+        /// <param name="namePoolId">The first name pool to inspect.</param>
+        /// <param name="shipName">The available ship name, when one is found.</param>
+        /// <returns>True when a name was taken; otherwise, false.</returns>
+        public bool TryTakeNextShipName(string namePoolId, out string shipName)
+        {
+            shipName = null;
+            if (string.IsNullOrWhiteSpace(namePoolId) || ShipNamePools.Count == 0)
+                return false;
+
+            HashSet<string> visitedPoolIds = new HashSet<string>(StringComparer.Ordinal);
+            string currentPoolId = namePoolId;
+            for (int fallbackDepth = 0; fallbackDepth < ShipNamePools.Count; fallbackDepth++)
+            {
+                if (string.IsNullOrWhiteSpace(currentPoolId) || !visitedPoolIds.Add(currentPoolId))
+                    return false;
+
+                FactionNamePool namePool = ShipNamePools.FirstOrDefault(pool =>
+                    string.Equals(pool.NamePoolID, currentPoolId, StringComparison.Ordinal)
+                );
+                if (namePool == null)
+                    return false;
+
+                int firstNameIndex = Math.Max(0, namePool.NextNameIndex);
+                for (int nameIndex = firstNameIndex; nameIndex < namePool.Names.Count; nameIndex++)
+                {
+                    namePool.NextNameIndex = nameIndex + 1;
+                    string candidate = namePool.Names[nameIndex];
+                    if (string.IsNullOrWhiteSpace(candidate))
+                        continue;
+
+                    shipName = candidate;
+                    return true;
+                }
+
+                namePool.NextNameIndex = namePool.Names.Count;
+                currentPoolId = namePool.FallbackNamePoolID;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Takes the next numbered generic name for a capital-ship type.
+        /// </summary>
+        /// <param name="ship">The ship that requires a generic name.</param>
+        /// <returns>The ship's generic display name with its faction-specific sequence number.</returns>
+        internal string TakeNextGenericShipName(CapitalShip ship)
+        {
+            if (ship == null)
+                throw new ArgumentNullException(nameof(ship));
+            if (string.IsNullOrWhiteSpace(ship.DisplayName))
+                throw new ArgumentException(
+                    "The ship requires a generic display name.",
+                    nameof(ship)
+                );
+
+            string counterKey = string.IsNullOrWhiteSpace(ship.TypeID)
+                ? ship.DisplayName
+                : ship.TypeID;
+            int nextNumber = _nextGenericShipNameNumbers.TryGetValue(
+                counterKey,
+                out int currentNumber
+            )
+                ? currentNumber
+                : 1;
+            _nextGenericShipNameNumbers[counterKey] = nextNumber + 1;
+            return $"{ship.DisplayName} {nextNumber}";
+        }
 
         /// <summary>
         /// Returns a list of units of a specific type owned by the faction.

--- a/Assets/Scripts/Game/Factions/FactionNamePool.cs
+++ b/Assets/Scripts/Game/Factions/FactionNamePool.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Rebellion.Util.Serialization;
+
+namespace Rebellion.Game.Factions
+{
+    /// <summary>
+    /// Defines one faction-specific pool of ship names and its fallback pool.
+    /// </summary>
+    [PersistableObject(Name = "NamePool")]
+    public class FactionNamePool
+    {
+        public string NamePoolID { get; set; }
+        public string FallbackNamePoolID { get; set; }
+
+        [PersistableCollectionItem(Name = "Name")]
+        public List<string> Names { get; set; } = new List<string>();
+        public int NextNameIndex { get; set; }
+    }
+}

--- a/Assets/Scripts/Game/Factions/FactionNamePool.cs.meta
+++ b/Assets/Scripts/Game/Factions/FactionNamePool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 28bcacc55751417c8e142e3e3267bcc8

--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -103,6 +103,8 @@ namespace Rebellion.Game.Galaxy
         private List<Building> _buildings = new List<Building>();
 
         // Manufacturing Status.
+        public bool IsConstructionYardReserved { get; set; }
+
         [PersistableIgnore]
         public Dictionary<ManufacturingType, List<IManufacturable>> ManufacturingQueue
         {
@@ -152,6 +154,7 @@ namespace Rebellion.Game.Galaxy
             copy.UprisingClearTimerOrder = UprisingClearTimerOrder;
             copy.NextUprisingTimerOrder = NextUprisingTimerOrder;
             copy.PopularSupport = new Dictionary<string, int>(PopularSupport);
+            copy.IsConstructionYardReserved = IsConstructionYardReserved;
             copy.ManufacturingQueue = ManufacturingQueue.Keys.ToDictionary(
                 type => type,
                 _ => new List<IManufacturable>()

--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -103,7 +103,9 @@ namespace Rebellion.Game.Galaxy
         private List<Building> _buildings = new List<Building>();
 
         // Manufacturing Status.
-        public bool IsConstructionYardReserved { get; set; }
+        [PersistableMember(Name = "ReservedManufacturingTypes")]
+        private HashSet<ManufacturingType> _reservedManufacturingTypes =
+            new HashSet<ManufacturingType>();
 
         [PersistableIgnore]
         public Dictionary<ManufacturingType, List<IManufacturable>> ManufacturingQueue
@@ -154,7 +156,9 @@ namespace Rebellion.Game.Galaxy
             copy.UprisingClearTimerOrder = UprisingClearTimerOrder;
             copy.NextUprisingTimerOrder = NextUprisingTimerOrder;
             copy.PopularSupport = new Dictionary<string, int>(PopularSupport);
-            copy.IsConstructionYardReserved = IsConstructionYardReserved;
+            copy._reservedManufacturingTypes = new HashSet<ManufacturingType>(
+                _reservedManufacturingTypes
+            );
             copy.ManufacturingQueue = ManufacturingQueue.Keys.ToDictionary(
                 type => type,
                 _ => new List<IManufacturable>()
@@ -568,6 +572,32 @@ namespace Rebellion.Game.Galaxy
         public double GetProductionRate(ManufacturingType type)
         {
             return GetCombinedProductionRate(type);
+        }
+
+        /// <summary>
+        /// Returns whether advisor automation may use a manufacturing lane on this planet.
+        /// </summary>
+        /// <param name="type">The manufacturing lane to inspect.</param>
+        /// <returns>True when the lane is reserved for manual orders.</returns>
+        public bool IsManufacturingReserved(ManufacturingType type)
+        {
+            return type != ManufacturingType.None && _reservedManufacturingTypes.Contains(type);
+        }
+
+        /// <summary>
+        /// Sets whether a manufacturing lane is reserved for manual orders.
+        /// </summary>
+        /// <param name="type">The manufacturing lane to update.</param>
+        /// <param name="reserved">Whether advisor automation must leave the lane available.</param>
+        public void SetManufacturingReserved(ManufacturingType type, bool reserved)
+        {
+            if (type == ManufacturingType.None)
+                throw new ArgumentOutOfRangeException(nameof(type));
+
+            if (reserved)
+                _reservedManufacturingTypes.Add(type);
+            else
+                _reservedManufacturingTypes.Remove(type);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Units/CapitalShip.cs
+++ b/Assets/Scripts/Game/Units/CapitalShip.cs
@@ -30,9 +30,16 @@ namespace Rebellion.Game.Units
     /// </summary>
     public class CapitalShip : ContainerNode, IManufacturable, IMovable
     {
+        [PersistableMember(Name = "HasAssignedName")]
+        private bool _hasAssignedName;
+
         public string BattleResultImagePath { get; set; }
         public string BattleResultInTransitImagePath { get; set; }
         public string BattleResultDamagedImagePath { get; set; }
+
+        // Naming Info.
+        public string ShipNamePoolID { get; set; }
+        public bool HasAssignedName => _hasAssignedName;
 
         // Manufacture Info.
         public string ProducerOwnerID { get; set; }
@@ -127,6 +134,8 @@ namespace Rebellion.Game.Units
             copy.BattleResultImagePath = BattleResultImagePath;
             copy.BattleResultInTransitImagePath = BattleResultInTransitImagePath;
             copy.BattleResultDamagedImagePath = BattleResultDamagedImagePath;
+            copy.ShipNamePoolID = ShipNamePoolID;
+            copy._hasAssignedName = _hasAssignedName;
             copy.ProducerOwnerID = ProducerOwnerID;
             copy.ProducerPlanetID = ProducerPlanetID;
             copy.ManufacturingQueueSequence = ManufacturingQueueSequence;
@@ -170,6 +179,19 @@ namespace Rebellion.Game.Units
             copy.CanDestroyPlanets = CanDestroyPlanets;
             copy.DetectionRating = DetectionRating;
             copy.InitialParentInstanceID = InitialParentInstanceID;
+        }
+
+        /// <summary>
+        /// Replaces the ship's display name and prevents automatic naming from replacing it.
+        /// </summary>
+        /// <param name="displayName">The name to assign.</param>
+        public void AssignName(string displayName)
+        {
+            if (string.IsNullOrWhiteSpace(displayName))
+                throw new ArgumentException("A ship name is required.", nameof(displayName));
+
+            DisplayName = displayName;
+            _hasAssignedName = true;
         }
 
         /// <summary>

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -415,6 +415,7 @@ public sealed class GameManager
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_planetaryControlSystem);
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_uprisingSystem);
         _resultProcessor.Subscribe<MissionCompletedResult>(_jediSystem);
+        _resultProcessor.Subscribe<OfficerCaptureStateResult>(_missionSystem);
         _resultProcessor.Subscribe<IntelligenceRevealedResult>(_fogOfWarSystem);
         _resultProcessor.Observe<GameObjectSabotagedResult>(_fogOfWarSystem.ProcessResults);
 

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -34,6 +34,7 @@ public sealed class GameManager
     private DuelSystem _duelSystem;
     private MovementSystem _movementSystem;
     private HeadquartersSystem _headquartersSystem;
+    private NamingSystem _namingSystem;
 
     // Economy Systems.
     private ManufacturingSystem _manufacturingSystem;
@@ -151,6 +152,7 @@ public sealed class GameManager
     public void ProcessFactionAutomation(Faction faction)
     {
         _factionAutomationSystem?.ProcessFaction(faction);
+        _namingSystem?.ProcessFaction(faction);
     }
 
     /// <summary>
@@ -255,6 +257,7 @@ public sealed class GameManager
 
         ProcessResults(_missionSystem.ProcessTick());
         ProcessResults(_eventSystem.ProcessEvents(_game.GetEventPool()));
+        _namingSystem.ProcessTick();
         ProcessResults(_aiSystem.ProcessTick());
 
         ProcessResults(_blockadeSystem.ProcessTick());
@@ -336,6 +339,7 @@ public sealed class GameManager
         _movementSystem = new MovementSystem(_game, _fogOfWarSystem, _fleetSystem, _blockadeSystem);
         _headquartersSystem = new HeadquartersSystem(_game, _movementSystem);
         _manufacturingSystem = new ManufacturingSystem(_game, _fleetSystem, _movementSystem);
+        _namingSystem = new NamingSystem(_game);
         _factionAutomationSystem = new FactionAutomationSystem(
             _game,
             _gameData,

--- a/Assets/Scripts/Systems/AISystem.cs
+++ b/Assets/Scripts/Systems/AISystem.cs
@@ -51,15 +51,13 @@ namespace Rebellion.Systems
         /// <summary>
         /// Processes AI turns for all AI-controlled factions.
         /// </summary>
-        /// <returns>An empty result list.</returns>
+        /// <returns>The results produced by AI actions.</returns>
         public List<GameResult> ProcessTick()
         {
             List<GameResult> results = new List<GameResult>();
 
             foreach (Faction faction in _game.GetFactions().Where(f => f.IsAIControlled()))
-            {
                 results.AddRange(_director.ProcessFaction(faction));
-            }
 
             return results;
         }

--- a/Assets/Scripts/Systems/FactionAutomationSystem.cs
+++ b/Assets/Scripts/Systems/FactionAutomationSystem.cs
@@ -68,9 +68,9 @@ namespace Rebellion.Systems
         private void FillGarrisonManufacturingCapacity(Faction faction)
         {
             List<Planet> ownedPlanets = GetOwnedPlanets(faction);
-            int availableCapacity = ownedPlanets.Sum(planet =>
-                planet.GetAvailableManufacturingCapacity(ManufacturingType.Troop)
-            );
+            int availableCapacity = ownedPlanets
+                .Where(planet => !planet.IsManufacturingReserved(ManufacturingType.Troop))
+                .Sum(planet => planet.GetAvailableManufacturingCapacity(ManufacturingType.Troop));
 
             for (int orderIndex = 0; orderIndex < availableCapacity; orderIndex++)
             {
@@ -125,7 +125,7 @@ namespace Rebellion.Systems
         {
             List<Planet> ownedPlanets = GetOwnedPlanets(faction);
             int availableCapacity = ownedPlanets
-                .Where(planet => !planet.IsConstructionYardReserved)
+                .Where(planet => !planet.IsManufacturingReserved(ManufacturingType.Building))
                 .Sum(planet =>
                     planet.GetAvailableManufacturingCapacity(ManufacturingType.Building)
                 );
@@ -257,7 +257,10 @@ namespace Rebellion.Systems
         )
         {
             return planets
-                .Where(planet => planet.GetAvailableManufacturingCapacity(manufacturingType) > 0)
+                .Where(planet =>
+                    !planet.IsManufacturingReserved(manufacturingType)
+                    && planet.GetAvailableManufacturingCapacity(manufacturingType) > 0
+                )
                 .OrderByDescending(planet =>
                     planet.GetAvailableManufacturingCapacity(manufacturingType)
                 )
@@ -282,7 +285,7 @@ namespace Rebellion.Systems
         {
             List<Planet> producers = planets
                 .Where(planet =>
-                    !planet.IsConstructionYardReserved
+                    !planet.IsManufacturingReserved(ManufacturingType.Building)
                     && planet.GetAvailableManufacturingCapacity(ManufacturingType.Building) > 0
                 )
                 .ToList();

--- a/Assets/Scripts/Systems/FactionAutomationSystem.cs
+++ b/Assets/Scripts/Systems/FactionAutomationSystem.cs
@@ -124,9 +124,11 @@ namespace Rebellion.Systems
         private void FillProductionManufacturingCapacity(Faction faction)
         {
             List<Planet> ownedPlanets = GetOwnedPlanets(faction);
-            int availableCapacity = ownedPlanets.Sum(planet =>
-                planet.GetAvailableManufacturingCapacity(ManufacturingType.Building)
-            );
+            int availableCapacity = ownedPlanets
+                .Where(planet => !planet.IsConstructionYardReserved)
+                .Sum(planet =>
+                    planet.GetAvailableManufacturingCapacity(ManufacturingType.Building)
+                );
 
             for (int orderIndex = 0; orderIndex < availableCapacity; orderIndex++)
             {
@@ -280,7 +282,8 @@ namespace Rebellion.Systems
         {
             List<Planet> producers = planets
                 .Where(planet =>
-                    planet.GetAvailableManufacturingCapacity(ManufacturingType.Building) > 0
+                    !planet.IsConstructionYardReserved
+                    && planet.GetAvailableManufacturingCapacity(ManufacturingType.Building) > 0
                 )
                 .ToList();
             IEnumerable<Planet> destinations = planets.Where(planet =>

--- a/Assets/Scripts/Systems/FogOfWarSystem.cs
+++ b/Assets/Scripts/Systems/FogOfWarSystem.cs
@@ -167,7 +167,7 @@ namespace Rebellion.Systems
                     else if (planetSnapshot != null)
                     {
                         viewPlanet = BlankPlanetView(masterPlanet);
-                        ApplySnapshotView(viewPlanet, planetSnapshot);
+                        ApplySnapshotView(viewPlanet, masterPlanet, masterSector, planetSnapshot);
                     }
                     else
                     {
@@ -476,19 +476,33 @@ namespace Rebellion.Systems
         /// visibility but has previously observed this planet.
         /// </summary>
         /// <param name="viewPlanet">The view planet to populate.</param>
+        /// <param name="masterPlanet">The authoritative planet data source.</param>
+        /// <param name="masterSector">The sector containing the planet.</param>
         /// <param name="planetSnapshot">The prior snapshot for the planet.</param>
-        private void ApplySnapshotView(Planet viewPlanet, PlanetSnapshot planetSnapshot)
+        private void ApplySnapshotView(
+            Planet viewPlanet,
+            Planet masterPlanet,
+            PlanetSector masterSector,
+            PlanetSnapshot planetSnapshot
+        )
         {
             viewPlanet.OwnerInstanceID = planetSnapshot.OwnerInstanceID;
             viewPlanet.IsColonized = planetSnapshot.IsColonized;
-            viewPlanet.IsInUprising = planetSnapshot.IsInUprising;
+            viewPlanet.IsInUprising =
+                masterSector.SectorType == PlanetSectorType.Core
+                    ? masterPlanet.IsInUprising
+                    : planetSnapshot.IsInUprising;
             viewPlanet.IsDestroyed = planetSnapshot.IsDestroyed;
             viewPlanet.IsHeadquarters = planetSnapshot.IsHeadquarters;
             viewPlanet.EnergyCapacity = planetSnapshot.EnergyCapacity;
             viewPlanet.AllocatedEnergy = planetSnapshot.AllocatedEnergy;
             viewPlanet.NumRawResourceNodes = planetSnapshot.NumRawResourceNodes;
 
-            viewPlanet.PopularSupport = new Dictionary<string, int>(planetSnapshot.PopularSupport);
+            Dictionary<string, int> popularSupport =
+                masterSector.SectorType == PlanetSectorType.Core
+                    ? masterPlanet.PopularSupport
+                    : planetSnapshot.PopularSupport;
+            viewPlanet.PopularSupport = new Dictionary<string, int>(popularSupport);
 
             viewPlanet.SetChildren(
                 planetSnapshot.Fleets.Select(FogOfWarRecorder.CopyFleetForSnapshot),

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -16,7 +16,9 @@ namespace Rebellion.Systems
     /// Orchestrates mission creation, participant travel, and external execution services.
     /// Each mission owns its post-arrival lifecycle.
     /// </summary>
-    public class MissionSystem : IMissionExecutionRuntime
+    public class MissionSystem
+        : IMissionExecutionRuntime,
+            IGameResultHandler<OfficerCaptureStateResult>
     {
         private readonly GameRoot _game;
         private readonly IRandomNumberProvider _provider;
@@ -238,6 +240,34 @@ namespace Rebellion.Systems
             );
             TearDownMission(mission, null, _pendingResults);
             return true;
+        }
+
+        /// <summary>
+        /// Ends missions whose participants were captured by another simulation system.
+        /// </summary>
+        /// <param name="results">The officer capture-state changes to process.</param>
+        /// <returns>Mission interruption results produced while tearing down affected missions.</returns>
+        public List<GameResult> HandleResults(IReadOnlyList<OfficerCaptureStateResult> results)
+        {
+            List<GameResult> missionResults = new List<GameResult>();
+            List<Mission> affectedMissions = results
+                .Where(result => result?.IsCaptured == true)
+                .Select(result => result.TargetOfficer?.GetParent() as Mission)
+                .Where(mission => mission != null)
+                .Distinct()
+                .ToList();
+
+            foreach (Mission mission in affectedMissions)
+            {
+                AddMissionResults(
+                    mission,
+                    mission.ResolveInterruption(_game, _provider),
+                    missionResults
+                );
+                TearDownMission(mission, null, missionResults);
+            }
+
+            return missionResults;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/NamingSystem.cs
+++ b/Assets/Scripts/Systems/NamingSystem.cs
@@ -1,0 +1,70 @@
+using System;
+using Rebellion.Game;
+using Rebellion.Game.Factions;
+using Rebellion.Game.Units;
+
+namespace Rebellion.Systems
+{
+    /// <summary>
+    /// Assigns faction-specific names to eligible game entities.
+    /// </summary>
+    public sealed class NamingSystem
+    {
+        private const int _maximumCapitalShipNamesPerPass = 10;
+
+        private readonly GameRoot _game;
+
+        /// <summary>
+        /// Creates a naming system.
+        /// </summary>
+        /// <param name="game">The active game.</param>
+        public NamingSystem(GameRoot game)
+        {
+            _game = game ?? throw new ArgumentNullException(nameof(game));
+        }
+
+        /// <summary>
+        /// Assigns names for factions whose ship naming is automated.
+        /// </summary>
+        public void ProcessTick()
+        {
+            foreach (Faction faction in _game.GetFactions())
+                ProcessFaction(faction);
+        }
+
+        /// <summary>
+        /// Assigns sequential faction names to eligible capital ships.
+        /// </summary>
+        /// <param name="faction">The faction whose ships should be named.</param>
+        /// <returns>The number of ships named.</returns>
+        public int ProcessFaction(Faction faction)
+        {
+            if (faction == null)
+                throw new ArgumentNullException(nameof(faction));
+            if (!faction.IsAIControlled() && !faction.ManageNaming)
+                return 0;
+
+            int namedShipCount = 0;
+            foreach (CapitalShip ship in faction.GetOwnedUnitsByType<CapitalShip>())
+            {
+                if (namedShipCount >= _maximumCapitalShipNamesPerPass)
+                    break;
+                if (
+                    ship.HasAssignedName
+                    || ship.ManufacturingStatus != ManufacturingStatus.Complete
+                    || string.IsNullOrWhiteSpace(ship.ShipNamePoolID)
+                )
+                    continue;
+
+                if (faction.TryTakeNextShipName(ship.ShipNamePoolID, out string shipName))
+                    ship.AssignName(shipName);
+                else
+                    ship.AssignName(faction.TakeNextGenericShipName(ship));
+
+                namedShipCount++;
+            }
+
+            return namedShipCount;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/NamingSystem.cs
+++ b/Assets/Scripts/Systems/NamingSystem.cs
@@ -10,8 +10,6 @@ namespace Rebellion.Systems
     /// </summary>
     public sealed class NamingSystem
     {
-        private const int _maximumCapitalShipNamesPerPass = 10;
-
         private readonly GameRoot _game;
 
         /// <summary>
@@ -47,8 +45,6 @@ namespace Rebellion.Systems
             int namedShipCount = 0;
             foreach (CapitalShip ship in faction.GetOwnedUnitsByType<CapitalShip>())
             {
-                if (namedShipCount >= _maximumCapitalShipNamesPerPass)
-                    break;
                 if (
                     ship.HasAssignedName
                     || ship.ManufacturingStatus != ManufacturingStatus.Complete

--- a/Assets/Scripts/Systems/NamingSystem.cs.meta
+++ b/Assets/Scripts/Systems/NamingSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ab65a2aa3e0445e29e15bbb294759c59

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleResultPresentation.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleResultPresentation.cs
@@ -575,22 +575,6 @@ internal abstract class BattleResultPresentation
         }
 
         /// <summary>
-        /// Returns completed fleet-engagement music from the saved recipient perspective.
-        /// </summary>
-        internal override string GetMusicPath(BattleAlertWindowTheme theme, string playerFactionId)
-        {
-            if (theme == null || report.CombatType != CombatReportType.SpaceBattle)
-                return null;
-            if (report.Winner == CombatSide.Draw)
-                return FirstNonBlank(theme.ResultDrawMusicPath, theme.ResultMusicPath);
-
-            CombatSide? playerSide = GetSideForOwner(report, playerFactionId);
-            return playerSide.HasValue && playerSide.Value == report.Winner
-                ? FirstNonBlank(theme.ResultVictoryMusicPath, theme.ResultMusicPath)
-                : FirstNonBlank(theme.ResultDefeatMusicPath, theme.ResultMusicPath);
-        }
-
-        /// <summary>
         /// Returns the outcome summary frozen into the delivered message.
         /// </summary>
         internal override string GetSummary(UIContext uiContext, string playerFactionId)
@@ -706,20 +690,6 @@ internal abstract class BattleResultPresentation
         private static SpaceCombatSideOutcome GetOutcome(CombatReport report, CombatSide side)
         {
             return side == CombatSide.Attacker ? report.AttackerOutcome : report.DefenderOutcome;
-        }
-
-        /// <summary>
-        /// Returns the saved side represented by one faction identifier.
-        /// </summary>
-        private static CombatSide? GetSideForOwner(CombatReport report, string ownerInstanceId)
-        {
-            if (string.IsNullOrEmpty(ownerInstanceId))
-                return null;
-            if (ownerInstanceId == report.AttackerOwnerInstanceID)
-                return CombatSide.Attacker;
-            if (ownerInstanceId == report.DefenderOwnerInstanceID)
-                return CombatSide.Defender;
-            return null;
         }
 
         /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
@@ -109,6 +109,7 @@ public enum StrategyMenuAction
     AdvisorObjectives,
     AdvisorManageGarrisons,
     AdvisorManageProduction,
+    AdvisorManageNaming,
     AdvisorTranslateCounterpart,
     AdvisorAgentAdvice,
     AdvisorMessages,

--- a/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
@@ -81,6 +81,7 @@ public enum StrategyMenuAction
     Stop,
     CreateMission,
     Destination,
+    Reserve,
     Scrap,
     Move,
     Retire,

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
@@ -57,7 +57,7 @@ internal static class FacilityWindowContextMenuBuilder
         bool playerControlsPlanet
     )
     {
-        return new List<StrategyMenuCommand>
+        List<StrategyMenuCommand> commands = new List<StrategyMenuCommand>
         {
             new StrategyMenuCommand(
                 StrategyMenuAction.Build,
@@ -77,8 +77,24 @@ internal static class FacilityWindowContextMenuBuilder
             new StrategyMenuCommand(StrategyMenuAction.None, "Rename", false),
             new StrategyMenuCommand(StrategyMenuAction.Encyclopedia, "Encyclopedia", true),
             new StrategyMenuCommand(StrategyMenuAction.Status, "Status", true),
-            new StrategyMenuCommand(StrategyMenuAction.None, "Reserved", false),
         };
+
+        if (manufacturingTab == FacilityWindowTab.Construction)
+        {
+            commands.Add(
+                new StrategyMenuCommand(
+                    StrategyMenuAction.Reserve,
+                    "Reserved",
+                    playerControlsPlanet,
+                    planet?.IsConstructionYardReserved == true
+                        ? StrategyContextMenuIconKeys.CheckMark
+                        : StrategyContextMenuIconKeys.None,
+                    usesIconColumn: true
+                )
+            );
+        }
+
+        return commands;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
@@ -79,14 +79,17 @@ internal static class FacilityWindowContextMenuBuilder
             new StrategyMenuCommand(StrategyMenuAction.Status, "Status", true),
         };
 
-        if (manufacturingTab == FacilityWindowTab.Construction)
+        ManufacturingType? manufacturingType = ConstructionOrderController.GetManufacturingType(
+            manufacturingTab
+        );
+        if (manufacturingType.HasValue)
         {
             commands.Add(
                 new StrategyMenuCommand(
                     StrategyMenuAction.Reserve,
                     "Reserved",
                     playerControlsPlanet,
-                    planet?.IsConstructionYardReserved == true
+                    planet?.IsManufacturingReserved(manufacturingType.Value) == true
                         ? StrategyContextMenuIconKeys.CheckMark
                         : StrategyContextMenuIconKeys.None,
                     usesIconColumn: true

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
@@ -317,6 +317,7 @@ public sealed class FacilityWindowController
         if (
             request?.Source is not StrategyContextMenuProviderContext context
             || command is not StrategyMenuCommand strategyCommand
+            || !strategyCommand.Enabled
             || !windowManager.TryGetWindowView(context.Window, out FacilityWindowView view)
         )
             return;
@@ -335,6 +336,9 @@ public sealed class FacilityWindowController
             case StrategyMenuAction.Destination:
                 BeginContextTargeting(context, strategyCommand.Action);
                 break;
+            case StrategyMenuAction.Reserve:
+                ToggleConstructionYardReservation(view);
+                break;
             case StrategyMenuAction.Encyclopedia:
                 actions.OpenFacilityInfo(GetStatusTarget(view));
                 break;
@@ -352,6 +356,31 @@ public sealed class FacilityWindowController
     /// </summary>
     /// <param name="request">The canceled context-menu request.</param>
     public void OnContextMenuCancelled(ContextMenuRequest request) { }
+
+    /// <summary>
+    /// Toggles whether the advisor may use the represented planet's construction yards.
+    /// </summary>
+    /// <param name="view">The facility view whose construction lane was selected.</param>
+    private void ToggleConstructionYardReservation(FacilityWindowView view)
+    {
+        if (
+            !TryGetSession(view, out FacilityWindowSession session)
+            || session.GetContextManufacturingTab() != FacilityWindowTab.Construction
+        )
+            return;
+
+        Planet planet = GetAuthoritativePlanet(session.Planet?.Planet?.InstanceID);
+        string playerFactionId = getGame()?.GetPlayerFaction()?.InstanceID;
+        if (
+            planet == null
+            || string.IsNullOrEmpty(playerFactionId)
+            || !string.Equals(planet.OwnerInstanceID, playerFactionId, StringComparison.Ordinal)
+        )
+            return;
+
+        planet.IsConstructionYardReserved = !planet.IsConstructionYardReserved;
+        actions.RefreshFacilityState();
+    }
 
     /// <summary>
     /// Begins destination targeting for a facility manufacturing lane.

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
@@ -337,7 +337,7 @@ public sealed class FacilityWindowController
                 BeginContextTargeting(context, strategyCommand.Action);
                 break;
             case StrategyMenuAction.Reserve:
-                ToggleConstructionYardReservation(view);
+                ToggleManufacturingReservation(view);
                 break;
             case StrategyMenuAction.Encyclopedia:
                 actions.OpenFacilityInfo(GetStatusTarget(view));
@@ -358,15 +358,19 @@ public sealed class FacilityWindowController
     public void OnContextMenuCancelled(ContextMenuRequest request) { }
 
     /// <summary>
-    /// Toggles whether the advisor may use the represented planet's construction yards.
+    /// Toggles whether the advisor may use the represented manufacturing lane.
     /// </summary>
-    /// <param name="view">The facility view whose construction lane was selected.</param>
-    private void ToggleConstructionYardReservation(FacilityWindowView view)
+    /// <param name="view">The facility view whose manufacturing lane was selected.</param>
+    private void ToggleManufacturingReservation(FacilityWindowView view)
     {
-        if (
-            !TryGetSession(view, out FacilityWindowSession session)
-            || session.GetContextManufacturingTab() != FacilityWindowTab.Construction
-        )
+        if (!TryGetSession(view, out FacilityWindowSession session))
+            return;
+
+        FacilityWindowTab? manufacturingTab = session.GetContextManufacturingTab();
+        ManufacturingType? manufacturingType = manufacturingTab.HasValue
+            ? ConstructionOrderController.GetManufacturingType(manufacturingTab.Value)
+            : null;
+        if (!manufacturingType.HasValue)
             return;
 
         Planet planet = GetAuthoritativePlanet(session.Planet?.Planet?.InstanceID);
@@ -378,7 +382,10 @@ public sealed class FacilityWindowController
         )
             return;
 
-        planet.IsConstructionYardReserved = !planet.IsConstructionYardReserved;
+        planet.SetManufacturingReserved(
+            manufacturingType.Value,
+            !planet.IsManufacturingReserved(manufacturingType.Value)
+        );
         actions.RefreshFacilityState();
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowController.cs
@@ -1070,7 +1070,12 @@ public sealed class FleetWindowController
             return;
 
         if (session.RenameTarget != null && !string.IsNullOrEmpty(value))
-            session.RenameTarget.DisplayName = value;
+        {
+            if (session.RenameTarget is CapitalShip capitalShip)
+                capitalShip.AssignName(value);
+            else
+                session.RenameTarget.DisplayName = value;
+        }
         session.EndRename();
         markDirty();
     }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -428,6 +428,12 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
                 faction?.ManageProduction == true
             ),
             CreateToggleCommand(
+                StrategyMenuAction.AdvisorManageNaming,
+                "Manage Naming",
+                faction != null,
+                faction?.ManageNaming == true
+            ),
+            CreateToggleCommand(
                 StrategyMenuAction.AdvisorTranslateCounterpart,
                 "Translate Counterpart",
                 faction != null,
@@ -580,6 +586,11 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
             case StrategyMenuAction.AdvisorManageProduction:
                 faction.ManageProduction = !faction.ManageProduction;
                 if (faction.ManageProduction)
+                    actions.ProcessAdvisorAutomation(faction);
+                break;
+            case StrategyMenuAction.AdvisorManageNaming:
+                faction.ManageNaming = !faction.ManageNaming;
+                if (faction.ManageNaming)
                     actions.ProcessAdvisorAutomation(faction);
                 break;
             case StrategyMenuAction.AdvisorTranslateCounterpart:

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rebellion.Game.Advisor;
 
 /// <summary>
 /// Defines shared non-themed sound resource paths used by strategy UI features.
@@ -35,6 +36,9 @@ internal static class StrategyUISoundPaths
         yield return GalacticInformationControl;
         yield return PlanetaryAssault;
 
+        foreach (string path in GetAdvisorNotificationAudioPaths(theme?.StrategyAdvisor))
+            yield return path;
+
         StrategyWindowSoundTheme windowSounds = theme?.StrategyWindowSounds;
         ConfirmDialogTheme confirmDialog = theme?.ConfirmDialogTheme;
         string[] themedPaths =
@@ -51,5 +55,45 @@ internal static class StrategyUISoundPaths
             if (!string.IsNullOrWhiteSpace(path))
                 yield return path.Trim();
         }
+    }
+
+    /// <summary>
+    /// Enumerates faction audio required by immediate strategy notifications.
+    /// </summary>
+    /// <param name="advisor">The active faction advisor theme.</param>
+    /// <returns>The configured notification audio paths.</returns>
+    private static IEnumerable<string> GetAdvisorNotificationAudioPaths(
+        StrategyAdvisorTheme advisor
+    )
+    {
+        StrategyAdvisorNotificationTheme assault = advisor?.GetNotification(
+            AdvisorNotificationType.PlanetaryAssault,
+            null,
+            AdvisorSubjectNotification.None
+        );
+        string droidPath = GetAdvisorAnimationAudioPath(advisor, assault?.Droid);
+        string protocolPath = GetAdvisorAnimationAudioPath(advisor, assault?.Protocol);
+        if (!string.IsNullOrWhiteSpace(droidPath))
+            yield return droidPath;
+        if (!string.IsNullOrWhiteSpace(protocolPath))
+            yield return protocolPath;
+    }
+
+    /// <summary>
+    /// Resolves one advisor animation's explicit or theme-relative audio path.
+    /// </summary>
+    /// <param name="advisor">The owning advisor theme.</param>
+    /// <param name="animation">The configured advisor animation.</param>
+    /// <returns>The resolved audio path, or null when no audio is configured.</returns>
+    private static string GetAdvisorAnimationAudioPath(
+        StrategyAdvisorTheme advisor,
+        StrategyAdvisorAnimationTheme animation
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(animation?.AudioPath))
+            return animation.AudioPath.Trim();
+        return string.IsNullOrWhiteSpace(animation?.Audio)
+            ? null
+            : advisor.GetAudioPath(animation.Audio.Trim());
     }
 }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -36,7 +36,7 @@ internal static class StrategyUISoundPaths
         yield return GalacticInformationControl;
         yield return PlanetaryAssault;
 
-        foreach (string path in GetAdvisorNotificationAudioPaths(theme?.StrategyAdvisor))
+        foreach (string path in GetPlanetaryAssaultAdvisorAudioPaths(theme?.StrategyAdvisor))
             yield return path;
 
         StrategyWindowSoundTheme windowSounds = theme?.StrategyWindowSounds;
@@ -58,11 +58,12 @@ internal static class StrategyUISoundPaths
     }
 
     /// <summary>
-    /// Enumerates faction audio required by immediate strategy notifications.
+    /// Returns the configured droid and protocol audio paths for the planetary-assault advisor
+    /// notification.
     /// </summary>
     /// <param name="advisor">The active faction advisor theme.</param>
-    /// <returns>The configured notification audio paths.</returns>
-    private static IEnumerable<string> GetAdvisorNotificationAudioPaths(
+    /// <returns>The planetary-assault advisor audio paths.</returns>
+    private static IEnumerable<string> GetPlanetaryAssaultAdvisorAudioPaths(
         StrategyAdvisorTheme advisor
     )
     {

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
@@ -1026,6 +1026,35 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
+        public void SetDisplayName_CapitalShip_MarksNameAsAssigned()
+        {
+            GameRoot game = BuildGame(out Planet planet, out _);
+            Fleet fleet = new Fleet
+            {
+                InstanceID = "fleet",
+                OwnerInstanceID = planet.OwnerInstanceID,
+            };
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "ship",
+                DisplayName = "Generic Ship",
+                OwnerInstanceID = planet.OwnerInstanceID,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+            SetDisplayNameAction action = new SetDisplayNameAction
+            {
+                TargetInstanceID = ship.InstanceID,
+                Name = "Named Ship",
+            };
+
+            action.Execute(game);
+
+            Assert.AreEqual("Named Ship", ship.DisplayName);
+            Assert.IsTrue(ship.HasAssignedName);
+        }
+
+        [Test]
         public void SetOfficerImages_ConfiguredValues_UpdatesOfficer()
         {
             GameRoot game = BuildGame(out _, out Planet rebelPlanet);

--- a/Assets/Tests/EditMode/GameTests/Game/Factions/FactionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Factions/FactionTests.cs
@@ -79,6 +79,93 @@ namespace Rebellion.Tests.Game.Factions
         }
 
         [Test]
+        public void TryTakeNextShipName_AvailableNames_ReturnsNamesInOrder()
+        {
+            _faction.ShipNamePools.Add(
+                new FactionNamePool
+                {
+                    NamePoolID = "POOL",
+                    Names = new List<string> { "First", "Second" },
+                }
+            );
+
+            bool foundFirst = _faction.TryTakeNextShipName("POOL", out string firstName);
+            bool foundSecond = _faction.TryTakeNextShipName("POOL", out string secondName);
+
+            Assert.IsTrue(foundFirst);
+            Assert.IsTrue(foundSecond);
+            Assert.AreEqual("First", firstName);
+            Assert.AreEqual("Second", secondName);
+            Assert.AreEqual(2, _faction.ShipNamePools.Single().NextNameIndex);
+        }
+
+        [Test]
+        public void TryTakeNextShipName_ExhaustedPrimaryPool_ReturnsFallbackName()
+        {
+            _faction.ShipNamePools.AddRange(
+                new FactionNamePool[]
+                {
+                    new FactionNamePool
+                    {
+                        NamePoolID = "PRIMARY",
+                        FallbackNamePoolID = "FALLBACK",
+                        Names = new List<string> { "Used" },
+                        NextNameIndex = 1,
+                    },
+                    new FactionNamePool
+                    {
+                        NamePoolID = "FALLBACK",
+                        Names = new List<string> { "Available" },
+                    },
+                }
+            );
+
+            bool found = _faction.TryTakeNextShipName("PRIMARY", out string shipName);
+
+            Assert.IsTrue(found);
+            Assert.AreEqual("Available", shipName);
+            Assert.AreEqual(1, _faction.ShipNamePools[1].NextNameIndex);
+        }
+
+        [Test]
+        public void TryTakeNextShipName_FallbackCycle_ReturnsFalse()
+        {
+            _faction.ShipNamePools.AddRange(
+                new FactionNamePool[]
+                {
+                    new FactionNamePool { NamePoolID = "FIRST", FallbackNamePoolID = "SECOND" },
+                    new FactionNamePool { NamePoolID = "SECOND", FallbackNamePoolID = "FIRST" },
+                }
+            );
+
+            bool found = _faction.TryTakeNextShipName("FIRST", out string shipName);
+
+            Assert.IsFalse(found);
+            Assert.IsNull(shipName);
+        }
+
+        [Test]
+        public void TakeNextGenericShipName_SameShipType_ReturnsSequentialNames()
+        {
+            CapitalShip firstShip = new CapitalShip
+            {
+                TypeID = "SHIP_TYPE",
+                DisplayName = "Generic Ship",
+            };
+            CapitalShip secondShip = new CapitalShip
+            {
+                TypeID = "SHIP_TYPE",
+                DisplayName = "Generic Ship",
+            };
+
+            string firstName = _faction.TakeNextGenericShipName(firstShip);
+            string secondName = _faction.TakeNextGenericShipName(secondShip);
+
+            Assert.AreEqual("Generic Ship 1", firstName);
+            Assert.AreEqual("Generic Ship 2", secondName);
+        }
+
+        [Test]
         public void AddOwnedUnit_ValidPlanet_AddsPlanetToOwnedNodes()
         {
             _faction.AddOwnedUnit(_planet1);
@@ -621,6 +708,22 @@ namespace Rebellion.Tests.Game.Factions
             _faction.AgentAdvice = false;
             _faction.ManageGarrisons = true;
             _faction.ManageProduction = true;
+            _faction.ManageNaming = true;
+            _faction.ShipNamePools.Add(
+                new FactionNamePool
+                {
+                    NamePoolID = "PRIMARY",
+                    FallbackNamePoolID = "FALLBACK",
+                    Names = new List<string> { "Used", "Available" },
+                    NextNameIndex = 1,
+                }
+            );
+            CapitalShip genericShip = new CapitalShip
+            {
+                TypeID = "SHIP_TYPE",
+                DisplayName = "Generic Ship",
+            };
+            _faction.TakeNextGenericShipName(genericShip);
             _faction.RawMaterialStockpile = 17;
             _faction.RefinedMaterialStockpile = 23;
             _faction.PendingRawMaterialFacilityIDs.AddRange(new[] { "REFINERY1", "REFINERY2" });
@@ -658,6 +761,13 @@ namespace Rebellion.Tests.Game.Factions
             Assert.IsFalse(deserialized.AgentAdvice);
             Assert.IsTrue(deserialized.ManageGarrisons);
             Assert.IsTrue(deserialized.ManageProduction);
+            Assert.IsTrue(deserialized.ManageNaming);
+            FactionNamePool deserializedNamePool = deserialized.ShipNamePools.Single();
+            Assert.AreEqual("PRIMARY", deserializedNamePool.NamePoolID);
+            Assert.AreEqual("FALLBACK", deserializedNamePool.FallbackNamePoolID);
+            CollectionAssert.AreEqual(new[] { "Used", "Available" }, deserializedNamePool.Names);
+            Assert.AreEqual(1, deserializedNamePool.NextNameIndex);
+            Assert.AreEqual("Generic Ship 2", deserialized.TakeNextGenericShipName(genericShip));
             Assert.AreEqual(_faction.RawMaterialStockpile, deserialized.RawMaterialStockpile);
             Assert.AreEqual(
                 _faction.RefinedMaterialStockpile,

--- a/Assets/Tests/EditMode/GameTests/Game/Galaxy/PlanetTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Galaxy/PlanetTests.cs
@@ -366,6 +366,7 @@ namespace Rebellion.Tests.Game.Galaxy
         {
             _planet.SetPopularSupport("FNALL1", 100);
             _planet.IsDestroyed = true;
+            _planet.IsConstructionYardReserved = true;
             _planet.AddChild(new Fleet { OwnerInstanceID = "FNALL1" });
 
             string serialized = SerializationHelper.Serialize(_planet);
@@ -380,6 +381,11 @@ namespace Rebellion.Tests.Game.Galaxy
                 _planet.GetPopularSupport("FNALL1"),
                 deserialized.GetPopularSupport("FNALL1"),
                 "Deserialized planet should retain popular support."
+            );
+            Assert.AreEqual(
+                _planet.IsConstructionYardReserved,
+                deserialized.IsConstructionYardReserved,
+                "Deserialized planet should retain its construction-yard reservation."
             );
             Assert.AreEqual(
                 _planet.GetChildren<Fleet>().Count,

--- a/Assets/Tests/EditMode/GameTests/Game/Galaxy/PlanetTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Galaxy/PlanetTests.cs
@@ -366,7 +366,9 @@ namespace Rebellion.Tests.Game.Galaxy
         {
             _planet.SetPopularSupport("FNALL1", 100);
             _planet.IsDestroyed = true;
-            _planet.IsConstructionYardReserved = true;
+            _planet.SetManufacturingReserved(ManufacturingType.Ship, true);
+            _planet.SetManufacturingReserved(ManufacturingType.Building, true);
+            _planet.SetManufacturingReserved(ManufacturingType.Troop, true);
             _planet.AddChild(new Fleet { OwnerInstanceID = "FNALL1" });
 
             string serialized = SerializationHelper.Serialize(_planet);
@@ -382,15 +384,35 @@ namespace Rebellion.Tests.Game.Galaxy
                 deserialized.GetPopularSupport("FNALL1"),
                 "Deserialized planet should retain popular support."
             );
-            Assert.AreEqual(
-                _planet.IsConstructionYardReserved,
-                deserialized.IsConstructionYardReserved,
-                "Deserialized planet should retain its construction-yard reservation."
-            );
+            Assert.IsTrue(deserialized.IsManufacturingReserved(ManufacturingType.Ship));
+            Assert.IsTrue(deserialized.IsManufacturingReserved(ManufacturingType.Building));
+            Assert.IsTrue(deserialized.IsManufacturingReserved(ManufacturingType.Troop));
             Assert.AreEqual(
                 _planet.GetChildren<Fleet>().Count,
                 deserialized.GetChildren<Fleet>().Count,
                 "Deserialized planet should retain fleets."
+            );
+        }
+
+        [Test]
+        public void SetManufacturingReserved_ReservedThenReleased_UpdatesSelectedLaneOnly()
+        {
+            _planet.SetManufacturingReserved(ManufacturingType.Troop, true);
+
+            Assert.IsTrue(_planet.IsManufacturingReserved(ManufacturingType.Troop));
+            Assert.IsFalse(_planet.IsManufacturingReserved(ManufacturingType.Ship));
+            Assert.IsFalse(_planet.IsManufacturingReserved(ManufacturingType.Building));
+
+            _planet.SetManufacturingReserved(ManufacturingType.Troop, false);
+
+            Assert.IsFalse(_planet.IsManufacturingReserved(ManufacturingType.Troop));
+        }
+
+        [Test]
+        public void SetManufacturingReserved_None_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                _planet.SetManufacturingReserved(ManufacturingType.None, true)
             );
         }
 

--- a/Assets/Tests/EditMode/GameTests/Game/Units/CapitalShipTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Units/CapitalShipTests.cs
@@ -39,6 +39,24 @@ namespace Rebellion.Tests.Game.Units
         }
 
         [Test]
+        public void AssignName_ValidName_ReplacesDisplayNameAndMarksAssigned()
+        {
+            _capitalShip.DisplayName = "Generic Ship";
+
+            _capitalShip.AssignName("Assigned Ship");
+
+            Assert.AreEqual("Assigned Ship", _capitalShip.DisplayName);
+            Assert.IsTrue(_capitalShip.HasAssignedName);
+        }
+
+        [Test]
+        public void AssignName_WhitespaceName_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => _capitalShip.AssignName(" "));
+            Assert.IsFalse(_capitalShip.HasAssignedName);
+        }
+
+        [Test]
         public void AddStarfighter_WithinCapacity_AddsStarfighter()
         {
             Starfighter starfighter = new Starfighter();
@@ -329,6 +347,8 @@ namespace Rebellion.Tests.Game.Units
         public void SerializeAndDeserialize_CapitalShipWithChildren_MaintainsState()
         {
             _capitalShip.ManufacturingQueueSequence = 7;
+            _capitalShip.ShipNamePoolID = "POOL";
+            _capitalShip.AssignName("Named Ship");
             Officer officer = new Officer { OwnerInstanceID = "FNALL1" };
             Starfighter starfighter = new Starfighter();
             Regiment regiment = new Regiment();
@@ -362,6 +382,9 @@ namespace Rebellion.Tests.Game.Units
                 deserialized.ManufacturingQueueSequence,
                 "ManufacturingQueueSequence should be correctly deserialized."
             );
+            Assert.AreEqual("POOL", deserialized.ShipNamePoolID);
+            Assert.AreEqual("Named Ship", deserialized.DisplayName);
+            Assert.IsTrue(deserialized.HasAssignedName);
             Assert.AreEqual(
                 _capitalShip.GetChildren<Officer>().Count,
                 deserialized.GetChildren<Officer>().Count,

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -143,6 +143,61 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
+        public void ProcessTick_EventCapturesMissionParticipant_TearsDownMission()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            Faction owner = new Faction { InstanceID = "OWNER" };
+            Faction captor = new Faction { InstanceID = "CAPTOR" };
+            game.GetFactions().Add(owner);
+            game.GetFactions().Add(captor);
+            PlanetSector sector = new PlanetSector { InstanceID = "SECTOR" };
+            Planet planet = new Planet
+            {
+                InstanceID = "PLANET",
+                OwnerInstanceID = owner.InstanceID,
+                IsColonized = true,
+            };
+            game.AttachNode(sector, game.GetGalaxyMap());
+            game.AttachNode(planet, sector);
+            Officer officer = EntityFactory.CreateOfficer("OFFICER", owner.InstanceID);
+            DiplomacyMission mission = new DiplomacyMission
+            {
+                InstanceID = "MISSION",
+                OwnerInstanceID = owner.InstanceID,
+                LocationInstanceID = planet.InstanceID,
+            };
+            game.AttachNode(officer, planet);
+            game.AttachNode(mission, planet);
+            game.MoveNode(officer, mission);
+            mission.Initiate(100);
+            game.GetEventPool()
+                .Add(
+                    new GameEvent
+                    {
+                        InstanceID = "CAPTURE_OFFICER",
+                        Schedule = new GameEventScheduler { At = new AtTick { Tick = 1 } },
+                        Actions = new List<GameAction>
+                        {
+                            new SetCaptureStatusAction
+                            {
+                                OfficerInstanceID = officer.InstanceID,
+                                IsCaptured = true,
+                                CaptorFactionInstanceID = captor.InstanceID,
+                            },
+                        },
+                    }
+                );
+            GameManager manager = TestContent.CreateGameManager(game);
+
+            manager.ProcessTick();
+
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Mission>(mission.InstanceID));
+            Assert.AreSame(planet, officer.GetParent());
+            Assert.IsTrue(officer.IsCaptured);
+            Assert.AreEqual(captor.InstanceID, officer.CaptorInstanceID);
+        }
+
+        [Test]
         public void ProcessTick_VictoryConditionMet_RaisesVictoryDeclaredOnce()
         {
             GameRoot game = new GameRoot(TestConfig.Create())

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -75,6 +75,42 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
+        public void ProcessFactionAutomation_ManageNaming_AssignsNameImmediately()
+        {
+            GameRoot game = new GameRoot();
+            Faction faction = new Faction
+            {
+                InstanceID = "FACTION",
+                PlayerID = "PLAYER",
+                ManageNaming = true,
+            };
+            faction.ShipNamePools.Add(
+                new FactionNamePool
+                {
+                    NamePoolID = "POOL",
+                    Names = new List<string> { "Named Ship" },
+                }
+            );
+            game.GetFactions().Add(faction);
+            GameManager manager = TestContent.CreateGameManager(game);
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "SHIP",
+                TypeID = "SHIP_TYPE",
+                DisplayName = "Generic Ship",
+                OwnerInstanceID = faction.InstanceID,
+                ShipNamePoolID = "POOL",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            faction.AddOwnedUnit(ship);
+
+            manager.ProcessFactionAutomation(faction);
+
+            Assert.AreEqual("Named Ship", ship.DisplayName);
+            Assert.IsTrue(ship.HasAssignedName);
+        }
+
+        [Test]
         public void ProcessTick_EventResults_DoesNotAddAutomaticMessages()
         {
             GameRoot game = new GameRoot();

--- a/Assets/Tests/EditMode/GameTests/Systems/FactionAutomationSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FactionAutomationSystemTests.cs
@@ -111,6 +111,17 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_ManageGarrisonsWithReservedTrainingFacility_DoesNotQueueWork()
+        {
+            _faction.ManageProduction = false;
+            _producer.SetManufacturingReserved(ManufacturingType.Troop, true);
+
+            _automation.ProcessTick();
+
+            Assert.IsEmpty(_destination.GetAllRegiments());
+        }
+
+        [Test]
         public void ProcessTick_ManageProduction_FillsCapacityWithMatchedPair()
         {
             _faction.ManageGarrisons = false;
@@ -137,10 +148,10 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_ManageProductionWithReservedConstructionYard_DoesNotQueueWork()
+        public void ProcessTick_ManageProductionWithReservedBuildingLane_DoesNotQueueWork()
         {
             _faction.ManageGarrisons = false;
-            _producer.IsConstructionYardReserved = true;
+            _producer.SetManufacturingReserved(ManufacturingType.Building, true);
             int mineCount = CountResourceFacilities(BuildingType.Mine);
             int refineryCount = CountResourceFacilities(BuildingType.Refinery);
 
@@ -154,7 +165,7 @@ namespace Rebellion.Tests.Systems
         public void ProcessTick_ReservedDestination_RemainsAvailableForAutomatedDelivery()
         {
             _faction.ManageGarrisons = false;
-            _destination.IsConstructionYardReserved = true;
+            _destination.SetManufacturingReserved(ManufacturingType.Building, true);
             _destination.PositionX = 1;
 
             _automation.ProcessTick();

--- a/Assets/Tests/EditMode/GameTests/Systems/FactionAutomationSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FactionAutomationSystemTests.cs
@@ -1,9 +1,15 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Rebellion.Game;
+using Rebellion.Game.Encyclopedia;
+using Rebellion.Game.Events;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
+using Rebellion.Game.Messages;
 using Rebellion.Game.Units;
+using Rebellion.Generation;
 using Rebellion.Systems;
 
 namespace Rebellion.Tests.Systems
@@ -11,6 +17,9 @@ namespace Rebellion.Tests.Systems
     [TestFixture]
     public class FactionAutomationSystemTests
     {
+        private const string _factionId = "faction";
+        private const string _garrisonTypeId = "garrison";
+
         private GameRoot _game;
         private Faction _faction;
         private Planet _producer;
@@ -20,10 +29,12 @@ namespace Rebellion.Tests.Systems
         [SetUp]
         public void SetUp()
         {
-            _game = new GameRoot(TestContent.Data.GameConfig);
+            GameConfig config = CreateGameConfig();
+            GameDataCatalog gameData = CreateGameData(config);
+            _game = new GameRoot(config);
             _faction = new Faction
             {
-                InstanceID = "FNALL1",
+                InstanceID = _factionId,
                 ManageGarrisons = true,
                 ManageProduction = true,
             };
@@ -46,7 +57,7 @@ namespace Rebellion.Tests.Systems
                 _game,
                 new FleetSystem(_game)
             );
-            _automation = new FactionAutomationSystem(_game, TestContent.Data, manufacturing);
+            _automation = new FactionAutomationSystem(_game, gameData, manufacturing);
         }
 
         [Test]
@@ -64,7 +75,7 @@ namespace Rebellion.Tests.Systems
                 ManufacturingStatus.Building,
                 _destination.GetAllRegiments().Single().ManufacturingStatus
             );
-            Assert.AreEqual("REAL002", _destination.GetAllRegiments().Single().TypeID);
+            Assert.AreEqual(_garrisonTypeId, _destination.GetAllRegiments().Single().TypeID);
         }
 
         [Test]
@@ -126,6 +137,32 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_ManageProductionWithReservedConstructionYard_DoesNotQueueWork()
+        {
+            _faction.ManageGarrisons = false;
+            _producer.IsConstructionYardReserved = true;
+            int mineCount = CountResourceFacilities(BuildingType.Mine);
+            int refineryCount = CountResourceFacilities(BuildingType.Refinery);
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(mineCount, CountResourceFacilities(BuildingType.Mine));
+            Assert.AreEqual(refineryCount, CountResourceFacilities(BuildingType.Refinery));
+        }
+
+        [Test]
+        public void ProcessTick_ReservedDestination_RemainsAvailableForAutomatedDelivery()
+        {
+            _faction.ManageGarrisons = false;
+            _destination.IsConstructionYardReserved = true;
+            _destination.PositionX = 1;
+
+            _automation.ProcessTick();
+
+            Assert.AreEqual(1, _destination.GetTotalBuildingTypeCount(BuildingType.Mine));
+        }
+
+        [Test]
         public void ProcessTick_ManageProductionWithoutMineCapacity_DoesNotAddRefinery()
         {
             _faction.ManageGarrisons = false;
@@ -161,6 +198,73 @@ namespace Rebellion.Tests.Systems
             };
             planet.SetFullPopularSupport(_faction.InstanceID);
             return planet;
+        }
+
+        private static GameConfig CreateGameConfig()
+        {
+            GameConfig config = new GameConfig();
+            config.AI.Garrison.SupportThreshold = 50;
+            config.AI.Garrison.GarrisonDivisor = 10;
+            config.AI.Garrison.UprisingMultiplier = 2;
+            return config;
+        }
+
+        private static GameDataCatalog CreateGameData(GameConfig config)
+        {
+            GameGenerationConfig generationConfig = new GameGenerationConfig
+            {
+                GalaxyClassification = new GalaxyClassificationSection
+                {
+                    FactionSetups = new List<FactionSetup>
+                    {
+                        new FactionSetup
+                        {
+                            FactionID = _factionId,
+                            GarrisonTroopTypeID = _garrisonTypeId,
+                        },
+                    },
+                },
+            };
+            List<string> manufacturingFactionIds = new List<string> { _factionId };
+            Building mine = new Building
+            {
+                TypeID = "mine",
+                BuildingType = BuildingType.Mine,
+                ConstructionCost = 1,
+                BaseBuildSpeed = 1,
+                ManufacturingFactionInstanceIDs = manufacturingFactionIds,
+            };
+            Building refinery = new Building
+            {
+                TypeID = "refinery",
+                BuildingType = BuildingType.Refinery,
+                ConstructionCost = 1,
+                BaseBuildSpeed = 1,
+                ManufacturingFactionInstanceIDs = manufacturingFactionIds,
+            };
+            Regiment garrison = new Regiment
+            {
+                TypeID = _garrisonTypeId,
+                ConstructionCost = 1,
+                BaseBuildSpeed = 1,
+                ManufacturingFactionInstanceIDs = manufacturingFactionIds,
+            };
+            return new GameDataCatalog(
+                config,
+                generationConfig,
+                Array.Empty<Faction>(),
+                Array.Empty<PlanetSector>(),
+                new[] { mine, refinery },
+                Array.Empty<CapitalShip>(),
+                Array.Empty<Starfighter>(),
+                new[] { garrison },
+                Array.Empty<SpecialForces>(),
+                Array.Empty<Officer>(),
+                Array.Empty<GameEvent>(),
+                Array.Empty<MessageDefinition>(),
+                new EncyclopediaEntries(),
+                new FactionThemes()
+            );
         }
 
         private void AddProductionFacility(Planet planet, string instanceId, ManufacturingType type)

--- a/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
@@ -330,12 +330,14 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void BuildFactionView_CorePlanetSectorSnapshot_PreservesObservedPopularSupport()
+        public void BuildFactionView_UnownedCorePlanet_UsesCurrentPopularSupport()
         {
             _coruscant.PopularSupport["FNALL1"] = 50;
+            _coruscant.EnergyCapacity = 8;
 
             _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSector, 10);
             _coruscant.PopularSupport["FNALL1"] = 25;
+            _coruscant.EnergyCapacity = 3;
 
             GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
 
@@ -344,7 +346,25 @@ namespace Rebellion.Tests.Sectors
                 .GetChildren<Planet>()
                 .First(p => p.InstanceID == "CORUSCANT");
 
-            Assert.AreEqual(50, viewCoruscant.PopularSupport["FNALL1"]);
+            Assert.AreEqual(25, viewCoruscant.PopularSupport["FNALL1"]);
+            Assert.AreEqual(8, viewCoruscant.EnergyCapacity);
+        }
+
+        [Test]
+        public void BuildFactionView_UnownedCorePlanet_UsesCurrentUprisingState()
+        {
+            _coruscant.IsInUprising = false;
+            _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSector, 10);
+            _coruscant.IsInUprising = true;
+
+            GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
+
+            Planet viewCoruscant = view.GetChildren<PlanetSector>()
+                .First(s => s.InstanceID == "CORE_SECTOR")
+                .GetChildren<Planet>()
+                .First(p => p.InstanceID == "CORUSCANT");
+
+            Assert.IsTrue(viewCoruscant.IsInUprising);
         }
 
         [Test]
@@ -1510,6 +1530,24 @@ namespace Rebellion.Tests.Sectors
                 .First(p => p.InstanceID == "TATOOINE");
 
             Assert.AreEqual(40, viewTatooine.PopularSupport["FNALL1"]);
+        }
+
+        [Test]
+        public void BuildFactionView_OuterRimSnapshot_PreservesObservedUprisingState()
+        {
+            MakeTatooineImperial();
+            _tatooine.IsInUprising = false;
+            _fogSystem.CaptureSnapshot(_alliance, _tatooine, _outerRim, 10);
+            _tatooine.IsInUprising = true;
+
+            GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
+
+            Planet viewTatooine = view.GetChildren<PlanetSector>()
+                .First(s => s.InstanceID == "OUTERRIM")
+                .GetChildren<Planet>()
+                .First(p => p.InstanceID == "TATOOINE");
+
+            Assert.IsFalse(viewTatooine.IsInUprising);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -2420,6 +2420,38 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void HandleResults_CapturedMissionParticipant_TearsDownMissionAtCurrentPlanet()
+        {
+            (GameRoot game, Planet planet, Officer officer, MovementSystem movement) = BuildScene(
+                factionOwnsPlanet: true
+            );
+            StubMission mission = CreateMission(game, planet, officer);
+            game.MoveNode(officer, mission);
+            mission.Initiate(1);
+            officer.IsCaptured = true;
+            officer.CaptorInstanceID = "rebels";
+            officer.IsEnabled = false;
+            MissionSystem system = TestSystems.CreateMissionSystem(game, new StubRNG(), movement);
+
+            system.HandleResults(
+                new List<OfficerCaptureStateResult>
+                {
+                    new OfficerCaptureStateResult
+                    {
+                        TargetOfficer = officer,
+                        IsCaptured = true,
+                        Context = planet,
+                    },
+                }
+            );
+
+            Assert.IsNull(mission.GetParent());
+            Assert.AreSame(planet, officer.GetParent());
+            Assert.IsTrue(officer.IsCaptured);
+            Assert.IsFalse(officer.IsEnabled);
+        }
+
+        [Test]
         public void InitiateMission_ResearchWithDiscipline_AttachesResearchMissionToPlanet()
         {
             (GameRoot game, Planet planet, Officer officer, MovementSystem movement) = BuildScene(

--- a/Assets/Tests/EditMode/GameTests/Systems/NamingSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/NamingSystemTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Rebellion.Game;
+using Rebellion.Game.Factions;
+using Rebellion.Game.Units;
+using Rebellion.Systems;
+
+namespace Rebellion.Tests.Systems
+{
+    [TestFixture]
+    public class NamingSystemTests
+    {
+        private GameRoot _game;
+        private Faction _faction;
+        private NamingSystem _system;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _game = new GameRoot();
+            _faction = new Faction { InstanceID = "FACTION" };
+            _faction.ShipNamePools.Add(
+                new FactionNamePool
+                {
+                    NamePoolID = "POOL",
+                    Names = new List<string> { "First", "Second", "Third" },
+                }
+            );
+            _game.GetFactions().Add(_faction);
+            _system = new NamingSystem(_game);
+        }
+
+        [Test]
+        public void ProcessTick_AIControlledFaction_AssignsName()
+        {
+            CapitalShip ship = AddShip("SHIP", ManufacturingStatus.Complete);
+
+            _system.ProcessTick();
+
+            Assert.AreEqual("First", ship.DisplayName);
+            Assert.IsTrue(ship.HasAssignedName);
+        }
+
+        [Test]
+        public void ProcessFaction_EligibleShips_AssignsSequentialNames()
+        {
+            CapitalShip firstShip = AddShip("FIRST", ManufacturingStatus.Complete);
+            CapitalShip secondShip = AddShip("SECOND", ManufacturingStatus.Complete);
+
+            int assignedCount = _system.ProcessFaction(_faction);
+
+            Assert.AreEqual(2, assignedCount);
+            Assert.AreEqual("First", firstShip.DisplayName);
+            Assert.AreEqual("Second", secondShip.DisplayName);
+            Assert.IsTrue(firstShip.HasAssignedName);
+            Assert.IsTrue(secondShip.HasAssignedName);
+        }
+
+        [Test]
+        public void ProcessFaction_PlayerFactionWithManagement_AssignsName()
+        {
+            _faction.PlayerID = "PLAYER";
+            _faction.ManageNaming = true;
+            CapitalShip ship = AddShip("SHIP", ManufacturingStatus.Complete);
+
+            int assignedCount = _system.ProcessFaction(_faction);
+
+            Assert.AreEqual(1, assignedCount);
+            Assert.AreEqual("First", ship.DisplayName);
+        }
+
+        [Test]
+        public void ProcessFaction_ExhaustedPools_AssignsGenericName()
+        {
+            _faction.ShipNamePools.Single().NextNameIndex = 3;
+            CapitalShip ship = AddShip("SHIP", ManufacturingStatus.Complete);
+
+            int assignedCount = _system.ProcessFaction(_faction);
+
+            Assert.AreEqual(1, assignedCount);
+            Assert.AreEqual("Generic SHIP 1", ship.DisplayName);
+            Assert.IsTrue(ship.HasAssignedName);
+        }
+
+        [Test]
+        public void ProcessFaction_MoreThanTenEligibleShips_AssignsTenNames()
+        {
+            _faction.ShipNamePools.Single().Names = Enumerable
+                .Range(1, 11)
+                .Select(index => $"Ship {index}")
+                .ToList();
+            List<CapitalShip> ships = Enumerable
+                .Range(1, 11)
+                .Select(index => AddShip($"SHIP_{index}", ManufacturingStatus.Complete))
+                .ToList();
+
+            int assignedCount = _system.ProcessFaction(_faction);
+
+            Assert.AreEqual(10, assignedCount);
+            Assert.AreEqual(10, ships.Count(ship => ship.HasAssignedName));
+        }
+
+        [Test]
+        public void ProcessFaction_ShipUnderConstruction_DoesNotAssignName()
+        {
+            CapitalShip ship = AddShip("SHIP", ManufacturingStatus.Building);
+
+            int assignedCount = _system.ProcessFaction(_faction);
+
+            Assert.AreEqual(0, assignedCount);
+            Assert.IsFalse(ship.HasAssignedName);
+        }
+
+        [Test]
+        public void ProcessFaction_AlreadyNamedShip_DoesNotReplaceName()
+        {
+            CapitalShip ship = AddShip("SHIP", ManufacturingStatus.Complete);
+            ship.AssignName("Existing Name");
+
+            int assignedCount = _system.ProcessFaction(_faction);
+
+            Assert.AreEqual(0, assignedCount);
+            Assert.AreEqual("Existing Name", ship.DisplayName);
+        }
+
+        [Test]
+        public void ProcessFaction_ShipWithoutNamePool_DoesNotAssignName()
+        {
+            CapitalShip ship = AddShip("SHIP", ManufacturingStatus.Complete);
+            ship.ShipNamePoolID = null;
+
+            int assignedCount = _system.ProcessFaction(_faction);
+
+            Assert.AreEqual(0, assignedCount);
+            Assert.IsFalse(ship.HasAssignedName);
+        }
+
+        [Test]
+        public void ProcessFaction_PlayerFactionWithoutManagement_DoesNotAssignName()
+        {
+            _faction.PlayerID = "PLAYER";
+            CapitalShip ship = AddShip("SHIP", ManufacturingStatus.Complete);
+
+            int assignedCount = _system.ProcessFaction(_faction);
+
+            Assert.AreEqual(0, assignedCount);
+            Assert.IsFalse(ship.HasAssignedName);
+        }
+
+        [Test]
+        public void ProcessFaction_NullFaction_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _system.ProcessFaction(null));
+        }
+
+        private CapitalShip AddShip(string instanceId, ManufacturingStatus manufacturingStatus)
+        {
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = instanceId,
+                TypeID = "SHIP_TYPE",
+                DisplayName = $"Generic {instanceId}",
+                OwnerInstanceID = _faction.InstanceID,
+                ShipNamePoolID = "POOL",
+                ManufacturingStatus = manufacturingStatus,
+            };
+            _faction.AddOwnedUnit(ship);
+            return ship;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/GameTests/Systems/NamingSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/NamingSystemTests.cs
@@ -85,7 +85,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessFaction_MoreThanTenEligibleShips_AssignsTenNames()
+        public void ProcessFaction_MoreThanTenEligibleShips_AssignsAllNames()
         {
             _faction.ShipNamePools.Single().Names = Enumerable
                 .Range(1, 11)
@@ -98,8 +98,8 @@ namespace Rebellion.Tests.Systems
 
             int assignedCount = _system.ProcessFaction(_faction);
 
-            Assert.AreEqual(10, assignedCount);
-            Assert.AreEqual(10, ships.Count(ship => ship.HasAssignedName));
+            Assert.AreEqual(11, assignedCount);
+            Assert.AreEqual(11, ships.Count(ship => ship.HasAssignedName));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/NamingSystemTests.cs.meta
+++ b/Assets/Tests/EditMode/GameTests/Systems/NamingSystemTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f45d8d12e74e47d4a409d91d7c46daf1

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowControllerTests.cs
@@ -6,6 +6,7 @@ using Rebellion.Game;
 using Rebellion.Game.Encyclopedia;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
+using Rebellion.Game.Messages;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using UnityEngine;
@@ -274,6 +275,58 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Combat
             Assert.AreEqual(BattleAlertWindowMode.Result, data.Mode);
             Assert.AreEqual(BattleResultCategory.Troops, data.Result.Category);
             Assert.AreEqual("Assault on Corellia", data.Result.Title);
+            Assert.IsEmpty(_playedTracks);
+            CollectionAssert.AreEqual(new[] { StrategyUISoundPaths.PlanetaryAssault }, _playedSfx);
+        }
+
+        [Test]
+        public void OpenResult_SpaceCombat_PlaysCompletedBattleMusic()
+        {
+            _pending = null;
+
+            _controller.OpenResult(_resolveResult);
+
+            Assert.AreEqual(1, _stopMusicCount);
+            Assert.AreEqual(1, _playedTracks.Count);
+            Assert.IsNotEmpty(_playedTracks[0]);
+        }
+
+        [Test]
+        public void OpenReport_SpaceCombat_PreservesStrategyMusic()
+        {
+            CombatReport report = new CombatReport
+            {
+                CombatType = CombatReportType.SpaceBattle,
+                PerspectiveOwnerInstanceID = _playerFactionId,
+                AttackerOwnerInstanceID = _playerFactionId,
+                DefenderOwnerInstanceID = _opponentFactionId,
+                Winner = CombatSide.Defender,
+                Title = "Battle at Corellia",
+                Body = "The defending fleet was victorious.",
+            };
+
+            _controller.OpenReport(report);
+
+            Assert.AreEqual(0, _stopMusicCount);
+            Assert.IsEmpty(_playedTracks);
+        }
+
+        [Test]
+        public void OpenReport_PlanetaryAssault_PlaysReportSoundWithoutChangingMusic()
+        {
+            CombatReport report = new CombatReport
+            {
+                CombatType = CombatReportType.PlanetaryAssault,
+                PerspectiveOwnerInstanceID = _playerFactionId,
+                AttackerOwnerInstanceID = _opponentFactionId,
+                DefenderOwnerInstanceID = _playerFactionId,
+                Title = "Assault on Corellia",
+                Body = "The defending troops repulsed the assault.",
+            };
+
+            _controller.OpenReport(report);
+
+            Assert.AreEqual(0, _stopMusicCount);
             Assert.IsEmpty(_playedTracks);
             CollectionAssert.AreEqual(new[] { StrategyUISoundPaths.PlanetaryAssault }, _playedSfx);
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
@@ -67,6 +67,63 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
         }
 
         [Test]
+        public void Build_UnreservedConstructionLane_ReturnsUncheckedReservationCommand()
+        {
+            Planet planet = CreatePlanet(withBuildingQueue: false);
+
+            List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
+                planet,
+                FacilityWindowTab.Manufacturing,
+                FacilityWindowTab.Construction,
+                null,
+                "owner"
+            );
+
+            StrategyMenuCommand reserve = commands.Single(command =>
+                command.Action == StrategyMenuAction.Reserve
+            );
+            Assert.IsTrue(reserve.Enabled);
+            Assert.AreEqual(StrategyContextMenuIconKeys.None, reserve.IconKey);
+            Assert.IsTrue(reserve.UsesIconColumn);
+        }
+
+        [Test]
+        public void Build_ReservedConstructionLane_ReturnsCheckedReservationCommand()
+        {
+            Planet planet = CreatePlanet(withBuildingQueue: false);
+            planet.IsConstructionYardReserved = true;
+
+            List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
+                planet,
+                FacilityWindowTab.Manufacturing,
+                FacilityWindowTab.Construction,
+                null,
+                "owner"
+            );
+
+            StrategyMenuCommand reserve = commands.Single(command =>
+                command.Action == StrategyMenuAction.Reserve
+            );
+            Assert.AreEqual(StrategyContextMenuIconKeys.CheckMark, reserve.IconKey);
+        }
+
+        [Test]
+        public void Build_NonConstructionManufacturingLane_OmitsReservationCommand()
+        {
+            Planet planet = CreatePlanet(withBuildingQueue: false);
+
+            List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
+                planet,
+                FacilityWindowTab.Manufacturing,
+                FacilityWindowTab.Shipyards,
+                null,
+                "owner"
+            );
+
+            Assert.IsFalse(commands.Any(command => command.Action == StrategyMenuAction.Reserve));
+        }
+
+        [Test]
         public void Build_InventoryItemUnderConstruction_ReturnsEnabledStopCommand()
         {
             Planet planet = CreatePlanet(withBuildingQueue: false);

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
@@ -66,15 +66,19 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
             Assert.IsFalse(stop.Enabled);
         }
 
-        [Test]
-        public void Build_UnreservedConstructionLane_ReturnsUncheckedReservationCommand()
+        [TestCase(FacilityWindowTab.Shipyards)]
+        [TestCase(FacilityWindowTab.Training)]
+        [TestCase(FacilityWindowTab.Construction)]
+        public void Build_UnreservedManufacturingLane_ReturnsUncheckedReservationCommand(
+            FacilityWindowTab manufacturingTab
+        )
         {
             Planet planet = CreatePlanet(withBuildingQueue: false);
 
             List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
                 planet,
                 FacilityWindowTab.Manufacturing,
-                FacilityWindowTab.Construction,
+                manufacturingTab,
                 null,
                 "owner"
             );
@@ -87,16 +91,21 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
             Assert.IsTrue(reserve.UsesIconColumn);
         }
 
-        [Test]
-        public void Build_ReservedConstructionLane_ReturnsCheckedReservationCommand()
+        [TestCase(FacilityWindowTab.Shipyards, ManufacturingType.Ship)]
+        [TestCase(FacilityWindowTab.Training, ManufacturingType.Troop)]
+        [TestCase(FacilityWindowTab.Construction, ManufacturingType.Building)]
+        public void Build_ReservedManufacturingLane_ReturnsCheckedReservationCommand(
+            FacilityWindowTab manufacturingTab,
+            ManufacturingType manufacturingType
+        )
         {
             Planet planet = CreatePlanet(withBuildingQueue: false);
-            planet.IsConstructionYardReserved = true;
+            planet.SetManufacturingReserved(manufacturingType, true);
 
             List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
                 planet,
                 FacilityWindowTab.Manufacturing,
-                FacilityWindowTab.Construction,
+                manufacturingTab,
                 null,
                 "owner"
             );
@@ -105,22 +114,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
                 command.Action == StrategyMenuAction.Reserve
             );
             Assert.AreEqual(StrategyContextMenuIconKeys.CheckMark, reserve.IconKey);
-        }
-
-        [Test]
-        public void Build_NonConstructionManufacturingLane_OmitsReservationCommand()
-        {
-            Planet planet = CreatePlanet(withBuildingQueue: false);
-
-            List<StrategyMenuCommand> commands = FacilityWindowContextMenuBuilder.Build(
-                planet,
-                FacilityWindowTab.Manufacturing,
-                FacilityWindowTab.Shipyards,
-                null,
-                "owner"
-            );
-
-            Assert.IsFalse(commands.Any(command => command.Action == StrategyMenuAction.Reserve));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowControllerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using Rebellion.Game;
 using Rebellion.Game.Encyclopedia;
@@ -9,6 +10,7 @@ using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 using Rebellion.Systems;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using GalaxyPlanetSector = Rebellion.Game.Galaxy.PlanetSector;
 
 namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
@@ -249,6 +251,47 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
 
             Assert.IsNull(_controller.GetStatusTarget(view));
             Assert.IsEmpty(_controller.GetScrapItems(view));
+        }
+
+        [Test]
+        public void OnContextMenuCommandSelected_ConstructionReservation_TogglesPlanetReservation()
+        {
+            FacilityWindowView view = OpenWindow(out UIWindow window);
+            ManufacturingLaneCardView card =
+                view.GetComponentsInChildren<ManufacturingLaneCardView>(true)
+                    .Single(candidate => candidate.name == "ConstructionManufacturingLaneCard");
+            UIComponentTestHelper.InvokeLifecycle(card, "Awake");
+            UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+            PointerEventData pointer = new PointerEventData(null)
+            {
+                button = PointerEventData.InputButton.Right,
+            };
+            card.GetComponent<UIPointerGestureRelay>().OnPointerDown(pointer);
+            StrategyContextMenuProviderContext context = new StrategyContextMenuProviderContext(
+                window,
+                new StrategyContextMenuLayout(1, 2, 3, 4, 5, 6, 7),
+                pointer,
+                10,
+                20
+            );
+            StrategyMenuCommand reserve = FacilityWindowContextMenuBuilder
+                .Build(
+                    _planet.Planet,
+                    FacilityWindowTab.Manufacturing,
+                    FacilityWindowTab.Construction,
+                    null,
+                    _playerFactionId
+                )
+                .Single(command => command.Action == StrategyMenuAction.Reserve);
+            ContextMenuRequest request = new ContextMenuRequest(
+                context,
+                new IContextMenuCommand[] { reserve },
+                _controller
+            );
+
+            _controller.OnContextMenuCommandSelected(request, reserve);
+
+            Assert.IsTrue(_planet.Planet.IsConstructionYardReserved);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowControllerTests.cs
@@ -254,7 +254,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
         }
 
         [Test]
-        public void OnContextMenuCommandSelected_ConstructionReservation_TogglesPlanetReservation()
+        public void OnContextMenuCommandSelected_ManufacturingReservation_TogglesSelectedLane()
         {
             FacilityWindowView view = OpenWindow(out UIWindow window);
             ManufacturingLaneCardView card =
@@ -291,7 +291,9 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
 
             _controller.OnContextMenuCommandSelected(request, reserve);
 
-            Assert.IsTrue(_planet.Planet.IsConstructionYardReserved);
+            Assert.IsTrue(_planet.Planet.IsManufacturingReserved(ManufacturingType.Building));
+            Assert.IsFalse(_planet.Planet.IsManufacturingReserved(ManufacturingType.Ship));
+            Assert.IsFalse(_planet.Planet.IsManufacturingReserved(ManufacturingType.Troop));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowControllerTests.cs
@@ -10,6 +10,7 @@ using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 using Rebellion.Systems;
+using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using GalaxyPlanetSector = Rebellion.Game.Galaxy.PlanetSector;
@@ -400,7 +401,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
         }
 
         [Test]
-        public void ContextMenu_BombardmentLeaf_ExecutesAndRoutesBattleResult()
+        public void OnContextMenuCommandSelected_BombardmentLeaf_ExecutesAndRoutesBattleResult()
         {
             _planet.Planet.OwnerInstanceID = _opposingFactionId;
             _fleet.GetChildren<CapitalShip>()[0].Bombardment = 1;
@@ -439,6 +440,52 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
                 ((BombardmentResult)_actions.LastBattleResult).Type
             );
             Assert.AreEqual(1, _actions.RefreshCount);
+        }
+
+        [Test]
+        public void OnContextMenuCommandSelected_CapitalShipRename_MarksNameAsAssigned()
+        {
+            FleetWindowView view = OpenWindow(out UIWindow window);
+            UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+            _controller.RenderWindow(view, window, true);
+            CapitalShip ship = _fleet.GetChildren<CapitalShip>().Single();
+            StrategyUnitCardView card = view.GetComponentsInChildren<StrategyUnitCardView>(true)
+                .Single(item => item.gameObject.activeInHierarchy);
+            PointerEventData eventData = new PointerEventData(null)
+            {
+                button = PointerEventData.InputButton.Right,
+                pointerCurrentRaycast = new RaycastResult
+                {
+                    gameObject = card.NameTextField.gameObject,
+                },
+                pointerPressRaycast = new RaycastResult
+                {
+                    gameObject = card.NameTextField.gameObject,
+                },
+            };
+            StrategyContextMenuProviderContext context = new StrategyContextMenuProviderContext(
+                window,
+                new StrategyContextMenuLayout(1, 177, 188, 4, 5, 6, 7),
+                eventData,
+                10,
+                20
+            );
+            _controller.TryCreateContextMenu(context, out ContextMenuRequest request, out _);
+            StrategyMenuCommand command = request
+                .Commands.Cast<StrategyMenuCommand>()
+                .Single(item => item.Action == StrategyMenuAction.Rename);
+            ContextMenuController contextMenuController = new ContextMenuController();
+            contextMenuController.Open(request);
+
+            bool selected = contextMenuController.TrySelectCommand(command);
+            _controller.RenderWindow(view, window, true);
+            TMP_InputField input = view.GetComponentInChildren<TMP_InputField>(true);
+            input.SetTextWithoutNotify("Named Ship");
+            input.onSubmit.Invoke(input.text);
+
+            Assert.IsTrue(selected);
+            Assert.AreEqual("Named Ship", ship.DisplayName);
+            Assert.IsTrue(ship.HasAssignedName);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -36,6 +36,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                     "Objectives",
                     "Manage Garrisons",
                     "Manage Production",
+                    "Manage Naming",
                     "Translate Counterpart",
                     "Agent Advice",
                 },
@@ -120,7 +121,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
-        public void ManageProduction_Enabled_ProcessesAutomationImmediately()
+        public void OnContextMenuCommandSelected_ManageProductionEnabled_ProcessesAutomationImmediately()
         {
             Faction faction = new Faction();
             TestActions actions = new TestActions();
@@ -152,6 +153,42 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             controller.OnContextMenuCommandSelected(request, command);
 
             Assert.IsTrue(faction.ManageProduction);
+            Assert.AreSame(faction, actions.ProcessedFaction);
+        }
+
+        [Test]
+        public void OnContextMenuCommandSelected_ManageNamingEnabled_ProcessesAutomationImmediately()
+        {
+            Faction faction = new Faction();
+            TestActions actions = new TestActions();
+            StrategyAdvisorController controller = new StrategyAdvisorController(
+                () => faction,
+                _ => null,
+                _ => { }
+            );
+            controller.Initialize(actions);
+            StrategyMenuCommand command = StrategyAdvisorController
+                .BuildCommandMenu(faction)
+                .Single(item => item.Action == StrategyMenuAction.AdvisorManageNaming);
+            ContextMenuRequest request = (ContextMenuRequest)
+                typeof(StrategyAdvisorController)
+                    .GetMethod(
+                        "CreateContextMenuRequest",
+                        BindingFlags.Instance | BindingFlags.NonPublic
+                    )
+                    ?.Invoke(
+                        controller,
+                        new object[]
+                        {
+                            new List<StrategyMenuCommand> { command },
+                            0,
+                            0,
+                        }
+                    );
+
+            controller.OnContextMenuCommandSelected(request, command);
+
+            Assert.IsTrue(faction.ManageNaming);
             Assert.AreSame(faction, actions.ProcessedFaction);
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using NUnit.Framework;
+using Rebellion.Game.Advisor;
 
 namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
 {
@@ -28,6 +29,21 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
         {
             FactionTheme theme = new FactionTheme
             {
+                StrategyAdvisor = new StrategyAdvisorTheme
+                {
+                    AudioRoot = "advisor-audio",
+                    Notifications =
+                    {
+                        new StrategyAdvisorNotificationTheme
+                        {
+                            NotificationType = AdvisorNotificationType.PlanetaryAssault,
+                            Protocol = new StrategyAdvisorAnimationTheme
+                            {
+                                Audio = "planetary-assault",
+                            },
+                        },
+                    },
+                },
                 StrategyWindowSounds = new StrategyWindowSoundTheme
                 {
                     PlanetWindowOpenSoundPath = "window-open",
@@ -51,6 +67,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                     StrategyUISoundPaths.GalacticInformationOpen,
                     StrategyUISoundPaths.GalacticInformationControl,
                     StrategyUISoundPaths.PlanetaryAssault,
+                    "advisor-audio/planetary-assault",
                     "window-open",
                     "window-expand",
                     "window-collapse",


### PR DESCRIPTION
## Summary

- Adds reusable faction ship naming through `NamingSystem` and keeps the behavior independent of AI implementation.
- Names eligible AI capital ships automatically and adds the player-facing **Manage Naming** advisor toggle with immediate execution.
- Persists faction name-pool progress, generic-name counters, ship pool assignments, and assigned-name state while preserving manually and event-assigned names.
- Adds persistent per-planet manufacturing reservations for construction yards, shipyards, and training facilities.
- Exposes reservation commands in the facility context menu and prevents advisor automation from using reserved manufacturing lanes.
- Exposes live popular-support and uprising changes on unowned Core planets while retaining snapshot behavior for other hidden state and Outer Rim planets.
- Ends an active mission immediately when an external event captures one of its participants.
- Preserves strategy music when the player reopens saved space-combat reports while retaining normal end-of-battle music and assault-report sound behavior.
- Preloads the active faction's planetary-assault advisor notification audio.
- Adds synthetic, content-independent coverage for naming, reservations, automation timing, UI commands, serialization, fog of war, mission result routing, and combat presentation.

Merged media PR https://github.com/davidadas/rebellion2-media/pull/58 supplies the faction name pools. Media PR https://github.com/davidadas/rebellion2-media/pull/59 supplies the corresponding strategy artwork, audio, and event changes.

## Validation

- `bash build.sh format` passes.
- `bash build.sh lint` passes compilation, analyzers, naming rules, and member-order checks with zero diagnostics.
- `bash build.sh test` passes 4,173 tests with zero failures or skips.
- `bash build.sh coverage` reports 79.5% line coverage and 90.0% method coverage while all 4,173 tests pass.
- The media counterpart passes XML, schema, LFS, oversized-blob, and engine/media byte-parity validation.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.