### PR TITLE
Fixing strategy gameplay presentation and visibility.

### DIFF
--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -415,6 +415,7 @@ public sealed class GameManager
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_planetaryControlSystem);
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_uprisingSystem);
         _resultProcessor.Subscribe<MissionCompletedResult>(_jediSystem);
+        _resultProcessor.Subscribe<OfficerCaptureStateResult>(_missionSystem);
         _resultProcessor.Subscribe<IntelligenceRevealedResult>(_fogOfWarSystem);
         _resultProcessor.Observe<GameObjectSabotagedResult>(_fogOfWarSystem.ProcessResults);
 

--- a/Assets/Scripts/Systems/FogOfWarSystem.cs
+++ b/Assets/Scripts/Systems/FogOfWarSystem.cs
@@ -167,7 +167,7 @@ namespace Rebellion.Systems
                     else if (planetSnapshot != null)
                     {
                         viewPlanet = BlankPlanetView(masterPlanet);
-                        ApplySnapshotView(viewPlanet, planetSnapshot);
+                        ApplySnapshotView(viewPlanet, masterPlanet, masterSector, planetSnapshot);
                     }
                     else
                     {
@@ -476,19 +476,33 @@ namespace Rebellion.Systems
         /// visibility but has previously observed this planet.
         /// </summary>
         /// <param name="viewPlanet">The view planet to populate.</param>
+        /// <param name="masterPlanet">The authoritative planet data source.</param>
+        /// <param name="masterSector">The sector containing the planet.</param>
         /// <param name="planetSnapshot">The prior snapshot for the planet.</param>
-        private void ApplySnapshotView(Planet viewPlanet, PlanetSnapshot planetSnapshot)
+        private void ApplySnapshotView(
+            Planet viewPlanet,
+            Planet masterPlanet,
+            PlanetSector masterSector,
+            PlanetSnapshot planetSnapshot
+        )
         {
             viewPlanet.OwnerInstanceID = planetSnapshot.OwnerInstanceID;
             viewPlanet.IsColonized = planetSnapshot.IsColonized;
-            viewPlanet.IsInUprising = planetSnapshot.IsInUprising;
+            viewPlanet.IsInUprising =
+                masterSector.SectorType == PlanetSectorType.Core
+                    ? masterPlanet.IsInUprising
+                    : planetSnapshot.IsInUprising;
             viewPlanet.IsDestroyed = planetSnapshot.IsDestroyed;
             viewPlanet.IsHeadquarters = planetSnapshot.IsHeadquarters;
             viewPlanet.EnergyCapacity = planetSnapshot.EnergyCapacity;
             viewPlanet.AllocatedEnergy = planetSnapshot.AllocatedEnergy;
             viewPlanet.NumRawResourceNodes = planetSnapshot.NumRawResourceNodes;
 
-            viewPlanet.PopularSupport = new Dictionary<string, int>(planetSnapshot.PopularSupport);
+            Dictionary<string, int> popularSupport =
+                masterSector.SectorType == PlanetSectorType.Core
+                    ? masterPlanet.PopularSupport
+                    : planetSnapshot.PopularSupport;
+            viewPlanet.PopularSupport = new Dictionary<string, int>(popularSupport);
 
             viewPlanet.SetChildren(
                 planetSnapshot.Fleets.Select(FogOfWarRecorder.CopyFleetForSnapshot),

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -16,7 +16,9 @@ namespace Rebellion.Systems
     /// Orchestrates mission creation, participant travel, and external execution services.
     /// Each mission owns its post-arrival lifecycle.
     /// </summary>
-    public class MissionSystem : IMissionExecutionRuntime
+    public class MissionSystem
+        : IMissionExecutionRuntime,
+            IGameResultHandler<OfficerCaptureStateResult>
     {
         private readonly GameRoot _game;
         private readonly IRandomNumberProvider _provider;
@@ -238,6 +240,34 @@ namespace Rebellion.Systems
             );
             TearDownMission(mission, null, _pendingResults);
             return true;
+        }
+
+        /// <summary>
+        /// Ends missions whose participants were captured by another simulation system.
+        /// </summary>
+        /// <param name="results">The officer capture-state changes to process.</param>
+        /// <returns>Mission interruption results produced while tearing down affected missions.</returns>
+        public List<GameResult> HandleResults(IReadOnlyList<OfficerCaptureStateResult> results)
+        {
+            List<GameResult> missionResults = new List<GameResult>();
+            List<Mission> affectedMissions = results
+                .Where(result => result?.IsCaptured == true)
+                .Select(result => result.TargetOfficer?.GetParent() as Mission)
+                .Where(mission => mission != null)
+                .Distinct()
+                .ToList();
+
+            foreach (Mission mission in affectedMissions)
+            {
+                AddMissionResults(
+                    mission,
+                    mission.ResolveInterruption(_game, _provider),
+                    missionResults
+                );
+                TearDownMission(mission, null, missionResults);
+            }
+
+            return missionResults;
         }
 
         /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleResultPresentation.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleResultPresentation.cs
@@ -575,22 +575,6 @@ internal abstract class BattleResultPresentation
         }
 
         /// <summary>
-        /// Returns completed fleet-engagement music from the saved recipient perspective.
-        /// </summary>
-        internal override string GetMusicPath(BattleAlertWindowTheme theme, string playerFactionId)
-        {
-            if (theme == null || report.CombatType != CombatReportType.SpaceBattle)
-                return null;
-            if (report.Winner == CombatSide.Draw)
-                return FirstNonBlank(theme.ResultDrawMusicPath, theme.ResultMusicPath);
-
-            CombatSide? playerSide = GetSideForOwner(report, playerFactionId);
-            return playerSide.HasValue && playerSide.Value == report.Winner
-                ? FirstNonBlank(theme.ResultVictoryMusicPath, theme.ResultMusicPath)
-                : FirstNonBlank(theme.ResultDefeatMusicPath, theme.ResultMusicPath);
-        }
-
-        /// <summary>
         /// Returns the outcome summary frozen into the delivered message.
         /// </summary>
         internal override string GetSummary(UIContext uiContext, string playerFactionId)
@@ -706,20 +690,6 @@ internal abstract class BattleResultPresentation
         private static SpaceCombatSideOutcome GetOutcome(CombatReport report, CombatSide side)
         {
             return side == CombatSide.Attacker ? report.AttackerOutcome : report.DefenderOutcome;
-        }
-
-        /// <summary>
-        /// Returns the saved side represented by one faction identifier.
-        /// </summary>
-        private static CombatSide? GetSideForOwner(CombatReport report, string ownerInstanceId)
-        {
-            if (string.IsNullOrEmpty(ownerInstanceId))
-                return null;
-            if (ownerInstanceId == report.AttackerOwnerInstanceID)
-                return CombatSide.Attacker;
-            if (ownerInstanceId == report.DefenderOwnerInstanceID)
-                return CombatSide.Defender;
-            return null;
         }
 
         /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Rebellion.Game.Advisor;
 
 /// <summary>
 /// Defines shared non-themed sound resource paths used by strategy UI features.
@@ -35,6 +36,9 @@ internal static class StrategyUISoundPaths
         yield return GalacticInformationControl;
         yield return PlanetaryAssault;
 
+        foreach (string path in GetAdvisorNotificationAudioPaths(theme?.StrategyAdvisor))
+            yield return path;
+
         StrategyWindowSoundTheme windowSounds = theme?.StrategyWindowSounds;
         ConfirmDialogTheme confirmDialog = theme?.ConfirmDialogTheme;
         string[] themedPaths =
@@ -51,5 +55,45 @@ internal static class StrategyUISoundPaths
             if (!string.IsNullOrWhiteSpace(path))
                 yield return path.Trim();
         }
+    }
+
+    /// <summary>
+    /// Enumerates faction audio required by immediate strategy notifications.
+    /// </summary>
+    /// <param name="advisor">The active faction advisor theme.</param>
+    /// <returns>The configured notification audio paths.</returns>
+    private static IEnumerable<string> GetAdvisorNotificationAudioPaths(
+        StrategyAdvisorTheme advisor
+    )
+    {
+        StrategyAdvisorNotificationTheme assault = advisor?.GetNotification(
+            AdvisorNotificationType.PlanetaryAssault,
+            null,
+            AdvisorSubjectNotification.None
+        );
+        string droidPath = GetAdvisorAnimationAudioPath(advisor, assault?.Droid);
+        string protocolPath = GetAdvisorAnimationAudioPath(advisor, assault?.Protocol);
+        if (!string.IsNullOrWhiteSpace(droidPath))
+            yield return droidPath;
+        if (!string.IsNullOrWhiteSpace(protocolPath))
+            yield return protocolPath;
+    }
+
+    /// <summary>
+    /// Resolves one advisor animation's explicit or theme-relative audio path.
+    /// </summary>
+    /// <param name="advisor">The owning advisor theme.</param>
+    /// <param name="animation">The configured advisor animation.</param>
+    /// <returns>The resolved audio path, or null when no audio is configured.</returns>
+    private static string GetAdvisorAnimationAudioPath(
+        StrategyAdvisorTheme advisor,
+        StrategyAdvisorAnimationTheme animation
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(animation?.AudioPath))
+            return animation.AudioPath.Trim();
+        return string.IsNullOrWhiteSpace(animation?.Audio)
+            ? null
+            : advisor.GetAudioPath(animation.Audio.Trim());
     }
 }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -36,7 +36,7 @@ internal static class StrategyUISoundPaths
         yield return GalacticInformationControl;
         yield return PlanetaryAssault;
 
-        foreach (string path in GetAdvisorNotificationAudioPaths(theme?.StrategyAdvisor))
+        foreach (string path in GetPlanetaryAssaultAdvisorAudioPaths(theme?.StrategyAdvisor))
             yield return path;
 
         StrategyWindowSoundTheme windowSounds = theme?.StrategyWindowSounds;
@@ -58,11 +58,12 @@ internal static class StrategyUISoundPaths
     }
 
     /// <summary>
-    /// Enumerates faction audio required by immediate strategy notifications.
+    /// Returns the configured droid and protocol audio paths for the planetary-assault advisor
+    /// notification.
     /// </summary>
     /// <param name="advisor">The active faction advisor theme.</param>
-    /// <returns>The configured notification audio paths.</returns>
-    private static IEnumerable<string> GetAdvisorNotificationAudioPaths(
+    /// <returns>The planetary-assault advisor audio paths.</returns>
+    private static IEnumerable<string> GetPlanetaryAssaultAdvisorAudioPaths(
         StrategyAdvisorTheme advisor
     )
     {

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -143,6 +143,61 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
+        public void ProcessTick_EventCapturesMissionParticipant_TearsDownMission()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            Faction owner = new Faction { InstanceID = "OWNER" };
+            Faction captor = new Faction { InstanceID = "CAPTOR" };
+            game.GetFactions().Add(owner);
+            game.GetFactions().Add(captor);
+            PlanetSector sector = new PlanetSector { InstanceID = "SECTOR" };
+            Planet planet = new Planet
+            {
+                InstanceID = "PLANET",
+                OwnerInstanceID = owner.InstanceID,
+                IsColonized = true,
+            };
+            game.AttachNode(sector, game.GetGalaxyMap());
+            game.AttachNode(planet, sector);
+            Officer officer = EntityFactory.CreateOfficer("OFFICER", owner.InstanceID);
+            DiplomacyMission mission = new DiplomacyMission
+            {
+                InstanceID = "MISSION",
+                OwnerInstanceID = owner.InstanceID,
+                LocationInstanceID = planet.InstanceID,
+            };
+            game.AttachNode(officer, planet);
+            game.AttachNode(mission, planet);
+            game.MoveNode(officer, mission);
+            mission.Initiate(100);
+            game.GetEventPool()
+                .Add(
+                    new GameEvent
+                    {
+                        InstanceID = "CAPTURE_OFFICER",
+                        Schedule = new GameEventScheduler { At = new AtTick { Tick = 1 } },
+                        Actions = new List<GameAction>
+                        {
+                            new SetCaptureStatusAction
+                            {
+                                OfficerInstanceID = officer.InstanceID,
+                                IsCaptured = true,
+                                CaptorFactionInstanceID = captor.InstanceID,
+                            },
+                        },
+                    }
+                );
+            GameManager manager = TestContent.CreateGameManager(game);
+
+            manager.ProcessTick();
+
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Mission>(mission.InstanceID));
+            Assert.AreSame(planet, officer.GetParent());
+            Assert.IsTrue(officer.IsCaptured);
+            Assert.AreEqual(captor.InstanceID, officer.CaptorInstanceID);
+        }
+
+        [Test]
         public void ProcessTick_VictoryConditionMet_RaisesVictoryDeclaredOnce()
         {
             GameRoot game = new GameRoot(TestConfig.Create())

--- a/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
@@ -330,12 +330,14 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void BuildFactionView_CorePlanetSectorSnapshot_PreservesObservedPopularSupport()
+        public void BuildFactionView_UnownedCorePlanet_UsesCurrentPopularSupport()
         {
             _coruscant.PopularSupport["FNALL1"] = 50;
+            _coruscant.EnergyCapacity = 8;
 
             _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSector, 10);
             _coruscant.PopularSupport["FNALL1"] = 25;
+            _coruscant.EnergyCapacity = 3;
 
             GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
 
@@ -344,7 +346,25 @@ namespace Rebellion.Tests.Sectors
                 .GetChildren<Planet>()
                 .First(p => p.InstanceID == "CORUSCANT");
 
-            Assert.AreEqual(50, viewCoruscant.PopularSupport["FNALL1"]);
+            Assert.AreEqual(25, viewCoruscant.PopularSupport["FNALL1"]);
+            Assert.AreEqual(8, viewCoruscant.EnergyCapacity);
+        }
+
+        [Test]
+        public void BuildFactionView_UnownedCorePlanet_UsesCurrentUprisingState()
+        {
+            _coruscant.IsInUprising = false;
+            _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSector, 10);
+            _coruscant.IsInUprising = true;
+
+            GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
+
+            Planet viewCoruscant = view.GetChildren<PlanetSector>()
+                .First(s => s.InstanceID == "CORE_SECTOR")
+                .GetChildren<Planet>()
+                .First(p => p.InstanceID == "CORUSCANT");
+
+            Assert.IsTrue(viewCoruscant.IsInUprising);
         }
 
         [Test]
@@ -1510,6 +1530,24 @@ namespace Rebellion.Tests.Sectors
                 .First(p => p.InstanceID == "TATOOINE");
 
             Assert.AreEqual(40, viewTatooine.PopularSupport["FNALL1"]);
+        }
+
+        [Test]
+        public void BuildFactionView_OuterRimSnapshot_PreservesObservedUprisingState()
+        {
+            MakeTatooineImperial();
+            _tatooine.IsInUprising = false;
+            _fogSystem.CaptureSnapshot(_alliance, _tatooine, _outerRim, 10);
+            _tatooine.IsInUprising = true;
+
+            GalaxyMap view = _fogSystem.BuildFactionView(_alliance);
+
+            Planet viewTatooine = view.GetChildren<PlanetSector>()
+                .First(s => s.InstanceID == "OUTERRIM")
+                .GetChildren<Planet>()
+                .First(p => p.InstanceID == "TATOOINE");
+
+            Assert.IsFalse(viewTatooine.IsInUprising);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -2420,6 +2420,38 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void HandleResults_CapturedMissionParticipant_TearsDownMissionAtCurrentPlanet()
+        {
+            (GameRoot game, Planet planet, Officer officer, MovementSystem movement) = BuildScene(
+                factionOwnsPlanet: true
+            );
+            StubMission mission = CreateMission(game, planet, officer);
+            game.MoveNode(officer, mission);
+            mission.Initiate(1);
+            officer.IsCaptured = true;
+            officer.CaptorInstanceID = "rebels";
+            officer.IsEnabled = false;
+            MissionSystem system = TestSystems.CreateMissionSystem(game, new StubRNG(), movement);
+
+            system.HandleResults(
+                new List<OfficerCaptureStateResult>
+                {
+                    new OfficerCaptureStateResult
+                    {
+                        TargetOfficer = officer,
+                        IsCaptured = true,
+                        Context = planet,
+                    },
+                }
+            );
+
+            Assert.IsNull(mission.GetParent());
+            Assert.AreSame(planet, officer.GetParent());
+            Assert.IsTrue(officer.IsCaptured);
+            Assert.IsFalse(officer.IsEnabled);
+        }
+
+        [Test]
         public void InitiateMission_ResearchWithDiscipline_AttachesResearchMissionToPlanet()
         {
             (GameRoot game, Planet planet, Officer officer, MovementSystem movement) = BuildScene(

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowControllerTests.cs
@@ -6,6 +6,7 @@ using Rebellion.Game;
 using Rebellion.Game.Encyclopedia;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
+using Rebellion.Game.Messages;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using UnityEngine;
@@ -274,6 +275,58 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Combat
             Assert.AreEqual(BattleAlertWindowMode.Result, data.Mode);
             Assert.AreEqual(BattleResultCategory.Troops, data.Result.Category);
             Assert.AreEqual("Assault on Corellia", data.Result.Title);
+            Assert.IsEmpty(_playedTracks);
+            CollectionAssert.AreEqual(new[] { StrategyUISoundPaths.PlanetaryAssault }, _playedSfx);
+        }
+
+        [Test]
+        public void OpenResult_SpaceCombat_PlaysCompletedBattleMusic()
+        {
+            _pending = null;
+
+            _controller.OpenResult(_resolveResult);
+
+            Assert.AreEqual(1, _stopMusicCount);
+            Assert.AreEqual(1, _playedTracks.Count);
+            Assert.IsNotEmpty(_playedTracks[0]);
+        }
+
+        [Test]
+        public void OpenReport_SpaceCombat_PreservesStrategyMusic()
+        {
+            CombatReport report = new CombatReport
+            {
+                CombatType = CombatReportType.SpaceBattle,
+                PerspectiveOwnerInstanceID = _playerFactionId,
+                AttackerOwnerInstanceID = _playerFactionId,
+                DefenderOwnerInstanceID = _opponentFactionId,
+                Winner = CombatSide.Defender,
+                Title = "Battle at Corellia",
+                Body = "The defending fleet was victorious.",
+            };
+
+            _controller.OpenReport(report);
+
+            Assert.AreEqual(0, _stopMusicCount);
+            Assert.IsEmpty(_playedTracks);
+        }
+
+        [Test]
+        public void OpenReport_PlanetaryAssault_PlaysReportSoundWithoutChangingMusic()
+        {
+            CombatReport report = new CombatReport
+            {
+                CombatType = CombatReportType.PlanetaryAssault,
+                PerspectiveOwnerInstanceID = _playerFactionId,
+                AttackerOwnerInstanceID = _opponentFactionId,
+                DefenderOwnerInstanceID = _playerFactionId,
+                Title = "Assault on Corellia",
+                Body = "The defending troops repulsed the assault.",
+            };
+
+            _controller.OpenReport(report);
+
+            Assert.AreEqual(0, _stopMusicCount);
             Assert.IsEmpty(_playedTracks);
             CollectionAssert.AreEqual(new[] { StrategyUISoundPaths.PlanetaryAssault }, _playedSfx);
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using NUnit.Framework;
+using Rebellion.Game.Advisor;
 
 namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
 {
@@ -28,6 +29,21 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
         {
             FactionTheme theme = new FactionTheme
             {
+                StrategyAdvisor = new StrategyAdvisorTheme
+                {
+                    AudioRoot = "advisor-audio",
+                    Notifications =
+                    {
+                        new StrategyAdvisorNotificationTheme
+                        {
+                            NotificationType = AdvisorNotificationType.PlanetaryAssault,
+                            Protocol = new StrategyAdvisorAnimationTheme
+                            {
+                                Audio = "planetary-assault",
+                            },
+                        },
+                    },
+                },
                 StrategyWindowSounds = new StrategyWindowSoundTheme
                 {
                     PlanetWindowOpenSoundPath = "window-open",
@@ -51,6 +67,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                     StrategyUISoundPaths.GalacticInformationOpen,
                     StrategyUISoundPaths.GalacticInformationControl,
                     StrategyUISoundPaths.PlanetaryAssault,
+                    "advisor-audio/planetary-assault",
                     "window-open",
                     "window-expand",
                     "window-collapse",


### PR DESCRIPTION
## Summary

- Exposes live popular-support and uprising changes on unowned Core planets while retaining snapshot behavior for other hidden state and Outer Rim planets.
- Ends an active mission immediately when an external event captures one of its participants.
- Preserves strategy music when the player reopens saved space-combat reports while retaining normal end-of-battle music and assault-report sound behavior.
- Preloads the active faction's immediate planetary-assault advisor notification audio.
- Adds synthetic behavior-owner tests, including end-to-end result routing through `GameManager`.

This PR depends on #135 because current media `main` already contains the faction ship-name-pool data. Media PR https://github.com/davidadas/rebellion2-media/pull/59 supplies the corresponding content changes.

## Validation

- `bash build.sh format` passes.
- `bash build.sh lint` passes compilation, analyzers, naming rules, and member-order checks with zero diagnostics.
- `bash build.sh test` passes 4,161 tests with zero failures or skips.
- `bash build.sh coverage` reports 79.4% line coverage and 90.0% method coverage while all 4,161 tests pass.
- The media counterpart passes XML, schema, LFS, and engine/media byte-parity validation.

A redundant post-commit Unity rerun cannot start because the Windows host exhausts its socket resources (`wakeup_pipes_init: bind failed`). Unity exits during initialization, before compilation or test discovery. The immediately preceding complete test and coverage runs pass, and the final source passes compilation and lint afterward.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.
