### PR TITLE
Fixing strategy gameplay and interface regressions

### DIFF
--- a/Assets/Editor/PrefabBuilders/Common/CommonUIPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/Common/CommonUIPrefabBuilder.cs
@@ -121,6 +121,7 @@ public static class CommonUIPrefabBuilder
             scrollbarObject.transform,
             _scrollUpTexturePath
         );
+        AttachTextureBinding(scrollUpImage, _scrollUpTexturePath);
         SetSourceRect(
             scrollUpImage.rectTransform,
             0,
@@ -136,6 +137,7 @@ public static class CommonUIPrefabBuilder
             scrollbarObject.transform,
             _scrollDownTexturePath
         );
+        AttachTextureBinding(scrollDownImage, _scrollDownTexturePath);
         SetSourceRect(
             scrollDownImage.rectTransform,
             0,
@@ -154,9 +156,7 @@ public static class CommonUIPrefabBuilder
             slidingArea.transform,
             _scrollHandleTexturePath
         );
-        ContentTextureBinding handleBinding =
-            handleImage.gameObject.AddComponent<ContentTextureBinding>();
-        handleBinding.SetAddress(ToContentAddress(_scrollHandleTexturePath));
+        AttachTextureBinding(handleImage, _scrollHandleTexturePath);
         FillParent(handleImage.rectTransform);
         handleImage.raycastTarget = true;
         scrollbar.handleRect = handleImage.rectTransform;
@@ -249,6 +249,17 @@ public static class CommonUIPrefabBuilder
     }
 
     /// <summary>
+    /// Attaches a runtime binding that restores a raw image from installation content.
+    /// </summary>
+    /// <param name="image">The raw image restored at runtime.</param>
+    /// <param name="texturePath">The authored content texture path.</param>
+    private static void AttachTextureBinding(RawImage image, string texturePath)
+    {
+        ContentTextureBinding binding = image.gameObject.AddComponent<ContentTextureBinding>();
+        binding.SetAddress(ToContentAddress(texturePath));
+    }
+
+    /// <summary>
     /// Converts an authored texture path to the extension-free address used by runtime content.
     /// </summary>
     /// <param name="texturePath">The authored content texture path.</param>
@@ -277,7 +288,25 @@ public static class CommonUIPrefabBuilder
         AssignReference(pressVisual, "image", image);
         AssignReference(pressVisual, "button", button);
         pressVisual.SetTextures(image.texture, null);
+        ConvertToPressVisualBinding(image.gameObject);
         return button;
+    }
+
+    /// <summary>
+    /// Transfers a button image's runtime texture address to its pressed-state visual.
+    /// </summary>
+    /// <param name="target">The button carrying the image and pressed-state visual.</param>
+    private static void ConvertToPressVisualBinding(GameObject target)
+    {
+        ContentTextureBinding textureBinding = target.GetComponent<ContentTextureBinding>();
+        if (textureBinding == null)
+            return;
+
+        ContentPressVisualBinding pressBinding =
+            target.GetComponent<ContentPressVisualBinding>()
+            ?? target.AddComponent<ContentPressVisualBinding>();
+        pressBinding.SetAddresses(textureBinding.Address, null);
+        UnityEngine.Object.DestroyImmediate(textureBinding);
     }
 
     /// <summary>

--- a/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs
@@ -2156,11 +2156,25 @@ public static class OptionsMenuPrefabBuilder
     /// <param name="texturePath">The content texture address.</param>
     private static void AttachTextureBinding(RawImage image, string texturePath)
     {
+        string address = ToContentAddress(texturePath);
+        if (image.TryGetComponent(out RawImagePressVisual _))
+        {
+            ContentTextureBinding textureBinding = image.GetComponent<ContentTextureBinding>();
+            if (textureBinding != null)
+                UnityEngine.Object.DestroyImmediate(textureBinding);
+
+            ContentPressVisualBinding pressBinding =
+                image.GetComponent<ContentPressVisualBinding>()
+                ?? image.gameObject.AddComponent<ContentPressVisualBinding>();
+            pressBinding.SetAddresses(address, null);
+            return;
+        }
+
         ContentTextureBinding existing = image.GetComponent<ContentTextureBinding>();
         if (existing != null)
             UnityEngine.Object.DestroyImmediate(existing);
         ContentTextureBinding binding = image.gameObject.AddComponent<ContentTextureBinding>();
-        binding.SetAddress(ToContentAddress(texturePath));
+        binding.SetAddress(address);
     }
 
     /// <summary>

--- a/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
@@ -5523,7 +5523,7 @@ public static class StrategyViewPrefabBuilder
             "ResultSummaryTextField",
             window.transform,
             "Battle summary",
-            new RectInt(25, 225, 350, 70),
+            new RectInt(25, 215, 350, 70),
             18,
             FontStyles.Normal,
             TextAlignmentOptions.TopLeft
@@ -7547,8 +7547,24 @@ public static class StrategyViewPrefabBuilder
     /// <param name="texturePath">The authored content texture asset path.</param>
     private static void AttachTextureBinding(RawImage image, string texturePath)
     {
-        ContentTextureBinding binding = image.gameObject.AddComponent<ContentTextureBinding>();
-        binding.SetAddress(ToContentAddress(texturePath));
+        string address = ToContentAddress(texturePath);
+        if (image.TryGetComponent(out RawImagePressVisual _))
+        {
+            ContentTextureBinding textureBinding = image.GetComponent<ContentTextureBinding>();
+            if (textureBinding != null)
+                UnityEngine.Object.DestroyImmediate(textureBinding);
+
+            ContentPressVisualBinding pressBinding =
+                image.GetComponent<ContentPressVisualBinding>()
+                ?? image.gameObject.AddComponent<ContentPressVisualBinding>();
+            pressBinding.SetAddresses(address, null);
+            return;
+        }
+
+        ContentTextureBinding binding = image.GetComponent<ContentTextureBinding>();
+        if (binding == null)
+            binding = image.gameObject.AddComponent<ContentTextureBinding>();
+        binding.SetAddress(address);
     }
 
     /// <summary>

--- a/Assets/Editor/PrefabBuilders/UIBuilderMenu.cs
+++ b/Assets/Editor/PrefabBuilders/UIBuilderMenu.cs
@@ -240,15 +240,17 @@ public static class UIBuilderMenu
 
         foreach (Scrollbar scrollbar in root.GetComponentsInChildren<Scrollbar>(true))
         {
-            RawImage handle = scrollbar.handleRect?.GetComponent<RawImage>();
-            if (
-                handle != null
-                && IsDevelopmentContentReference(handle.texture)
-                && handle.GetComponent<ContentTextureBinding>() == null
-            )
-                throw new InvalidOperationException(
-                    $"{prefabPath}/{handle.name} has a stripped scrollbar texture without a runtime binding."
-                );
+            foreach (RawImage image in scrollbar.GetComponentsInChildren<RawImage>(true))
+            {
+                if (
+                    IsDevelopmentContentReference(image.texture)
+                    && image.GetComponent<ContentTextureBinding>() == null
+                    && image.GetComponent<ContentPressVisualBinding>() == null
+                )
+                    throw new InvalidOperationException(
+                        $"{prefabPath}/{image.name} has a stripped scrollbar texture without a runtime binding."
+                    );
+            }
         }
     }
 

--- a/Assets/Scripts/App/GameRuntime.cs
+++ b/Assets/Scripts/App/GameRuntime.cs
@@ -67,7 +67,7 @@ public sealed class GameRuntime
     /// <returns>The created GameManager.</returns>
     public GameManager StartGame(GameRoot game)
     {
-        return StartSession(game, reconcileLoadedState: false);
+        return ReplaceSession(game);
     }
 
     /// <summary>
@@ -77,16 +77,17 @@ public sealed class GameRuntime
     /// <returns>The created game manager.</returns>
     public GameManager StartLoadedGame(GameRoot game)
     {
-        return StartSession(game, reconcileLoadedState: true);
+        GameManager gameManager = ReplaceSession(game);
+        gameManager.ReconcileLoadedState();
+        return gameManager;
     }
 
     /// <summary>
-    /// Starts an active game session and optionally reconciles loaded runtime state.
+    /// Replaces the active game session with one backed by the supplied game.
     /// </summary>
     /// <param name="game">The game instance to manage.</param>
-    /// <param name="reconcileLoadedState">Whether the game was restored from persisted state.</param>
     /// <returns>The created game manager.</returns>
-    private GameManager StartSession(GameRoot game, bool reconcileLoadedState)
+    private GameManager ReplaceSession(GameRoot game)
     {
         if (_activeGameSession != null)
         {
@@ -96,8 +97,6 @@ public sealed class GameRuntime
         ValidateGameContent(game);
         _activeGameSession = new GameManager(game, _contentPack.GameData);
         _activeGameSession.TickCompleted += HandleTickCompleted;
-        if (reconcileLoadedState)
-            _activeGameSession.ReconcileLoadedState();
         return _activeGameSession;
     }
 

--- a/Assets/Scripts/App/GameRuntime.cs
+++ b/Assets/Scripts/App/GameRuntime.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using Rebellion.Game;
+using Rebellion.Util.Common;
 using UnityEngine;
 
 /// <summary>
@@ -17,6 +18,11 @@ public sealed class GameRuntime
     /// Gets whether a game session is currently active.
     /// </summary>
     public bool HasActiveGame => _activeGameSession != null;
+
+    /// <summary>
+    /// Gets whether the active simulation is at a stable boundary that can be saved.
+    /// </summary>
+    public bool CanSave => _activeGameSession?.IsTickSettled == true;
 
     /// <summary>
     /// Creates an application runtime backed by the active content pack.
@@ -61,6 +67,27 @@ public sealed class GameRuntime
     /// <returns>The created GameManager.</returns>
     public GameManager StartGame(GameRoot game)
     {
+        return StartSession(game, reconcileLoadedState: false);
+    }
+
+    /// <summary>
+    /// Starts a game session from deserialized state and reconstructs unresolved runtime decisions.
+    /// </summary>
+    /// <param name="game">The loaded game instance to manage.</param>
+    /// <returns>The created game manager.</returns>
+    public GameManager StartLoadedGame(GameRoot game)
+    {
+        return StartSession(game, reconcileLoadedState: true);
+    }
+
+    /// <summary>
+    /// Starts an active game session and optionally reconciles loaded runtime state.
+    /// </summary>
+    /// <param name="game">The game instance to manage.</param>
+    /// <param name="reconcileLoadedState">Whether the game was restored from persisted state.</param>
+    /// <returns>The created game manager.</returns>
+    private GameManager StartSession(GameRoot game, bool reconcileLoadedState)
+    {
         if (_activeGameSession != null)
         {
             EndGame();
@@ -69,6 +96,8 @@ public sealed class GameRuntime
         ValidateGameContent(game);
         _activeGameSession = new GameManager(game, _contentPack.GameData);
         _activeGameSession.TickCompleted += HandleTickCompleted;
+        if (reconcileLoadedState)
+            _activeGameSession.ReconcileLoadedState();
         return _activeGameSession;
     }
 
@@ -88,21 +117,42 @@ public sealed class GameRuntime
 
     /// <summary>
     /// Quick save the current game.
-    /// If no active game, does nothing.
     /// </summary>
-    public void QuickSave()
+    /// <returns>True when the quicksave was written.</returns>
+    public bool QuickSave()
     {
-        if (!HasActiveGame)
-            return;
+        if (!CanSave)
+        {
+            LogUnsettledSaveWarning();
+            return false;
+        }
 
-        GameRoot game = GetActiveGame();
-        if (game == null)
-            return;
-
-        _saveGameManager.SaveQuickGameData(game);
-        Debug.Log(
+        _saveGameManager.SaveQuickGameData(GetActiveGame());
+        GameLogger.Log(
             $"Quick save completed: {_saveGameManager.GetSaveFilePath(SaveGameManager.QuickSaveFileName)}"
         );
+        return true;
+    }
+
+    /// <summary>
+    /// Saves the active game when its simulation state is settled.
+    /// </summary>
+    /// <param name="fileName">The save file name without its extension.</param>
+    /// <param name="displayName">The display name stored with the save.</param>
+    /// <returns>True when the save was written; otherwise false.</returns>
+    public bool SaveGame(string fileName, string displayName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return false;
+
+        if (!CanSave)
+        {
+            LogUnsettledSaveWarning();
+            return false;
+        }
+
+        _saveGameManager.SaveGameData(GetActiveGame(), fileName, displayName);
+        return true;
     }
 
     /// <summary>
@@ -122,7 +172,18 @@ public sealed class GameRuntime
     /// </summary>
     private void HandleTickCompleted()
     {
+        if (!CanSave)
+            return;
+
         _saveGameManager.ProcessAutosaveTick(GetActiveGame(), _getGameplaySettings?.Invoke());
+    }
+
+    /// <summary>
+    /// Logs that a requested save cannot capture an unsettled simulation tick.
+    /// </summary>
+    private static void LogUnsettledSaveWarning()
+    {
+        GameLogger.Warning("Save skipped because the active game is not at a stable boundary.");
     }
 
     /// <summary>
@@ -156,6 +217,7 @@ public sealed class GameRuntime
         GameRoot loadedGame = _saveGameManager.LoadGameData(fileName);
         ValidateGameContent(loadedGame);
         _activeGameSession.ReplaceGame(loadedGame);
+        _activeGameSession.ReconcileLoadedState();
     }
 
     /// <summary>

--- a/Assets/Scripts/Game/Events/GameActions.cs
+++ b/Assets/Scripts/Game/Events/GameActions.cs
@@ -409,6 +409,9 @@ namespace Rebellion.Game.Events
         public string RelatedSubjectInstanceID { get; set; }
 
         [PersistableAttribute]
+        public bool ShowSubjectImage { get; set; }
+
+        [PersistableAttribute]
         public string LocationInstanceID { get; set; }
 
         [PersistableAttribute]
@@ -469,7 +472,9 @@ namespace Rebellion.Game.Events
                     Body = Body ?? string.Empty,
                     BackgroundImageKey = BackgroundImage?.Key,
                     BackgroundImagePath = imagePath,
-                    OverlayImagePath = OverlayImage?.Path ?? (subject as Officer)?.MessageImagePath,
+                    OverlayImagePath =
+                        OverlayImage?.Path
+                        ?? (ShowSubjectImage ? (subject as Officer)?.MessageImagePath : null),
                     BackgroundAudioPath = backgroundAudioPath,
                     OfficerVoicePath = OfficerVoice?.ResolvePath(subject as Officer, provider),
                     AdvisorNotification = this.AdvisorNotification,

--- a/Assets/Scripts/Game/Factions/Faction.cs
+++ b/Assets/Scripts/Game/Factions/Faction.cs
@@ -287,18 +287,24 @@ namespace Rebellion.Game.Factions
         /// Returns a list of units of a specific type owned by the faction.
         /// </summary>
         /// <typeparam name="T">The type of unit to get.</typeparam>
+        /// <param name="includeDisabled">Whether to include disabled units.</param>
         /// <returns>A list of owned units of the specified type.</returns>
-        public List<T> GetOwnedUnitsByType<T>()
+        public List<T> GetOwnedUnitsByType<T>(bool includeDisabled = false)
             where T : ISceneNode
         {
             if (_ownedEntities.TryGetValue(typeof(T), out List<ISceneNode> exactMatches))
-                return exactMatches.Where(node => node.IsActive()).Cast<T>().ToList();
+            {
+                return exactMatches
+                    .Where(node => includeDisabled || node.IsActive())
+                    .Cast<T>()
+                    .ToList();
+            }
 
             return _ownedEntities
                 .Where(entry => typeof(T).IsAssignableFrom(entry.Key))
                 .SelectMany(entry => entry.Value)
                 .Distinct()
-                .Where(node => node.IsActive())
+                .Where(node => includeDisabled || node.IsActive())
                 .Cast<T>()
                 .ToList();
         }

--- a/Assets/Scripts/Generation/OfficerSeeder.cs
+++ b/Assets/Scripts/Generation/OfficerSeeder.cs
@@ -12,12 +12,12 @@ using Rebellion.Util.Extensions;
 namespace Rebellion.Generation
 {
     /// <summary>
-    /// Selects, decorates, and deploys officers during game generation.
+    /// Decorates, selects, and deploys officers during game generation.
     /// </summary>
     public sealed class OfficerSeeder : IGameSeeder
     {
         /// <summary>
-        /// Seeds officers into the generation context: selects, decorates, and places
+        /// Seeds officers into the generation context: decorates, selects, and places
         /// them, then stores the deployed and unrecruited pools on the context.
         /// </summary>
         /// <param name="ctx">The generation context.</param>
@@ -27,6 +27,7 @@ namespace Rebellion.Generation
                 ctx.Config.Officers,
                 ctx.Summary.GalaxySize
             );
+            DecorateOfficers(ctx.Officers, ctx.Rng);
             Officer[] selected = SelectOfficers(
                 ctx.Officers,
                 ctx.Config,
@@ -34,7 +35,6 @@ namespace Rebellion.Generation
                 startingOfficerRules,
                 ctx.Rng
             );
-            DecorateOfficers(selected, ctx.Rng);
             DeployOfficers(selected, ctx.Sectors, startingOfficerRules, ctx.Rng);
 
             ctx.DeployedOfficers = selected;
@@ -251,11 +251,11 @@ namespace Rebellion.Generation
         }
 
         /// <summary>
-        /// Adds a random value in [0, variance) to the officer's existing rating.
+        /// Adds an inclusive variance roll to the officer's existing rating.
         /// </summary>
         /// <param name="officer">The officer whose rating is rolled.</param>
         /// <param name="rating">The rating to add variance to.</param>
-        /// <param name="variance">The exclusive upper bound for the random variance.</param>
+        /// <param name="variance">The signed extent of the random variance.</param>
         /// <param name="rng">Random number provider.</param>
         private void AddRatingVariance(
             Officer officer,
@@ -271,16 +271,14 @@ namespace Rebellion.Generation
         }
 
         /// <summary>
-        /// Returns a non-negative variance roll, returning 0 when <paramref name="variance"/>
-        /// is non-positive to avoid calling <see cref="IRandomNumberProvider.NextInt"/> with
-        /// an empty range.
+        /// Returns a variance roll that includes both zero and the configured extent.
         /// </summary>
-        /// <param name="variance">Exclusive upper bound for the roll.</param>
+        /// <param name="variance">Signed extent of the roll.</param>
         /// <param name="rng">Random number provider.</param>
-        /// <returns>A value in [0, variance), or 0 when variance is non-positive.</returns>
+        /// <returns>A value from zero through a positive extent, or from a negative extent through zero.</returns>
         private int RollVariance(int variance, IRandomNumberProvider rng)
         {
-            return variance <= 0 ? 0 : rng.NextInt(0, variance);
+            return variance >= 0 ? rng.NextInt(0, checked(variance + 1)) : rng.NextInt(variance, 1);
         }
 
         /// <summary>

--- a/Assets/Scripts/Managers/AudioManager.cs
+++ b/Assets/Scripts/Managers/AudioManager.cs
@@ -21,6 +21,9 @@ public sealed class AudioManager : MonoBehaviour
     private AudioSource sfxSource;
 
     [SerializeField]
+    private AudioSource messageSource;
+
+    [SerializeField]
     private AudioSource ambienceSource;
 
     [Range(0f, 1f)]
@@ -63,10 +66,12 @@ public sealed class AudioManager : MonoBehaviour
     private Func<string> _nextTrackPathProvider;
     private Coroutine _playlistCoroutine;
     private Coroutine _musicLoadCoroutine;
+    private Coroutine _messagePlaybackCoroutine;
     private Coroutine _fadeOutCoroutine;
     private ContentAssets _contentAssets;
     private Task<AudioClip> _musicClipLoad;
     private bool _activeTrackLoop;
+    private bool _messageAudioPaused;
 
     /// <summary>
     /// Gets the active global audio manager instance.
@@ -424,6 +429,44 @@ public sealed class AudioManager : MonoBehaviour
     {
         EnsureAudioSources();
         sfxSource.Stop();
+        StopMessageAudio();
+    }
+
+    /// <summary>
+    /// Replaces message-detail audio with an ordered sequence of addressed clips.
+    /// </summary>
+    /// <param name="resourcePaths">The content addresses to play in order.</param>
+    public void PlayMessageAudio(IReadOnlyList<string> resourcePaths)
+    {
+        StopMessageAudio();
+
+        string[] playablePaths =
+            resourcePaths
+                ?.Where(resourcePath => !string.IsNullOrWhiteSpace(resourcePath))
+                .Select(resourcePath => resourcePath.Trim())
+                .ToArray()
+            ?? Array.Empty<string>();
+        if (playablePaths.Length == 0)
+            return;
+
+        _messagePlaybackCoroutine = StartCoroutine(PlayMessageAudioSequence(playablePaths));
+    }
+
+    /// <summary>
+    /// Stops message-detail audio and discards its remaining sequence.
+    /// </summary>
+    public void StopMessageAudio()
+    {
+        if (_messagePlaybackCoroutine != null)
+        {
+            StopCoroutine(_messagePlaybackCoroutine);
+            _messagePlaybackCoroutine = null;
+        }
+
+        EnsureAudioSources();
+        _messageAudioPaused = false;
+        messageSource.Stop();
+        messageSource.clip = null;
     }
 
     /// <summary>
@@ -433,6 +476,8 @@ public sealed class AudioManager : MonoBehaviour
     {
         EnsureAudioSources();
         sfxSource.Pause();
+        _messageAudioPaused = messageSource.isPlaying;
+        messageSource.Pause();
     }
 
     /// <summary>
@@ -442,6 +487,8 @@ public sealed class AudioManager : MonoBehaviour
     {
         EnsureAudioSources();
         sfxSource.UnPause();
+        messageSource.UnPause();
+        _messageAudioPaused = false;
     }
 
     /// <summary>
@@ -570,6 +617,8 @@ public sealed class AudioManager : MonoBehaviour
             musicSource = CreateAudioSource();
         if (sfxSource == null)
             sfxSource = CreateAudioSource();
+        if (messageSource == null)
+            messageSource = CreateAudioSource();
         if (ambienceSource == null)
             ambienceSource = CreateAudioSource();
     }
@@ -595,6 +644,7 @@ public sealed class AudioManager : MonoBehaviour
         musicSource.volume = musicVolume * masterVolume;
         ambienceSource.volume = ambienceVolume * masterVolume;
         sfxSource.volume = sfxVolume * masterVolume;
+        messageSource.volume = sfxVolume * masterVolume;
     }
 
     /// <summary>
@@ -815,6 +865,53 @@ public sealed class AudioManager : MonoBehaviour
             ? $": {load.Exception?.GetBaseException().Message}"
             : ": the loader returned no audio clip";
         GameLogger.Warning($"Failed to load sound effect '{path}'{failureReason}.");
+    }
+
+    /// <summary>
+    /// Loads and plays message-detail clips one at a time in their requested order.
+    /// </summary>
+    /// <param name="paths">The normalized content addresses to play.</param>
+    /// <returns>The playback coroutine.</returns>
+    private IEnumerator PlayMessageAudioSequence(IReadOnlyList<string> paths)
+    {
+        foreach (string path in paths)
+        {
+            AudioClip clip = null;
+            if (
+                !_preloadedSfx.TryGetValue(path, out clip)
+                && !_loadedSfx.TryGetValue(path, out clip)
+            )
+            {
+                Task<AudioClip> load = GetContentAssets().LoadAudioAsync(path);
+                while (!load.IsCompleted)
+                    yield return null;
+
+                if (load.IsCompletedSuccessfully && load.Result != null)
+                {
+                    clip = load.Result;
+                    _loadedSfx[path] = clip;
+                }
+                else if (!load.IsCanceled)
+                {
+                    string failureReason = load.IsFaulted
+                        ? $": {load.Exception?.GetBaseException().Message}"
+                        : ": the loader returned no audio clip";
+                    GameLogger.Warning($"Failed to load message audio '{path}'{failureReason}.");
+                }
+            }
+
+            if (clip == null)
+                continue;
+
+            messageSource.clip = clip;
+            messageSource.loop = false;
+            messageSource.Play();
+            while (messageSource.isPlaying || _messageAudioPaused)
+                yield return null;
+        }
+
+        messageSource.clip = null;
+        _messagePlaybackCoroutine = null;
     }
 
     /// <summary>

--- a/Assets/Scripts/Managers/AudioManager.cs
+++ b/Assets/Scripts/Managers/AudioManager.cs
@@ -21,9 +21,6 @@ public sealed class AudioManager : MonoBehaviour
     private AudioSource sfxSource;
 
     [SerializeField]
-    private AudioSource messageSource;
-
-    [SerializeField]
     private AudioSource ambienceSource;
 
     [Range(0f, 1f)]
@@ -57,6 +54,9 @@ public sealed class AudioManager : MonoBehaviour
         string,
         Task<AudioClip>
     >(StringComparer.Ordinal);
+    private readonly HashSet<AudioPlaybackHandle> _activeSfxPlaybacks =
+        new HashSet<AudioPlaybackHandle>();
+    private readonly Stack<AudioSource> _availableSfxSources = new Stack<AudioSource>();
     private AudioClip[] _clipPlaylist;
     private string[] _activePlaylistPaths;
     private string[] _requestedPlaylistPaths;
@@ -66,12 +66,10 @@ public sealed class AudioManager : MonoBehaviour
     private Func<string> _nextTrackPathProvider;
     private Coroutine _playlistCoroutine;
     private Coroutine _musicLoadCoroutine;
-    private Coroutine _messagePlaybackCoroutine;
     private Coroutine _fadeOutCoroutine;
     private ContentAssets _contentAssets;
     private Task<AudioClip> _musicClipLoad;
     private bool _activeTrackLoop;
-    private bool _messageAudioPaused;
 
     /// <summary>
     /// Gets the active global audio manager instance.
@@ -171,6 +169,7 @@ public sealed class AudioManager : MonoBehaviour
     /// </summary>
     private void OnDestroy()
     {
+        StopTrackedSfx();
         _musicClipLoad = null;
         _sfxLoads.Clear();
         _loadedSfx.Clear();
@@ -423,50 +422,52 @@ public sealed class AudioManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Plays one addressed sound effect through an independently controllable source.
+    /// </summary>
+    /// <param name="resourcePath">The content address for the sound effect clip.</param>
+    /// <returns>The playback handle, or null when the path is blank.</returns>
+    public AudioPlaybackHandle PlaySfxInstance(string resourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(resourcePath))
+            return null;
+
+        string normalizedPath = resourcePath.Trim();
+        if (_preloadedSfx.TryGetValue(normalizedPath, out AudioClip preloadedClip))
+            return PlaySfxInstance(preloadedClip);
+        if (_loadedSfx.TryGetValue(normalizedPath, out AudioClip loadedClip))
+            return PlaySfxInstance(loadedClip);
+
+        AudioPlaybackHandle playback = CreatePlayback();
+        Coroutine loadCoroutine = StartCoroutine(LoadAndPlaySfxInstance(playback, normalizedPath));
+        if (_activeSfxPlaybacks.Contains(playback) && playback.Source == null)
+            playback.LoadCoroutine = loadCoroutine;
+
+        return playback;
+    }
+
+    /// <summary>
+    /// Plays one loaded sound effect through an independently controllable source.
+    /// </summary>
+    /// <param name="clip">The sound effect clip to play.</param>
+    /// <returns>The playback handle, or null when the clip is missing.</returns>
+    public AudioPlaybackHandle PlaySfxInstance(AudioClip clip)
+    {
+        if (clip == null)
+            return null;
+
+        AudioPlaybackHandle playback = CreatePlayback();
+        StartPlayback(playback, clip);
+        return playback;
+    }
+
+    /// <summary>
     /// Stops sound-effect playback immediately.
     /// </summary>
     public void StopSfx()
     {
         EnsureAudioSources();
         sfxSource.Stop();
-        StopMessageAudio();
-    }
-
-    /// <summary>
-    /// Replaces message-detail audio with an ordered sequence of addressed clips.
-    /// </summary>
-    /// <param name="resourcePaths">The content addresses to play in order.</param>
-    public void PlayMessageAudio(IReadOnlyList<string> resourcePaths)
-    {
-        StopMessageAudio();
-
-        string[] playablePaths =
-            resourcePaths
-                ?.Where(resourcePath => !string.IsNullOrWhiteSpace(resourcePath))
-                .Select(resourcePath => resourcePath.Trim())
-                .ToArray()
-            ?? Array.Empty<string>();
-        if (playablePaths.Length == 0)
-            return;
-
-        _messagePlaybackCoroutine = StartCoroutine(PlayMessageAudioSequence(playablePaths));
-    }
-
-    /// <summary>
-    /// Stops message-detail audio and discards its remaining sequence.
-    /// </summary>
-    public void StopMessageAudio()
-    {
-        if (_messagePlaybackCoroutine != null)
-        {
-            StopCoroutine(_messagePlaybackCoroutine);
-            _messagePlaybackCoroutine = null;
-        }
-
-        EnsureAudioSources();
-        _messageAudioPaused = false;
-        messageSource.Stop();
-        messageSource.clip = null;
+        StopTrackedSfx();
     }
 
     /// <summary>
@@ -476,8 +477,14 @@ public sealed class AudioManager : MonoBehaviour
     {
         EnsureAudioSources();
         sfxSource.Pause();
-        _messageAudioPaused = messageSource.isPlaying;
-        messageSource.Pause();
+        foreach (AudioPlaybackHandle playback in _activeSfxPlaybacks)
+        {
+            if (playback.Source?.isPlaying != true)
+                continue;
+
+            playback.Paused = true;
+            playback.Source.Pause();
+        }
     }
 
     /// <summary>
@@ -487,8 +494,37 @@ public sealed class AudioManager : MonoBehaviour
     {
         EnsureAudioSources();
         sfxSource.UnPause();
-        messageSource.UnPause();
-        _messageAudioPaused = false;
+        foreach (AudioPlaybackHandle playback in _activeSfxPlaybacks)
+        {
+            if (!playback.Paused || playback.Source == null)
+                continue;
+
+            playback.Source.UnPause();
+            playback.Paused = false;
+        }
+    }
+
+    /// <summary>
+    /// Stops one independently controlled playback and returns its source for reuse.
+    /// </summary>
+    /// <param name="playback">The playback to stop.</param>
+    internal void StopPlayback(AudioPlaybackHandle playback)
+    {
+        if (playback == null || !_activeSfxPlaybacks.Remove(playback))
+            return;
+
+        if (playback.LoadCoroutine != null)
+            StopCoroutine(playback.LoadCoroutine);
+
+        if (playback.Source != null)
+        {
+            playback.Source.Stop();
+            playback.Source.clip = null;
+            playback.Source.loop = false;
+            _availableSfxSources.Push(playback.Source);
+        }
+
+        playback.Release();
     }
 
     /// <summary>
@@ -617,8 +653,6 @@ public sealed class AudioManager : MonoBehaviour
             musicSource = CreateAudioSource();
         if (sfxSource == null)
             sfxSource = CreateAudioSource();
-        if (messageSource == null)
-            messageSource = CreateAudioSource();
         if (ambienceSource == null)
             ambienceSource = CreateAudioSource();
     }
@@ -644,7 +678,11 @@ public sealed class AudioManager : MonoBehaviour
         musicSource.volume = musicVolume * masterVolume;
         ambienceSource.volume = ambienceVolume * masterVolume;
         sfxSource.volume = sfxVolume * masterVolume;
-        messageSource.volume = sfxVolume * masterVolume;
+        foreach (AudioPlaybackHandle playback in _activeSfxPlaybacks)
+        {
+            if (playback.Source != null)
+                playback.Source.volume = sfxVolume * masterVolume;
+        }
     }
 
     /// <summary>
@@ -868,50 +906,76 @@ public sealed class AudioManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Loads and plays message-detail clips one at a time in their requested order.
+    /// Loads one independently controlled sound effect and starts it if still requested.
     /// </summary>
-    /// <param name="paths">The normalized content addresses to play.</param>
+    /// <param name="playback">The playback awaiting its clip.</param>
+    /// <param name="path">The normalized content address.</param>
     /// <returns>The playback coroutine.</returns>
-    private IEnumerator PlayMessageAudioSequence(IReadOnlyList<string> paths)
+    private IEnumerator LoadAndPlaySfxInstance(AudioPlaybackHandle playback, string path)
     {
-        foreach (string path in paths)
+        Task<AudioClip> load = GetContentAssets().LoadAudioAsync(path);
+        while (!load.IsCompleted)
+            yield return null;
+
+        playback.LoadCoroutine = null;
+        if (!_activeSfxPlaybacks.Contains(playback))
+            yield break;
+
+        if (load.IsCompletedSuccessfully && load.Result != null)
         {
-            AudioClip clip = null;
-            if (
-                !_preloadedSfx.TryGetValue(path, out clip)
-                && !_loadedSfx.TryGetValue(path, out clip)
-            )
-            {
-                Task<AudioClip> load = GetContentAssets().LoadAudioAsync(path);
-                while (!load.IsCompleted)
-                    yield return null;
-
-                if (load.IsCompletedSuccessfully && load.Result != null)
-                {
-                    clip = load.Result;
-                    _loadedSfx[path] = clip;
-                }
-                else if (!load.IsCanceled)
-                {
-                    string failureReason = load.IsFaulted
-                        ? $": {load.Exception?.GetBaseException().Message}"
-                        : ": the loader returned no audio clip";
-                    GameLogger.Warning($"Failed to load message audio '{path}'{failureReason}.");
-                }
-            }
-
-            if (clip == null)
-                continue;
-
-            messageSource.clip = clip;
-            messageSource.loop = false;
-            messageSource.Play();
-            while (messageSource.isPlaying || _messageAudioPaused)
-                yield return null;
+            _loadedSfx[path] = load.Result;
+            StartPlayback(playback, load.Result);
+            yield break;
         }
 
-        messageSource.clip = null;
-        _messagePlaybackCoroutine = null;
+        if (!load.IsCanceled)
+        {
+            string failureReason = load.IsFaulted
+                ? $": {load.Exception?.GetBaseException().Message}"
+                : ": the loader returned no audio clip";
+            GameLogger.Warning($"Failed to load sound effect '{path}'{failureReason}.");
+        }
+
+        StopPlayback(playback);
+    }
+
+    /// <summary>
+    /// Registers a new independently controlled sound-effect playback.
+    /// </summary>
+    /// <returns>The registered playback.</returns>
+    private AudioPlaybackHandle CreatePlayback()
+    {
+        AudioPlaybackHandle playback = new AudioPlaybackHandle(this);
+        _activeSfxPlaybacks.Add(playback);
+        return playback;
+    }
+
+    /// <summary>
+    /// Assigns a loaded clip to one independently controlled playback source.
+    /// </summary>
+    /// <param name="playback">The playback receiving the clip.</param>
+    /// <param name="clip">The loaded clip.</param>
+    private void StartPlayback(AudioPlaybackHandle playback, AudioClip clip)
+    {
+        if (!_activeSfxPlaybacks.Contains(playback) || clip == null)
+            return;
+
+        AudioSource source =
+            _availableSfxSources.Count > 0 ? _availableSfxSources.Pop() : CreateAudioSource();
+        playback.Source = source;
+        source.clip = clip;
+        source.loop = false;
+        source.volume = sfxVolume * masterVolume;
+        source.Play();
+    }
+
+    /// <summary>
+    /// Stops every independently controlled sound effect.
+    /// </summary>
+    private void StopTrackedSfx()
+    {
+        foreach (AudioPlaybackHandle playback in _activeSfxPlaybacks.ToArray())
+            StopPlayback(playback);
     }
 
     /// <summary>

--- a/Assets/Scripts/Managers/AudioPlaybackHandle.cs
+++ b/Assets/Scripts/Managers/AudioPlaybackHandle.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+/// <summary>
+/// Controls one independently stoppable sound-effect playback.
+/// </summary>
+public sealed class AudioPlaybackHandle
+{
+    private AudioManager _owner;
+
+    internal Coroutine LoadCoroutine { get; set; }
+
+    internal bool Paused { get; set; }
+
+    internal AudioSource Source { get; set; }
+
+    /// <summary>
+    /// Creates a playback handle owned by an audio manager.
+    /// </summary>
+    /// <param name="owner">The manager controlling the playback.</param>
+    internal AudioPlaybackHandle(AudioManager owner)
+    {
+        _owner = owner;
+    }
+
+    /// <summary>
+    /// Stops this playback without affecting any other sound.
+    /// </summary>
+    public void Stop()
+    {
+        _owner?.StopPlayback(this);
+    }
+
+    /// <summary>
+    /// Releases this handle after its playback has stopped.
+    /// </summary>
+    internal void Release()
+    {
+        _owner = null;
+        LoadCoroutine = null;
+        Paused = false;
+        Source = null;
+    }
+}

--- a/Assets/Scripts/Managers/AudioPlaybackHandle.cs.meta
+++ b/Assets/Scripts/Managers/AudioPlaybackHandle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: abf3b973e7cc18249b76e60b51f1584d

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -16,6 +16,16 @@ using Rebellion.Util.Extensions;
 /// </summary>
 public sealed class GameManager
 {
+    /// <summary>
+    /// Identifies whether the manager is idle, advancing a tick, or waiting for combat input.
+    /// </summary>
+    private enum TickExecutionState
+    {
+        Idle,
+        Processing,
+        AwaitingCombatDecision,
+    }
+
     // Game State.
     private GameRoot _game;
     private readonly GameDataCatalog _gameData;
@@ -70,10 +80,17 @@ public sealed class GameManager
     private float? _tickInterval;
     private float _tickTimer;
     private bool _tickInProgress;
+    private TickExecutionState _tickState;
 
     // Game Events.
     public event Action GameSpeedChanged;
     public event Action TickCompleted;
+
+    /// <summary>
+    /// Raised when tick processing pauses for a player-controlled space-combat decision.
+    /// </summary>
+    public event Action CombatDecisionRequired;
+
     public event Action<GameRoot> GameReplaced;
     public event Action<HeadquartersLostResult> HeadquartersLost;
     public event Action<VictoryResult> VictoryDeclared;
@@ -113,6 +130,11 @@ public sealed class GameManager
     internal PlanetaryAssaultSystem PlanetaryAssaultSystem => _planetaryAssaultSystem;
 
     /// <summary>
+    /// Gets whether the simulation is between ticks with no unresolved decision.
+    /// </summary>
+    internal bool IsTickSettled => _tickState == TickExecutionState.Idle;
+
+    /// <summary>
     /// Creates a new GameManager for the given game instance.
     /// </summary>
     /// <param name="game">The game instance to manage.</param>
@@ -131,6 +153,14 @@ public sealed class GameManager
     {
         InitializeGame(game);
         GameReplaced?.Invoke(_game);
+    }
+
+    /// <summary>
+    /// Reconstructs unresolved runtime decisions represented by loaded game state.
+    /// </summary>
+    internal void ReconcileLoadedState()
+    {
+        ReconcileLoadedCombatState();
     }
 
     /// <summary>
@@ -226,7 +256,7 @@ public sealed class GameManager
         if (
             elapsedSeconds <= 0f
             || _tickInProgress
-            || _spaceCombatSystem.HasPendingDecision
+            || _tickState != TickExecutionState.Idle
             || _tickInterval == null
         )
             return false;
@@ -263,12 +293,13 @@ public sealed class GameManager
     {
         if (
             _tickInProgress
-            || _spaceCombatSystem.HasPendingDecision
+            || _tickState != TickExecutionState.Idle
             || _game.GetGameSpeed() == TickSpeed.Paused
         )
             yield break;
 
         _tickInProgress = true;
+        _tickState = TickExecutionState.Processing;
         try
         {
             foreach (object step in ProcessTickCore())
@@ -277,6 +308,8 @@ public sealed class GameManager
         finally
         {
             _tickInProgress = false;
+            if (_tickState == TickExecutionState.Processing)
+                _tickState = TickExecutionState.Idle;
         }
     }
 
@@ -315,12 +348,22 @@ public sealed class GameManager
         if (_spaceCombatSystem.HasPendingDecision)
         {
             StoreDeferredMessageResults(movementPhaseResults);
-            TickCompleted?.Invoke();
+            BeginPendingCombatDecision();
             yield break;
         }
 
         ProcessMessageReactions(movementPhaseResults);
 
+        foreach (object step in ProcessRemainingTickPhases())
+            yield return step;
+    }
+
+    /// <summary>
+    /// Processes the phases that run after movement and space combat have settled.
+    /// </summary>
+    /// <returns>A sequence containing one step per completed AI phase.</returns>
+    private IEnumerable<object> ProcessRemainingTickPhases()
+    {
         ProcessResults(_missionSystem.ProcessTick());
         ProcessResults(_eventSystem.ProcessEvents(_game.GetEventPool()));
         _namingSystem.ProcessTick();
@@ -336,6 +379,7 @@ public sealed class GameManager
         ProcessResults(_researchSystem.ProcessTick());
         ProcessResults(_jediSystem.ProcessTick());
         ProcessResults(_victorySystem.ProcessTick());
+        _tickState = TickExecutionState.Idle;
         TickCompleted?.Invoke();
     }
 
@@ -381,6 +425,8 @@ public sealed class GameManager
         _game.RebuildSceneState();
 
         _randomProvider = _game.Random;
+        _deferredMessageResults.Clear();
+        _tickState = TickExecutionState.Idle;
         InitializeSystems();
         RebuildDerivedState();
         _tickTimer = 0f;
@@ -522,17 +568,70 @@ public sealed class GameManager
     /// <returns>The space-combat result in the routed batch, when present.</returns>
     private SpaceCombatResult CompleteCombatResolution(List<GameResult> combatResults)
     {
-        combatResults = ProcessResults(combatResults, processMessages: false);
+        _tickInProgress = true;
+        _tickState = TickExecutionState.Processing;
+        try
+        {
+            combatResults = ProcessResults(combatResults, processMessages: false);
+            SpaceCombatResult completedCombat = combatResults
+                .OfType<SpaceCombatResult>()
+                .FirstOrDefault();
 
-        List<GameResult> waypointResults = ProcessAvailableWaypointContinuations();
+            List<GameResult> waypointResults = ProcessAvailableWaypointContinuations();
+            List<GameResult> additionalCombatResults = ProcessResults(
+                _spaceCombatSystem.ProcessTick(),
+                processMessages: false
+            );
+            _deferredMessageResults.AddRange(combatResults);
+            _deferredMessageResults.AddRange(waypointResults);
+            _deferredMessageResults.AddRange(additionalCombatResults);
 
-        List<GameResult> movementPhaseResults = TakeDeferredMessageResults();
-        movementPhaseResults.AddRange(combatResults);
-        movementPhaseResults.AddRange(waypointResults);
-        _messageSystem.ProcessResults(movementPhaseResults);
-        _tickTimer = 0f;
+            if (_spaceCombatSystem.HasPendingDecision)
+            {
+                BeginPendingCombatDecision();
+                return completedCombat;
+            }
 
-        return combatResults.OfType<SpaceCombatResult>().FirstOrDefault();
+            ProcessMessageReactions(TakeDeferredMessageResults());
+            IEnumerator remainingTick = ProcessRemainingTickPhases().GetEnumerator();
+            try
+            {
+                while (remainingTick.MoveNext()) { }
+            }
+            finally
+            {
+                (remainingTick as IDisposable)?.Dispose();
+            }
+
+            _tickTimer = 0f;
+            return completedCombat;
+        }
+        finally
+        {
+            _tickInProgress = false;
+            if (_tickState == TickExecutionState.Processing)
+                _tickState = TickExecutionState.Idle;
+        }
+    }
+
+    /// <summary>
+    /// Reconstructs unresolved space combat represented by loaded fleet locations without
+    /// advancing the game tick.
+    /// </summary>
+    private void ReconcileLoadedCombatState()
+    {
+        List<GameResult> combatResults = ProcessResults(
+            _spaceCombatSystem.ProcessTick(),
+            processMessages: false
+        );
+        if (_spaceCombatSystem.HasPendingDecision)
+        {
+            StoreDeferredMessageResults(combatResults);
+            BeginPendingCombatDecision();
+            return;
+        }
+
+        ProcessMessageReactions(combatResults);
     }
 
     /// <summary>
@@ -630,6 +729,15 @@ public sealed class GameManager
         _deferredMessageResults.Clear();
         if (results != null)
             _deferredMessageResults.AddRange(results);
+    }
+
+    /// <summary>
+    /// Suspends the active tick and notifies presentation that player combat input is required.
+    /// </summary>
+    private void BeginPendingCombatDecision()
+    {
+        _tickState = TickExecutionState.AwaitingCombatDecision;
+        CombatDecisionRequired?.Invoke();
     }
 
     /// <summary>

--- a/Assets/Scripts/Systems/GameEventSystem.cs
+++ b/Assets/Scripts/Systems/GameEventSystem.cs
@@ -42,7 +42,7 @@ namespace Rebellion.Systems
 
         /// <summary>
         /// Validates the authored trigger, schedule, binding, and dependency contracts for the
-        /// complete event pool before gameplay begins.
+        /// active event pool before gameplay begins.
         /// </summary>
         /// <param name="events">The event definitions installed in the game.</param>
         /// <exception cref="InvalidOperationException">Thrown when an event contract is ambiguous or references an unknown event.</exception>
@@ -158,7 +158,12 @@ namespace Rebellion.Systems
                             ?? Enumerable.Empty<string>();
                 foreach (string dependencyID in dependencies)
                 {
-                    if (!eventIDs.Contains(dependencyID))
+                    bool isCompletedDependency =
+                        _game.EventRuntime.States.TryGetValue(
+                            dependencyID,
+                            out GameEventState dependencyState
+                        ) && dependencyState.IsComplete;
+                    if (!eventIDs.Contains(dependencyID) && !isCompletedDependency)
                         throw new InvalidOperationException(
                             $"Event '{gameEvent.InstanceID}' references unknown event '{dependencyID}'."
                         );

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -574,6 +574,37 @@ namespace Rebellion.Systems
             string ownerInstanceId
         )
         {
+            bool accepted = TryExecutePlayerMove(
+                items,
+                destination,
+                ownerInstanceId,
+                out _,
+                out List<GameResult> results
+            );
+            if (accepted)
+                ResultsProduced?.Invoke(results);
+            return accepted;
+        }
+
+        /// <summary>
+        /// Validates and executes a player-controlled move without publishing its results.
+        /// </summary>
+        /// <param name="items">The selected scene nodes or their snapshots.</param>
+        /// <param name="destination">The requested destination or its snapshot.</param>
+        /// <param name="ownerInstanceId">The faction authorized to move the selection.</param>
+        /// <param name="createdDestinationFleet">Receives a fleet created for capital ships.</param>
+        /// <param name="results">Receives the movement results produced by the accepted order.</param>
+        /// <returns>True when the complete movement order was accepted.</returns>
+        private bool TryExecutePlayerMove(
+            IReadOnlyList<ISceneNode> items,
+            ContainerNode destination,
+            string ownerInstanceId,
+            out Fleet createdDestinationFleet,
+            out List<GameResult> results
+        )
+        {
+            createdDestinationFleet = null;
+            results = new List<GameResult>();
             ContainerNode liveDestination = ResolveRegisteredContainer(destination);
             if (
                 liveDestination == null
@@ -585,7 +616,6 @@ namespace Rebellion.Systems
             )
                 return false;
 
-            Fleet createdDestinationFleet = null;
             if (liveDestination is Planet planet && liveItems.Any(item => item is CapitalShip))
             {
                 createdDestinationFleet = _fleetSystem.CreateAtPlanet(planet, ownerInstanceId);
@@ -609,7 +639,6 @@ namespace Rebellion.Systems
                 return false;
             }
 
-            List<GameResult> results = new List<GameResult>();
             bool accepted = TryExecuteNormalMoveGroup(movables, liveDestination, results);
             if (accepted)
             {
@@ -618,17 +647,14 @@ namespace Rebellion.Systems
             }
 
             _fleetSystem.RemoveIfEmpty(createdDestinationFleet, "transfer");
-            if (accepted)
-                ResultsProduced?.Invoke(results);
-
             return accepted;
         }
 
         /// <summary>
-        /// Determines whether a player-controlled fleet selection can accept one complete waypoint
-        /// route without changing game state.
+        /// Determines whether a player-controlled fleet or capital-ship selection can accept one
+        /// complete waypoint route without changing game state.
         /// </summary>
-        /// <param name="items">The selected fleets or their visible snapshots.</param>
+        /// <param name="items">The selected fleets, capital ships, or their visible snapshots.</param>
         /// <param name="waypointPlanetIds">The ordered destination planet identifiers.</param>
         /// <param name="ownerInstanceId">The faction authorized to command the fleets.</param>
         /// <returns>True when the complete route is valid.</returns>
@@ -639,18 +665,25 @@ namespace Rebellion.Systems
         )
         {
             return TryPlanFleetWaypointRoute(
-                items,
-                waypointPlanetIds,
-                ownerInstanceId,
-                out _,
-                out _
-            );
+                    items,
+                    waypointPlanetIds,
+                    ownerInstanceId,
+                    out _,
+                    out _
+                )
+                || TryPlanCapitalShipWaypointRoute(
+                    items,
+                    waypointPlanetIds,
+                    ownerInstanceId,
+                    out _,
+                    out _
+                );
         }
 
         /// <summary>
-        /// Commits one complete waypoint route and starts its first leg for stationary fleets.
+        /// Commits one complete waypoint route and starts its first leg.
         /// </summary>
-        /// <param name="items">The selected fleets or their visible snapshots.</param>
+        /// <param name="items">The selected fleets, capital ships, or their visible snapshots.</param>
         /// <param name="waypointPlanetIds">The ordered destination planet identifiers.</param>
         /// <param name="ownerInstanceId">The faction authorized to command the fleets.</param>
         /// <returns>True when the route was committed to every selected fleet.</returns>
@@ -660,6 +693,32 @@ namespace Rebellion.Systems
             string ownerInstanceId
         )
         {
+            if (
+                TryPlanCapitalShipWaypointRoute(
+                    items,
+                    waypointPlanetIds,
+                    ownerInstanceId,
+                    out List<CapitalShip> capitalShips,
+                    out List<Planet> capitalShipDestinations
+                )
+            )
+            {
+                bool capitalShipMoveAccepted = TryExecutePlayerMove(
+                    capitalShips.Cast<ISceneNode>().ToList(),
+                    capitalShipDestinations[0],
+                    ownerInstanceId,
+                    out Fleet routeFleet,
+                    out List<GameResult> capitalShipResults
+                );
+                if (!capitalShipMoveAccepted)
+                    return false;
+
+                if (routeFleet?.GetParent() != null)
+                    routeFleet.Waypoints.AddRange(waypointPlanetIds);
+                ResultsProduced?.Invoke(capitalShipResults);
+                return true;
+            }
+
             if (
                 !TryPlanFleetWaypointRoute(
                     items,
@@ -736,6 +795,9 @@ namespace Rebellion.Systems
             foreach (Fleet fleet in fleets)
             {
                 if (fleet == null)
+                    continue;
+
+                if (AwaitsCapitalShipWaypointAssembly(fleet))
                     continue;
 
                 if (!fleet.HasOperationalCapitalShips())
@@ -1280,9 +1342,8 @@ namespace Rebellion.Systems
             fleets = new List<Fleet>();
             destinations = new List<Planet>();
             if (
-                waypointPlanetIds == null
-                || waypointPlanetIds.Count == 0
-                || !TryResolveControlledFleets(items, ownerInstanceId, out fleets)
+                !TryResolveControlledFleets(items, ownerInstanceId, out fleets)
+                || !TryResolveWaypointDestinations(waypointPlanetIds, out destinations)
             )
                 return false;
 
@@ -1296,6 +1357,88 @@ namespace Rebellion.Systems
                     || fleet.GetParentOfType<Planet>() == null
                 )
             )
+                return false;
+
+            Planet firstDestination = destinations[0];
+            if (
+                fleetsAreMoving
+                && fleets.Any(fleet =>
+                    ReferenceEquals(fleet.GetParentOfType<Planet>(), firstDestination)
+                )
+            )
+                return false;
+            if (
+                !fleetsAreMoving
+                && fleets.All(fleet =>
+                    ReferenceEquals(fleet.GetParentOfType<Planet>(), firstDestination)
+                )
+            )
+                return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Validates and resolves a capital-ship waypoint route without changing fleet membership.
+        /// </summary>
+        /// <param name="items">The selected capital ships or their snapshots.</param>
+        /// <param name="waypointPlanetIds">The ordered destination planet identifiers.</param>
+        /// <param name="ownerInstanceId">The faction authorized to command the ships.</param>
+        /// <param name="capitalShips">Receives the registered controlled capital ships.</param>
+        /// <param name="destinations">Receives the registered destination planets.</param>
+        /// <returns>True when the complete plan is valid.</returns>
+        private bool TryPlanCapitalShipWaypointRoute(
+            IReadOnlyList<ISceneNode> items,
+            IReadOnlyList<string> waypointPlanetIds,
+            string ownerInstanceId,
+            out List<CapitalShip> capitalShips,
+            out List<Planet> destinations
+        )
+        {
+            capitalShips = new List<CapitalShip>();
+            destinations = new List<Planet>();
+            if (
+                !TryResolveControlledSelection(
+                    items,
+                    ownerInstanceId,
+                    out List<ISceneNode> liveItems
+                )
+                || liveItems.Any(item => item is not CapitalShip)
+                || !TryResolveWaypointDestinations(waypointPlanetIds, out destinations)
+            )
+                return false;
+
+            capitalShips = liveItems.Cast<CapitalShip>().ToList();
+            Planet origin = capitalShips[0].GetParentOfType<Planet>();
+            if (
+                origin == null
+                || capitalShips.Any(ship =>
+                    !ReferenceEquals(ship.GetParentOfType<Planet>(), origin)
+                )
+                || ReferenceEquals(origin, destinations[0])
+            )
+                return false;
+
+            return TryGetTransitTicks(
+                capitalShips.Cast<IMovable>().ToList(),
+                destinations[0],
+                out _
+            );
+        }
+
+        /// <summary>
+        /// Resolves an ordered waypoint identifier list into live, valid destination planets.
+        /// </summary>
+        /// <param name="waypointPlanetIds">The ordered destination planet identifiers.</param>
+        /// <param name="destinations">Receives the registered destination planets.</param>
+        /// <returns>True when every destination is valid and consecutive stops are distinct.</returns>
+        private bool TryResolveWaypointDestinations(
+            IReadOnlyList<string> waypointPlanetIds,
+            out List<Planet> destinations
+        )
+        {
+            destinations = new List<Planet>();
+            if (waypointPlanetIds == null || waypointPlanetIds.Count == 0)
                 return false;
 
             string previousDestinationId = null;
@@ -1315,22 +1458,6 @@ namespace Rebellion.Systems
                 destinations.Add(destination);
                 previousDestinationId = destination.InstanceID;
             }
-
-            Planet firstDestination = destinations[0];
-            if (
-                fleetsAreMoving
-                && fleets.Any(fleet =>
-                    ReferenceEquals(fleet.GetParentOfType<Planet>(), firstDestination)
-                )
-            )
-                return false;
-            if (
-                !fleetsAreMoving
-                && fleets.All(fleet =>
-                    ReferenceEquals(fleet.GetParentOfType<Planet>(), firstDestination)
-                )
-            )
-                return false;
 
             return true;
         }
@@ -1854,12 +1981,28 @@ namespace Rebellion.Systems
             {
                 string waypointId = fleet.Waypoints[0];
                 Planet destination = _game.GetSceneNodeByInstanceID<Planet>(waypointId);
-                if (
-                    destination?.IsDestroyed != false
-                    || ReferenceEquals(fleet.GetParentOfType<Planet>(), destination)
-                )
+                if (destination?.IsDestroyed != false)
                 {
                     fleet.Waypoints.RemoveAt(0);
+                    continue;
+                }
+
+                if (ReferenceEquals(fleet.GetParentOfType<Planet>(), destination))
+                {
+                    fleet.Waypoints.RemoveAt(0);
+                    if (!fleet.HasWaypoints())
+                    {
+                        results.Add(
+                            new FleetWaypointsCompletedResult
+                            {
+                                Fleet = fleet,
+                                Destination = destination,
+                                Tick = _game.CurrentTick,
+                            }
+                        );
+                        return true;
+                    }
+
                     continue;
                 }
 
@@ -1874,6 +2017,36 @@ namespace Rebellion.Systems
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Returns whether a capital-ship waypoint selection is still reaching or completing at
+        /// its first destination before the resulting fleet may continue.
+        /// </summary>
+        /// <param name="fleet">The fleet that owns the committed route.</param>
+        /// <returns>True when at least one selected ship has not completed the first leg.</returns>
+        private static bool AwaitsCapitalShipWaypointAssembly(Fleet fleet)
+        {
+            if (fleet?.HasWaypoints() != true)
+                return false;
+
+            Planet currentPlanet = fleet.GetParentOfType<Planet>();
+            if (
+                currentPlanet == null
+                || !string.Equals(
+                    fleet.Waypoints[0],
+                    currentPlanet.InstanceID,
+                    StringComparison.Ordinal
+                )
+            )
+                return false;
+
+            return fleet
+                .GetChildren<CapitalShip>()
+                .Any(ship =>
+                    ship.ManufacturingStatus == ManufacturingStatus.Building
+                    || ship.Movement != null
+                );
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -168,7 +168,7 @@ namespace Rebellion.Systems
             )
             {
                 if (
-                    TryExecuteNormalMoveGroup(
+                    TryExecuteMoveGroupClearingWaypoints(
                         units.ToList(),
                         destination,
                         reactions,
@@ -354,7 +354,12 @@ namespace Rebellion.Systems
             if (destination == null)
                 throw new ArgumentNullException(nameof(destination));
 
-            TryExecuteNormalMoveGroup(units, destination, _pendingResults, sourceEventInstanceID);
+            TryExecuteMoveGroupClearingWaypoints(
+                units,
+                destination,
+                _pendingResults,
+                sourceEventInstanceID
+            );
         }
 
         /// <summary>
@@ -562,7 +567,7 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Validates and executes a player-controlled movement selection.
+        /// Validates and executes an owner-controlled movement selection.
         /// </summary>
         /// <param name="items">The selected scene nodes or their snapshots.</param>
         /// <param name="destination">The requested destination or its snapshot.</param>
@@ -574,7 +579,7 @@ namespace Rebellion.Systems
             string ownerInstanceId
         )
         {
-            bool accepted = TryExecutePlayerMove(
+            bool accepted = TryExecuteSelectionMove(
                 items,
                 destination,
                 ownerInstanceId,
@@ -587,7 +592,7 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Validates and executes a player-controlled move without publishing its results.
+        /// Validates and executes an owner-controlled selection without publishing its results.
         /// </summary>
         /// <param name="items">The selected scene nodes or their snapshots.</param>
         /// <param name="destination">The requested destination or its snapshot.</param>
@@ -595,7 +600,7 @@ namespace Rebellion.Systems
         /// <param name="createdDestinationFleet">Receives a fleet created for capital ships.</param>
         /// <param name="results">Receives the movement results produced by the accepted order.</param>
         /// <returns>True when the complete movement order was accepted.</returns>
-        private bool TryExecutePlayerMove(
+        private bool TryExecuteSelectionMove(
             IReadOnlyList<ISceneNode> items,
             ContainerNode destination,
             string ownerInstanceId,
@@ -626,7 +631,7 @@ namespace Rebellion.Systems
             }
 
             if (
-                !TryBuildMoveGroup(
+                !TryResolveSelectionMoveGroup(
                     liveItems,
                     liveDestination,
                     ownerInstanceId,
@@ -639,7 +644,11 @@ namespace Rebellion.Systems
                 return false;
             }
 
-            bool accepted = TryExecuteNormalMoveGroup(movables, liveDestination, results);
+            bool accepted = TryExecuteMoveGroupClearingWaypoints(
+                movables,
+                liveDestination,
+                results
+            );
             if (accepted)
             {
                 foreach (Fleet sourceFleet in sourceFleets.Distinct())
@@ -651,7 +660,7 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Determines whether a player-controlled fleet or capital-ship selection can accept one
+        /// Determines whether an owner-controlled fleet or capital-ship selection can accept one
         /// complete waypoint route without changing game state.
         /// </summary>
         /// <param name="items">The selected fleets, capital ships, or their visible snapshots.</param>
@@ -664,14 +673,14 @@ namespace Rebellion.Systems
             string ownerInstanceId
         )
         {
-            return TryPlanFleetWaypointRoute(
+            return TryResolveFleetWaypointRoute(
                     items,
                     waypointPlanetIds,
                     ownerInstanceId,
                     out _,
                     out _
                 )
-                || TryPlanCapitalShipWaypointRoute(
+                || TryResolveCapitalShipWaypointRoute(
                     items,
                     waypointPlanetIds,
                     ownerInstanceId,
@@ -694,7 +703,7 @@ namespace Rebellion.Systems
         )
         {
             if (
-                TryPlanCapitalShipWaypointRoute(
+                TryResolveCapitalShipWaypointRoute(
                     items,
                     waypointPlanetIds,
                     ownerInstanceId,
@@ -703,14 +712,14 @@ namespace Rebellion.Systems
                 )
             )
             {
-                bool capitalShipMoveAccepted = TryExecutePlayerMove(
+                bool moveAccepted = TryExecuteSelectionMove(
                     capitalShips.Cast<ISceneNode>().ToList(),
                     capitalShipDestinations[0],
                     ownerInstanceId,
                     out Fleet routeFleet,
                     out List<GameResult> capitalShipResults
                 );
-                if (!capitalShipMoveAccepted)
+                if (!moveAccepted)
                     return false;
 
                 if (routeFleet?.GetParent() != null)
@@ -720,7 +729,7 @@ namespace Rebellion.Systems
             }
 
             if (
-                !TryPlanFleetWaypointRoute(
+                !TryResolveFleetWaypointRoute(
                     items,
                     waypointPlanetIds,
                     ownerInstanceId,
@@ -730,7 +739,7 @@ namespace Rebellion.Systems
             )
                 return false;
 
-            bool startsRoute = fleets[0].Movement == null;
+            bool startsFirstLeg = fleets[0].Movement == null;
             foreach (Fleet fleet in fleets)
             {
                 if (fleet.Movement != null)
@@ -739,7 +748,7 @@ namespace Rebellion.Systems
                 fleet.Waypoints.AddRange(waypointPlanetIds);
             }
 
-            if (!startsRoute)
+            if (!startsFirstLeg)
                 return true;
 
             List<GameResult> results = new List<GameResult>();
@@ -797,7 +806,7 @@ namespace Rebellion.Systems
                 if (fleet == null)
                     continue;
 
-                if (AwaitsCapitalShipWaypointAssembly(fleet))
+                if (HasPendingCapitalShipsAtCurrentWaypoint(fleet))
                     continue;
 
                 if (!fleet.HasOperationalCapitalShips())
@@ -809,14 +818,14 @@ namespace Rebellion.Systems
                 if (fleet.Movement != null || fleet.IsInCombat || !fleet.HasWaypoints())
                     continue;
 
-                TryStartNextFleetWaypoint(fleet, results);
+                AdvanceFleetWaypointRoute(fleet, results);
             }
 
             return results;
         }
 
         /// <summary>
-        /// Estimates transit time for a player-controlled selection without mutating it.
+        /// Estimates transit time for an owner-controlled selection without mutating it.
         /// </summary>
         /// <param name="items">The selected scene nodes or their snapshots.</param>
         /// <param name="destination">The requested destination or its snapshot.</param>
@@ -839,7 +848,7 @@ namespace Rebellion.Systems
                     ownerInstanceId,
                     out List<ISceneNode> liveItems
                 )
-                || !TryBuildMoveGroup(
+                || !TryResolveSelectionMoveGroup(
                     liveItems,
                     liveDestination,
                     ownerInstanceId,
@@ -996,24 +1005,24 @@ namespace Rebellion.Systems
         /// <returns>True if the whole group can move.</returns>
         private bool CanMoveGroup(List<IMovable> units, ContainerNode destination)
         {
-            return TryPlanMoveGroup(units, destination, out _);
+            return TryResolveMoveGroupDestinations(units, destination, out _);
         }
 
         /// <summary>
         /// Resolves destinations for a movement group without mutating scene state.
         /// </summary>
-        /// <param name="units">The units being planned together.</param>
+        /// <param name="units">The units being validated together.</param>
         /// <param name="destination">The shared requested destination.</param>
         /// <param name="resolvedDestinations">The accepted destination for each unit in order.</param>
         /// <returns>True when every unit has an accepted destination.</returns>
-        private bool TryPlanMoveGroup(
+        private bool TryResolveMoveGroupDestinations(
             List<IMovable> units,
             ContainerNode destination,
             out List<ContainerNode> resolvedDestinations
         )
         {
             resolvedDestinations = new List<ContainerNode>();
-            Dictionary<ContainerNode, List<ISceneNode>> plannedChildren =
+            Dictionary<ContainerNode, List<ISceneNode>> reservedChildren =
                 new Dictionary<ContainerNode, List<ISceneNode>>();
             Planet groupOrigin = null;
             foreach (IMovable unit in units)
@@ -1050,21 +1059,21 @@ namespace Rebellion.Systems
                     !TryResolveAcceptedDestination(
                         unit,
                         destination,
-                        plannedChildren,
+                        reservedChildren,
                         out ContainerNode resolvedDestination
                     )
                 )
                     return false;
 
                 if (
-                    !plannedChildren.TryGetValue(
+                    !reservedChildren.TryGetValue(
                         resolvedDestination,
                         out List<ISceneNode> destinationChildren
                     )
                 )
                 {
                     destinationChildren = new List<ISceneNode>();
-                    plannedChildren.Add(resolvedDestination, destinationChildren);
+                    reservedChildren.Add(resolvedDestination, destinationChildren);
                 }
 
                 destinationChildren.Add(unit);
@@ -1086,14 +1095,14 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Submits a normal movement group and replaces any existing fleet waypoint routes.
+        /// Executes a movement group and clears any existing fleet waypoint routes.
         /// </summary>
         /// <param name="units">The movable units in execution order.</param>
         /// <param name="destination">The shared destination.</param>
         /// <param name="results">The collection receiving movement results.</param>
         /// <param name="sourceEventInstanceID">The event that requested the movement, if any.</param>
         /// <returns>True when the movement group was accepted.</returns>
-        private bool TryExecuteNormalMoveGroup(
+        private bool TryExecuteMoveGroupClearingWaypoints(
             List<IMovable> units,
             ContainerNode destination,
             ICollection<GameResult> results,
@@ -1128,7 +1137,13 @@ namespace Rebellion.Systems
                 return false;
 
             destination = ResolveLiveContainer(destination);
-            if (!TryPlanMoveGroup(units, destination, out List<ContainerNode> destinations))
+            if (
+                !TryResolveMoveGroupDestinations(
+                    units,
+                    destination,
+                    out List<ContainerNode> destinations
+                )
+            )
                 return false;
 
             string movementGroupID = Guid.NewGuid().ToString("N");
@@ -1185,7 +1200,11 @@ namespace Rebellion.Systems
             }
 
             if (
-                !TryPlanPlacementGroup(liveUnits, destination, out List<ContainerNode> destinations)
+                !TryResolvePlacementGroupDestinations(
+                    liveUnits,
+                    destination,
+                    out List<ContainerNode> destinations
+                )
             )
                 return false;
 
@@ -1210,14 +1229,18 @@ namespace Rebellion.Systems
         /// <summary>
         /// Resolves a valid destination for every unit without mutating scene state.
         /// </summary>
-        private bool TryPlanPlacementGroup(
+        /// <param name="units">The units being placed together.</param>
+        /// <param name="destination">The shared requested destination.</param>
+        /// <param name="resolvedDestinations">The accepted destination for each unit in order.</param>
+        /// <returns>True when every unit has an accepted destination.</returns>
+        private bool TryResolvePlacementGroupDestinations(
             IReadOnlyList<IMovable> units,
             ContainerNode destination,
             out List<ContainerNode> resolvedDestinations
         )
         {
             resolvedDestinations = new List<ContainerNode>();
-            Dictionary<ContainerNode, List<ISceneNode>> plannedChildren =
+            Dictionary<ContainerNode, List<ISceneNode>> reservedChildren =
                 new Dictionary<ContainerNode, List<ISceneNode>>();
             foreach (IMovable unit in units)
             {
@@ -1226,18 +1249,21 @@ namespace Rebellion.Systems
                     || !TryResolveAcceptedDestination(
                         unit,
                         destination,
-                        plannedChildren,
+                        reservedChildren,
                         out ContainerNode resolvedDestination
                     )
                 )
                     return false;
 
                 if (
-                    !plannedChildren.TryGetValue(resolvedDestination, out List<ISceneNode> children)
+                    !reservedChildren.TryGetValue(
+                        resolvedDestination,
+                        out List<ISceneNode> children
+                    )
                 )
                 {
                     children = new List<ISceneNode>();
-                    plannedChildren.Add(resolvedDestination, children);
+                    reservedChildren.Add(resolvedDestination, children);
                 }
                 children.Add(unit);
                 resolvedDestinations.Add(resolvedDestination);
@@ -1246,7 +1272,7 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Resolves and validates a player-controlled selection before movement planning.
+        /// Resolves and validates an owner-controlled selection before movement execution.
         /// </summary>
         /// <param name="items">The selected scene nodes or their snapshots.</param>
         /// <param name="ownerInstanceId">The faction authorized to move the selection.</param>
@@ -1330,8 +1356,8 @@ namespace Rebellion.Systems
         /// <param name="ownerInstanceId">The faction authorized to command the fleets.</param>
         /// <param name="fleets">Receives the registered controlled fleets.</param>
         /// <param name="destinations">Receives the registered destination planets.</param>
-        /// <returns>True when the complete plan is valid.</returns>
-        private bool TryPlanFleetWaypointRoute(
+        /// <returns>True when the complete route is valid.</returns>
+        private bool TryResolveFleetWaypointRoute(
             IReadOnlyList<ISceneNode> items,
             IReadOnlyList<string> waypointPlanetIds,
             string ownerInstanceId,
@@ -1386,8 +1412,8 @@ namespace Rebellion.Systems
         /// <param name="ownerInstanceId">The faction authorized to command the ships.</param>
         /// <param name="capitalShips">Receives the registered controlled capital ships.</param>
         /// <param name="destinations">Receives the registered destination planets.</param>
-        /// <returns>True when the complete plan is valid.</returns>
-        private bool TryPlanCapitalShipWaypointRoute(
+        /// <returns>True when the complete route is valid.</returns>
+        private bool TryResolveCapitalShipWaypointRoute(
             IReadOnlyList<ISceneNode> items,
             IReadOnlyList<string> waypointPlanetIds,
             string ownerInstanceId,
@@ -1471,7 +1497,7 @@ namespace Rebellion.Systems
         /// <param name="movables">Receives the concrete units to move.</param>
         /// <param name="sourceFleets">Receives fleets that may become empty.</param>
         /// <returns>True when at least one unique movable was produced.</returns>
-        private static bool TryBuildMoveGroup(
+        private static bool TryResolveSelectionMoveGroup(
             IReadOnlyList<ISceneNode> items,
             ContainerNode destination,
             string ownerInstanceId,
@@ -1969,12 +1995,11 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Starts the first valid queued waypoint for one stationary fleet.
+        /// Advances one stationary fleet to its next valid waypoint.
         /// </summary>
         /// <param name="fleet">The fleet whose route should continue.</param>
-        /// <param name="results">The result collection receiving the new movement leg.</param>
-        /// <returns>True when a new movement leg began.</returns>
-        private bool TryStartNextFleetWaypoint(Fleet fleet, List<GameResult> results)
+        /// <param name="results">The result collection receiving route advancement results.</param>
+        private void AdvanceFleetWaypointRoute(Fleet fleet, List<GameResult> results)
         {
             int waypointCount = fleet.Waypoints.Count;
             for (int index = 0; index < waypointCount; index++)
@@ -2000,7 +2025,7 @@ namespace Rebellion.Systems
                                 Tick = _game.CurrentTick,
                             }
                         );
-                        return true;
+                        return;
                     }
 
                     continue;
@@ -2013,19 +2038,17 @@ namespace Rebellion.Systems
                 );
                 if (!accepted)
                     fleet.Waypoints.Clear();
-                return accepted;
+                return;
             }
-
-            return false;
         }
 
         /// <summary>
-        /// Returns whether a capital-ship waypoint selection is still reaching or completing at
-        /// its first destination before the resulting fleet may continue.
+        /// Returns whether a fleet has capital ships still reaching or completing at its current
+        /// waypoint before the fleet may continue.
         /// </summary>
         /// <param name="fleet">The fleet that owns the committed route.</param>
-        /// <returns>True when at least one selected ship has not completed the first leg.</returns>
-        private static bool AwaitsCapitalShipWaypointAssembly(Fleet fleet)
+        /// <returns>True when at least one capital ship is still moving or under construction.</returns>
+        private static bool HasPendingCapitalShipsAtCurrentWaypoint(Fleet fleet)
         {
             if (fleet?.HasWaypoints() != true)
                 return false;
@@ -2681,16 +2704,16 @@ namespace Rebellion.Systems
         /// </summary>
         /// <param name="unit">The unit being moved.</param>
         /// <param name="destination">The requested destination.</param>
-        /// <param name="plannedChildren">The children already reserved during group planning.</param>
+        /// <param name="reservedChildren">The children already reserved by the movement group.</param>
         /// <returns>The node that should receive the unit, or null if none is available.</returns>
         private ContainerNode ResolveMoveDestination(
             IMovable unit,
             ContainerNode destination,
-            IReadOnlyDictionary<ContainerNode, List<ISceneNode>> plannedChildren
+            IReadOnlyDictionary<ContainerNode, List<ISceneNode>> reservedChildren
         )
         {
             if (destination is Fleet targetFleet && !(unit is Fleet) && !(unit is CapitalShip))
-                return ResolveFleetTarget(unit, targetFleet, plannedChildren);
+                return ResolveFleetTarget(unit, targetFleet, reservedChildren);
 
             return destination;
         }
@@ -2741,21 +2764,21 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Resolves a destination against children already reserved by the current group plan.
+        /// Resolves a destination against children already reserved by the movement group.
         /// </summary>
         /// <param name="unit">The unit being moved.</param>
         /// <param name="destination">The requested destination.</param>
-        /// <param name="plannedChildren">The children already reserved by the group plan.</param>
+        /// <param name="reservedChildren">The children already reserved by the movement group.</param>
         /// <param name="resolvedDestination">The resolved destination when accepted.</param>
         /// <returns>True when the destination can receive the unit.</returns>
         private bool TryResolveAcceptedDestination(
             IMovable unit,
             ContainerNode destination,
-            IReadOnlyDictionary<ContainerNode, List<ISceneNode>> plannedChildren,
+            IReadOnlyDictionary<ContainerNode, List<ISceneNode>> reservedChildren,
             out ContainerNode resolvedDestination
         )
         {
-            resolvedDestination = ResolveMoveDestination(unit, destination, plannedChildren);
+            resolvedDestination = ResolveMoveDestination(unit, destination, reservedChildren);
             if (resolvedDestination == null)
             {
                 GameLogger.Warning(
@@ -2781,7 +2804,7 @@ namespace Rebellion.Systems
                 return false;
             }
 
-            if (CanAcceptPlannedChild(resolvedDestination, unit, plannedChildren))
+            if (CanAcceptReservedChild(resolvedDestination, unit, reservedChildren))
                 return true;
 
             GameLogger.Warning(
@@ -2893,12 +2916,12 @@ namespace Rebellion.Systems
         /// </summary>
         /// <param name="unit">The non-fleet unit being assigned.</param>
         /// <param name="fleet">The fleet to find a suitable ship within.</param>
-        /// <param name="plannedChildren">The children already reserved during group planning.</param>
+        /// <param name="reservedChildren">The children already reserved by the movement group.</param>
         /// <returns>The target ship, or null if no valid ship exists.</returns>
         private ContainerNode ResolveFleetTarget(
             IMovable unit,
             Fleet fleet,
-            IReadOnlyDictionary<ContainerNode, List<ISceneNode>> plannedChildren
+            IReadOnlyDictionary<ContainerNode, List<ISceneNode>> reservedChildren
         )
         {
             if (unit is Starfighter)
@@ -2911,7 +2934,7 @@ namespace Rebellion.Systems
                     .FirstOrDefault(ship =>
                         ship.ManufacturingStatus == ManufacturingStatus.Complete
                         && ship.Movement == null
-                        && CanAcceptPlannedChild(ship, unit, plannedChildren)
+                        && CanAcceptReservedChild(ship, unit, reservedChildren)
                     );
             }
 
@@ -2925,7 +2948,7 @@ namespace Rebellion.Systems
                     .FirstOrDefault(ship =>
                         ship.ManufacturingStatus == ManufacturingStatus.Complete
                         && ship.Movement == null
-                        && CanAcceptPlannedChild(ship, unit, plannedChildren)
+                        && CanAcceptReservedChild(ship, unit, reservedChildren)
                     );
             }
 
@@ -2942,17 +2965,17 @@ namespace Rebellion.Systems
         /// </summary>
         /// <param name="destination">The destination being evaluated.</param>
         /// <param name="child">The child proposed for the destination.</param>
-        /// <param name="plannedChildren">The children already reserved by the group plan.</param>
+        /// <param name="reservedChildren">The children already reserved by the movement group.</param>
         /// <returns>True when the destination has capacity for the proposed child.</returns>
-        private static bool CanAcceptPlannedChild(
+        private static bool CanAcceptReservedChild(
             ContainerNode destination,
             ISceneNode child,
-            IReadOnlyDictionary<ContainerNode, List<ISceneNode>> plannedChildren
+            IReadOnlyDictionary<ContainerNode, List<ISceneNode>> reservedChildren
         )
         {
             IReadOnlyCollection<ISceneNode> destinationChildren =
-                plannedChildren != null
-                && plannedChildren.TryGetValue(
+                reservedChildren != null
+                && reservedChildren.TryGetValue(
                     destination,
                     out List<ISceneNode> existingDestinationChildren
                 )

--- a/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
@@ -284,6 +284,7 @@ public sealed class MainMenuController : MonoBehaviour
             () => view.GetOptionsWindowPosition(_optionsMenuPrefab),
             windowManager.DestroyWindow,
             bootstrap,
+            bootstrap.GetRuntime().SaveGame,
             RequestSavedGameLaunch,
             MarkOptionsDirty,
             SaveGameManager.Instance

--- a/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsMenuController.cs
+++ b/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsMenuController.cs
@@ -15,6 +15,7 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
     private readonly Action<UIWindow> _closeWindow;
     private readonly Action _markDirty;
     private readonly AppBootstrap _bootstrap;
+    private readonly Func<string, string, bool> _saveGame;
     private readonly Func<string, bool> _loadSave;
     private readonly SaveGameManager _saveGameManager;
     private readonly IContentAssetSource _contentAssets;
@@ -50,6 +51,7 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
     /// <param name="getWindowPosition">Returns the Options menu position.</param>
     /// <param name="closeWindow">Closes a registered window.</param>
     /// <param name="bootstrap">The application runtime and service owner.</param>
+    /// <param name="saveGame">Saves through the active game's runtime policy.</param>
     /// <param name="loadSave">Loads a save through the owning scene's hot- or cold-load flow.</param>
     /// <param name="markDirty">Marks the menu data as changed.</param>
     /// <param name="saveGameManager">The save-game persistence service.</param>
@@ -60,6 +62,7 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
         Func<Vector2Int> getWindowPosition,
         Action<UIWindow> closeWindow,
         AppBootstrap bootstrap,
+        Func<string, string, bool> saveGame,
         Func<string, bool> loadSave,
         Action markDirty,
         SaveGameManager saveGameManager
@@ -73,6 +76,7 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
         _closeWindow = closeWindow ?? throw new ArgumentNullException(nameof(closeWindow));
         _markDirty = markDirty ?? throw new ArgumentNullException(nameof(markDirty));
         _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
+        _saveGame = saveGame ?? throw new ArgumentNullException(nameof(saveGame));
         _loadSave = loadSave ?? throw new ArgumentNullException(nameof(loadSave));
         _saveGameManager =
             saveGameManager ?? throw new ArgumentNullException(nameof(saveGameManager));
@@ -207,6 +211,7 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
                 _saveSlots,
                 _selectedSlot,
                 HasActiveGame(),
+                CanSaveGame(),
                 _bindingSession.ListeningRow,
                 _bindingSession.ListeningSecondary,
                 _settingsSession.GetGameplayStates(),
@@ -341,14 +346,18 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
 
         if (_saveSlots[slot].IsCreateNew)
         {
-            CreateNamedSave(newName);
+            if (!CreateNamedSave(newName))
+                return;
             _selectedSlot = -1;
         }
         else
         {
             string fileName = _saveSlots[slot].FileName;
             if (submitted && HasActiveGame())
-                OverwriteSave(fileName, newName);
+            {
+                if (!OverwriteSave(fileName, newName))
+                    return;
+            }
             else
                 _saveGameManager.SetSaveDisplayName(fileName, newName);
             RefreshSaveSlots(fileName);
@@ -388,11 +397,12 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
     /// </summary>
     private void HandleSaveRequested()
     {
-        if (!HasActiveGame() || !IsSelectedExistingSave())
+        if (!CanSaveGame() || !IsSelectedExistingSave())
             return;
 
         string fileName = _saveSlots[_selectedSlot].FileName;
-        OverwriteSave(fileName, _saveSlots[_selectedSlot].Name);
+        if (!OverwriteSave(fileName, _saveSlots[_selectedSlot].Name))
+            return;
         RefreshSaveSlots(fileName);
         _markDirty();
     }
@@ -435,7 +445,7 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
     private void RefreshSaveSlots(string selectedFileName = null)
     {
         _saveSlots.Clear();
-        if (HasActiveGame())
+        if (CanSaveGame())
             _saveSlots.Add(new OptionsSaveSlot("Create New Save", string.Empty, null, true, null));
 
         foreach (SaveGameEntry entry in _saveGameManager.GetSavedGames())
@@ -482,14 +492,14 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
     /// Creates a named save from the active game.
     /// </summary>
     /// <param name="displayName">The requested display name.</param>
-    private void CreateNamedSave(string displayName)
+    /// <returns>True when the save was written.</returns>
+    private bool CreateNamedSave(string displayName)
     {
-        GameRoot game = GetActiveGame();
-        if (game == null)
-            return;
+        if (!CanSaveGame())
+            return false;
 
         string fileName = $"save_{DateTime.Now:yyyyMMdd_HHmmss}";
-        _saveGameManager.SaveGameData(game, fileName, displayName);
+        return _saveGame(fileName, displayName);
     }
 
     /// <summary>
@@ -497,13 +507,13 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
     /// </summary>
     /// <param name="fileName">The save identifier.</param>
     /// <param name="displayName">The display name to persist.</param>
-    private void OverwriteSave(string fileName, string displayName)
+    /// <returns>True when the save was written.</returns>
+    private bool OverwriteSave(string fileName, string displayName)
     {
-        GameRoot game = GetActiveGame();
-        if (game == null || string.IsNullOrEmpty(fileName))
-            return;
+        if (!CanSaveGame() || string.IsNullOrEmpty(fileName))
+            return false;
 
-        _saveGameManager.SaveGameData(game, fileName, displayName);
+        return _saveGame(fileName, displayName);
     }
 
     /// <summary>
@@ -844,6 +854,15 @@ public sealed class OptionsMenuController : ICancelable, IDisposable
     private bool HasActiveGame()
     {
         return GetActiveGame() != null;
+    }
+
+    /// <summary>
+    /// Checks whether the active game is at a stable save boundary.
+    /// </summary>
+    /// <returns>True when the runtime permits a new save snapshot.</returns>
+    private bool CanSaveGame()
+    {
+        return _bootstrap.GetRuntime()?.CanSave == true;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsMenuRenderData.cs
+++ b/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsMenuRenderData.cs
@@ -110,6 +110,7 @@ public sealed class OptionsMenuRenderData
     public IReadOnlyList<OptionsSaveSlot> SaveSlots { get; }
 
     public bool HasActiveGame { get; }
+    public bool CanSave { get; }
 
     /// <summary>
     /// Creates the Options menu data.
@@ -125,6 +126,7 @@ public sealed class OptionsMenuRenderData
     /// <param name="saveSlots">The save-slot rows.</param>
     /// <param name="selectedSlot">The selected save-slot index, or -1.</param>
     /// <param name="hasActiveGame">Whether a game is currently active.</param>
+    /// <param name="canSave">Whether the active game is at a stable save boundary.</param>
     /// <param name="listeningRow">The binding row awaiting a key press, or -1.</param>
     /// <param name="listeningSecondary">Whether the secondary column is awaiting a key press.</param>
     /// <param name="gameplayStates">The current gameplay-toggle states keyed by option.</param>
@@ -142,6 +144,7 @@ public sealed class OptionsMenuRenderData
         IReadOnlyList<OptionsSaveSlot> saveSlots,
         int selectedSlot,
         bool hasActiveGame,
+        bool canSave,
         int listeningRow,
         bool listeningSecondary,
         IReadOnlyDictionary<UserGameplayOption, bool> gameplayStates = null,
@@ -163,6 +166,7 @@ public sealed class OptionsMenuRenderData
         SaveSlots = saveSlots ?? Array.Empty<OptionsSaveSlot>();
         SelectedSlot = selectedSlot;
         HasActiveGame = hasActiveGame;
+        CanSave = canSave;
         ListeningRow = listeningRow;
         ListeningSecondary = listeningSecondary;
     }

--- a/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsSaveListView.cs
+++ b/Assets/Scripts/UI/SceneUI/OptionsMenu/OptionsSaveListView.cs
@@ -169,7 +169,7 @@ public sealed class OptionsSaveListView : MonoBehaviour, IContentInitializable
             selected >= 0
             && selected < data.SaveSlots.Count
             && !data.SaveSlots[selected].IsCreateNew;
-        bool canSave = data.HasActiveGame && existingSelected;
+        bool canSave = data.CanSave && existingSelected;
         bool canLoad = existingSelected;
         _saveButton.interactable = canSave;
         _loadButton.interactable = canLoad;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
@@ -28,7 +28,7 @@ public sealed class StrategyMenuCommand : IContextMenuParentCommand
 
     public bool IsSubmenu { get; }
 
-    public bool UsesIconColumn { get; }
+    public bool UsesIconColumn => HasIcon || IsSubmenu;
 
     /// <summary>
     /// Creates one strategy context-menu command.
@@ -38,14 +38,12 @@ public sealed class StrategyMenuCommand : IContextMenuParentCommand
     /// <param name="enabled">Whether the command can be selected.</param>
     /// <param name="iconKey">The optional semantic icon identifier.</param>
     /// <param name="submenuCommands">The ordered child commands.</param>
-    /// <param name="usesIconColumn">Whether the row reserves space for an icon.</param>
     public StrategyMenuCommand(
         StrategyMenuAction action,
         string text,
         bool enabled,
         int iconKey = 0,
-        IReadOnlyList<StrategyMenuCommand> submenuCommands = null,
-        bool usesIconColumn = false
+        IReadOnlyList<StrategyMenuCommand> submenuCommands = null
     )
     {
         Action = action;
@@ -54,7 +52,6 @@ public sealed class StrategyMenuCommand : IContextMenuParentCommand
         IconKey = iconKey;
         SubmenuCommands = submenuCommands?.ToList() ?? new List<StrategyMenuCommand>();
         IsSubmenu = submenuCommands != null;
-        UsesIconColumn = usesIconColumn || HasIcon || IsSubmenu;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Defense/DefenseWindowProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Defense/DefenseWindowProjector.cs
@@ -288,6 +288,8 @@ internal sealed class DefenseWindowProjector
             starfighterBadgeTexture: null,
             troopBadgeTexture: null,
             personnelBadgeTexture: null,
+            hideBackgroundWhenSelected: item
+                is IManufacturable { ManufacturingStatus: ManufacturingStatus.Building },
             canDrag: DefenseWindowSession.CanDragItem(item)
         );
     }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilder.cs
@@ -91,8 +91,7 @@ internal static class FacilityWindowContextMenuBuilder
                     playerControlsPlanet,
                     planet?.IsManufacturingReserved(manufacturingType.Value) == true
                         ? StrategyContextMenuIconKeys.CheckMark
-                        : StrategyContextMenuIconKeys.None,
-                    usesIconColumn: true
+                        : StrategyContextMenuIconKeys.None
                 )
             );
         }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Finder/FinderWindowRowBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Finder/FinderWindowRowBuilder.cs
@@ -270,7 +270,9 @@ public sealed class FinderWindowRowBuilder
                 seen,
                 null,
                 PlanetIcon.Defense,
-                ownedFaction?.GetOwnedUnitsByType<Officer>().Where(officer => !officer.IsKilled)
+                ownedFaction
+                    ?.GetOwnedUnitsByType<Officer>(includeDisabled: true)
+                    .Where(officer => !officer.IsKilled)
             );
         }
 
@@ -424,14 +426,20 @@ public sealed class FinderWindowRowBuilder
             if (!seen.Add(key))
                 continue;
 
+            bool hideLocation = !candidate.IsEnabled;
+            GalaxyMapPlanet displayedPlanet = hideLocation ? null : planet;
+            PlanetIcon displayedTargetIcon = hideLocation ? PlanetIcon.None : targetIcon;
+            Fleet displayedFleet = hideLocation ? null : fleet;
+            Mission displayedMission = hideLocation ? null : mission;
+
             rows.Add(
                 new FinderWindowRow(
-                    GetPersonnelDisplayName(candidate, planet, fleet),
-                    planet,
-                    targetIcon,
+                    GetPersonnelDisplayName(candidate, displayedPlanet, displayedFleet),
+                    displayedPlanet,
+                    displayedTargetIcon,
                     candidate,
-                    fleet,
-                    mission: mission
+                    displayedFleet,
+                    mission: displayedMission
                 )
             );
         }
@@ -477,6 +485,8 @@ public sealed class FinderWindowRowBuilder
         Fleet fleet = null
     )
     {
+        if (personnel is { IsEnabled: false })
+            return "Location Unknown";
         if (fleet != null)
             return fleet.GetDisplayName();
         if (personnel?.GetParentOfType<Fleet>() is Fleet parentFleet)
@@ -484,7 +494,7 @@ public sealed class FinderWindowRowBuilder
         if (personnel?.GetParentOfType<Planet>() is Planet parentPlanet)
             return parentPlanet.GetDisplayName();
 
-        return planet?.Planet?.GetDisplayName() ?? "Unknown";
+        return planet?.Planet?.GetDisplayName() ?? "Location Unknown";
     }
 
     /// <summary>
@@ -502,6 +512,8 @@ public sealed class FinderWindowRowBuilder
             return "Captured";
         if (personnel is Officer { InjuryPoints: > 0 })
             return "Injured";
+        if (personnel is { IsEnabled: false })
+            return "On Mission";
         if (personnel is IMovable movable && movable.GetTransitMovement() != null)
             return "Enroute";
         if (personnel is Officer officerOnMission && officerOnMission.IsOnMission())

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowContextMenuBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowContextMenuBuilder.cs
@@ -91,18 +91,16 @@ internal static class FleetWindowContextMenuBuilder
             new StrategyMenuCommand(StrategyMenuAction.MoveConfirm, "Confirmed Move", canMove),
         };
 
-        if (fleetCount == itemCount)
-        {
-            bool hasWaypoints = items.OfType<Fleet>().Any(fleet => fleet.HasWaypoints());
-            bool allFleetsAreMoving = items.OfType<Fleet>().All(fleet => fleet.Movement != null);
-            commands.Add(
-                new StrategyMenuCommand(
-                    StrategyMenuAction.WaypointMove,
-                    hasWaypoints ? "Clear Waypoints" : "Waypoint Move",
-                    playerControlsItems && (canMove || allFleetsAreMoving || hasWaypoints)
-                )
-            );
-        }
+        bool hasWaypoints = items.OfType<Fleet>().Any(fleet => fleet.HasWaypoints());
+        bool allFleetsAreMoving =
+            fleetCount == itemCount && items.OfType<Fleet>().All(fleet => fleet.Movement != null);
+        commands.Add(
+            new StrategyMenuCommand(
+                StrategyMenuAction.WaypointMove,
+                hasWaypoints ? "Clear Waypoints" : "Waypoint Move",
+                playerControlsItems && (canMove || allFleetsAreMoving || hasWaypoints)
+            )
+        );
 
         if (fleetCount > 0 && shipCount == 0)
         {

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowController.cs
@@ -708,6 +708,7 @@ public sealed class FleetWindowController
         view.DetailItemPressed += HandleDetailItemPressed;
         view.DetailItemReleased += HandleDetailItemReleased;
         view.FleetDestinationDropped += HandleFleetDestinationDropped;
+        view.FleetListDropped += HandleFleetListDropped;
         view.FleetRowDoubleClicked += HandleItemDoubleClicked;
         view.FleetRowDropped += HandleFleetRowDropped;
         view.FleetRowPressed += HandleFleetRowPressed;
@@ -1016,6 +1017,17 @@ public sealed class FleetWindowController
     }
 
     /// <summary>
+    /// Handles a fleet-list surface drop as a planet-level targeting selection.
+    /// </summary>
+    /// <param name="view">The destination fleet view.</param>
+    /// <param name="eventData">The pointer event.</param>
+    private void HandleFleetListDropped(FleetWindowView view, PointerEventData eventData)
+    {
+        if (TryGetSession(view, out FleetWindowSession session))
+            TrySelectTarget(session, null);
+    }
+
+    /// <summary>
     /// Handles a fleet or detail item double click as a status request.
     /// </summary>
     /// <param name="view">The source fleet view.</param>
@@ -1255,6 +1267,7 @@ public sealed class FleetWindowController
         view.DetailItemPressed -= HandleDetailItemPressed;
         view.DetailItemReleased -= HandleDetailItemReleased;
         view.FleetDestinationDropped -= HandleFleetDestinationDropped;
+        view.FleetListDropped -= HandleFleetListDropped;
         view.FleetRowDoubleClicked -= HandleItemDoubleClicked;
         view.FleetRowDropped -= HandleFleetRowDropped;
         view.FleetRowPressed -= HandleFleetRowPressed;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowProjector.cs
@@ -275,6 +275,8 @@ internal sealed class FleetWindowProjector
                         capitalShip?.GetChildren<Officer>().Any() == true,
                         badgeIcons => badgeIcons.FleetPersonnelBadgeImagePath
                     ),
+                    hideBackgroundWhenSelected: item
+                        is IManufacturable { ManufacturingStatus: ManufacturingStatus.Building },
                     canDrag: true
                 )
             );

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowView.cs
@@ -133,6 +133,11 @@ public sealed class FleetWindowView : MonoBehaviour, IPointerClickHandler, IDrop
     internal event Action<FleetWindowView, PointerEventData> FleetDestinationDropped;
 
     /// <summary>
+    /// Occurs when a pointer drop is received by the fleet-list surface.
+    /// </summary>
+    internal event Action<FleetWindowView, PointerEventData> FleetListDropped;
+
+    /// <summary>
     /// Occurs when the fleet row is double-clicked.
     /// </summary>
     internal event Action<FleetWindowView, int, PointerEventData> FleetRowDoubleClicked;
@@ -926,7 +931,7 @@ public sealed class FleetWindowView : MonoBehaviour, IPointerClickHandler, IDrop
 
         fleetListScrollArea.Dragged += HandleScrollDragged;
         fleetListScrollArea.DragEnded += HandleScrollDragEnded;
-        fleetListScrollArea.Dropped += HandleFleetDestinationDropped;
+        fleetListScrollArea.Dropped += HandleFleetListDropped;
         detailItemsScrollArea.Dragged += HandleScrollDragged;
         detailItemsScrollArea.DragEnded += HandleScrollDragEnded;
         detailItemsScrollArea.Dropped += HandleFleetDestinationDropped;
@@ -943,7 +948,7 @@ public sealed class FleetWindowView : MonoBehaviour, IPointerClickHandler, IDrop
 
         fleetListScrollArea.Dragged -= HandleScrollDragged;
         fleetListScrollArea.DragEnded -= HandleScrollDragEnded;
-        fleetListScrollArea.Dropped -= HandleFleetDestinationDropped;
+        fleetListScrollArea.Dropped -= HandleFleetListDropped;
         detailItemsScrollArea.Dragged -= HandleScrollDragged;
         detailItemsScrollArea.DragEnded -= HandleScrollDragEnded;
         detailItemsScrollArea.Dropped -= HandleFleetDestinationDropped;
@@ -1061,6 +1066,16 @@ public sealed class FleetWindowView : MonoBehaviour, IPointerClickHandler, IDrop
     )
     {
         DetailItemDoubleClicked?.Invoke(this, item.Index, eventData);
+    }
+
+    /// <summary>
+    /// Forwards a drop on the fleet-list surface.
+    /// </summary>
+    /// <param name="eventData">The pointer event.</param>
+    private void HandleFleetListDropped(PointerEventData eventData)
+    {
+        if (eventData != null)
+            FleetListDropped?.Invoke(this, eventData);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -786,8 +786,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
             action,
             text,
             enabled,
-            selected ? StrategyContextMenuIconKeys.CheckMark : StrategyContextMenuIconKeys.None,
-            usesIconColumn: true
+            selected ? StrategyContextMenuIconKeys.CheckMark : StrategyContextMenuIconKeys.None
         );
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Messages/MessagesWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Messages/MessagesWindowController.cs
@@ -37,16 +37,17 @@ public interface IMessagesWindowActions
 public sealed class MessagesWindowController
 {
     private readonly Action<UIWindow> closeWindow;
+    private readonly List<AudioPlaybackHandle> detailAudioPlaybacks =
+        new List<AudioPlaybackHandle>();
     private readonly Func<Vector2Int> getWindowPosition;
     private readonly Func<UIContext> getUIContext;
     private readonly Action markDirty;
-    private readonly Action<IReadOnlyList<string>> playMessageAudio;
     private readonly Action<string> playSfx;
+    private readonly Func<string, AudioPlaybackHandle> playSfxInstance;
     private readonly Dictionary<MessagesWindowView, MessagesWindowSession> sessions =
         new Dictionary<MessagesWindowView, MessagesWindowSession>();
     private readonly StrategyWindowLayerView windowLayer;
     private readonly UIWindowManager windowManager;
-    private readonly Action stopMessageAudio;
     private IMessagesWindowActions actions;
 
     /// <summary>
@@ -58,8 +59,7 @@ public sealed class MessagesWindowController
     /// Creates the Messages feature controller with current presentation-resource access.
     /// </summary>
     /// <param name="playSfx">Plays a strategy sound effect path.</param>
-    /// <param name="playMessageAudio">Replaces message-detail audio with an ordered sequence.</param>
-    /// <param name="stopMessageAudio">Stops active message-detail audio.</param>
+    /// <param name="playSfxInstance">Plays an independently controllable sound effect path.</param>
     /// <param name="getUIContext">Resolves the current theme and texture context.</param>
     /// <param name="windowLayer">Provides the authored Messages prefab and modal layer.</param>
     /// <param name="windowManager">Owns strategy-window creation, focus, and registration.</param>
@@ -68,8 +68,7 @@ public sealed class MessagesWindowController
     /// <param name="markDirty">Invalidates strategy presentation after window changes.</param>
     public MessagesWindowController(
         Action<string> playSfx,
-        Action<IReadOnlyList<string>> playMessageAudio,
-        Action stopMessageAudio,
+        Func<string, AudioPlaybackHandle> playSfxInstance,
         Func<UIContext> getUIContext,
         StrategyWindowLayerView windowLayer,
         UIWindowManager windowManager,
@@ -79,10 +78,8 @@ public sealed class MessagesWindowController
     )
     {
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
-        this.playMessageAudio =
-            playMessageAudio ?? throw new ArgumentNullException(nameof(playMessageAudio));
-        this.stopMessageAudio =
-            stopMessageAudio ?? throw new ArgumentNullException(nameof(stopMessageAudio));
+        this.playSfxInstance =
+            playSfxInstance ?? throw new ArgumentNullException(nameof(playSfxInstance));
         this.getUIContext = getUIContext ?? throw new ArgumentNullException(nameof(getUIContext));
         this.windowLayer = windowLayer ?? throw new ArgumentNullException(nameof(windowLayer));
         this.windowManager =
@@ -147,7 +144,7 @@ public sealed class MessagesWindowController
     /// <param name="tab">The semantic Messages tab.</param>
     public void OpenTab(MessagesWindowView view, MessagesTab tab)
     {
-        stopMessageAudio();
+        StopMessageDetailAudio();
         MessagesWindowSession session = GetSession(view);
         session.SelectTab(MessagesTabCatalog.Clamp((int)tab));
         RefreshSession(session);
@@ -319,10 +316,10 @@ public sealed class MessagesWindowController
     }
 
     /// <summary>
-    /// Returns message detail audio in playback order.
+    /// Returns the available audio paths for one message detail.
     /// </summary>
     /// <param name="message">The source message.</param>
-    /// <returns>The non-empty voice paths associated with the message.</returns>
+    /// <returns>The non-empty audio paths associated with the message.</returns>
     internal static IReadOnlyList<string> GetDetailAudioPaths(Message message)
     {
         if (message == null)
@@ -376,7 +373,13 @@ public sealed class MessagesWindowController
     /// <param name="message">The message whose detail was presented.</param>
     internal void PlayMessageDetailAudio(Message message)
     {
-        playMessageAudio(GetDetailAudioPaths(message));
+        StopMessageDetailAudio();
+        foreach (string path in GetDetailAudioPaths(message))
+        {
+            AudioPlaybackHandle playback = playSfxInstance(path);
+            if (playback != null)
+                detailAudioPlaybacks.Add(playback);
+        }
     }
 
     /// <summary>
@@ -514,7 +517,7 @@ public sealed class MessagesWindowController
         FocusWindow(view);
         if (TryGetSession(view, out MessagesWindowSession session))
         {
-            stopMessageAudio();
+            StopMessageDetailAudio();
             closeWindow(session.Window);
         }
     }
@@ -575,7 +578,7 @@ public sealed class MessagesWindowController
             return;
 
         FocusWindow(view);
-        stopMessageAudio();
+        StopMessageDetailAudio();
         session.HideDetail();
         RequestRender();
     }
@@ -611,7 +614,7 @@ public sealed class MessagesWindowController
         Faction playerFaction = GetPlayerFaction();
         if (RemoveSelectedMessages(playerFaction, session.GetSelectedMessageIDs()))
         {
-            stopMessageAudio();
+            StopMessageDetailAudio();
             session.ClearSelection();
             session.HideDetail();
             RefreshSession(session);
@@ -676,7 +679,7 @@ public sealed class MessagesWindowController
         if (message is not CombatReport report)
             return false;
 
-        stopMessageAudio();
+        StopMessageDetailAudio();
         closeWindow(session.Window);
         actions.OpenCombatReport(report);
         markDirty();
@@ -752,7 +755,7 @@ public sealed class MessagesWindowController
         if (ReferenceEquals(view, null) || !sessions.Remove(view))
             return;
 
-        stopMessageAudio();
+        StopMessageDetailAudio();
         view.ChatRequested -= HandleChatRequested;
         view.CloseRequested -= HandleCloseRequested;
         view.ContextRequested -= HandleContextRequested;
@@ -792,6 +795,17 @@ public sealed class MessagesWindowController
             PlayMessageDetailAudio(message);
         }
         RequestRender();
+    }
+
+    /// <summary>
+    /// Stops every sound owned by the currently displayed message detail.
+    /// </summary>
+    private void StopMessageDetailAudio()
+    {
+        foreach (AudioPlaybackHandle playback in detailAudioPlaybacks)
+            playback.Stop();
+
+        detailAudioPlaybacks.Clear();
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Messages/MessagesWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Messages/MessagesWindowController.cs
@@ -40,11 +40,13 @@ public sealed class MessagesWindowController
     private readonly Func<Vector2Int> getWindowPosition;
     private readonly Func<UIContext> getUIContext;
     private readonly Action markDirty;
+    private readonly Action<IReadOnlyList<string>> playMessageAudio;
     private readonly Action<string> playSfx;
     private readonly Dictionary<MessagesWindowView, MessagesWindowSession> sessions =
         new Dictionary<MessagesWindowView, MessagesWindowSession>();
     private readonly StrategyWindowLayerView windowLayer;
     private readonly UIWindowManager windowManager;
+    private readonly Action stopMessageAudio;
     private IMessagesWindowActions actions;
 
     /// <summary>
@@ -56,6 +58,8 @@ public sealed class MessagesWindowController
     /// Creates the Messages feature controller with current presentation-resource access.
     /// </summary>
     /// <param name="playSfx">Plays a strategy sound effect path.</param>
+    /// <param name="playMessageAudio">Replaces message-detail audio with an ordered sequence.</param>
+    /// <param name="stopMessageAudio">Stops active message-detail audio.</param>
     /// <param name="getUIContext">Resolves the current theme and texture context.</param>
     /// <param name="windowLayer">Provides the authored Messages prefab and modal layer.</param>
     /// <param name="windowManager">Owns strategy-window creation, focus, and registration.</param>
@@ -64,6 +68,8 @@ public sealed class MessagesWindowController
     /// <param name="markDirty">Invalidates strategy presentation after window changes.</param>
     public MessagesWindowController(
         Action<string> playSfx,
+        Action<IReadOnlyList<string>> playMessageAudio,
+        Action stopMessageAudio,
         Func<UIContext> getUIContext,
         StrategyWindowLayerView windowLayer,
         UIWindowManager windowManager,
@@ -73,6 +79,10 @@ public sealed class MessagesWindowController
     )
     {
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
+        this.playMessageAudio =
+            playMessageAudio ?? throw new ArgumentNullException(nameof(playMessageAudio));
+        this.stopMessageAudio =
+            stopMessageAudio ?? throw new ArgumentNullException(nameof(stopMessageAudio));
         this.getUIContext = getUIContext ?? throw new ArgumentNullException(nameof(getUIContext));
         this.windowLayer = windowLayer ?? throw new ArgumentNullException(nameof(windowLayer));
         this.windowManager =
@@ -137,6 +147,7 @@ public sealed class MessagesWindowController
     /// <param name="tab">The semantic Messages tab.</param>
     public void OpenTab(MessagesWindowView view, MessagesTab tab)
     {
+        stopMessageAudio();
         MessagesWindowSession session = GetSession(view);
         session.SelectTab(MessagesTabCatalog.Clamp((int)tab));
         RefreshSession(session);
@@ -365,8 +376,7 @@ public sealed class MessagesWindowController
     /// <param name="message">The message whose detail was presented.</param>
     internal void PlayMessageDetailAudio(Message message)
     {
-        foreach (string path in GetDetailAudioPaths(message))
-            playSfx(path);
+        playMessageAudio(GetDetailAudioPaths(message));
     }
 
     /// <summary>
@@ -503,7 +513,10 @@ public sealed class MessagesWindowController
     {
         FocusWindow(view);
         if (TryGetSession(view, out MessagesWindowSession session))
+        {
+            stopMessageAudio();
             closeWindow(session.Window);
+        }
     }
 
     /// <summary>
@@ -562,6 +575,7 @@ public sealed class MessagesWindowController
             return;
 
         FocusWindow(view);
+        stopMessageAudio();
         session.HideDetail();
         RequestRender();
     }
@@ -597,6 +611,7 @@ public sealed class MessagesWindowController
         Faction playerFaction = GetPlayerFaction();
         if (RemoveSelectedMessages(playerFaction, session.GetSelectedMessageIDs()))
         {
+            stopMessageAudio();
             session.ClearSelection();
             session.HideDetail();
             RefreshSession(session);
@@ -661,6 +676,7 @@ public sealed class MessagesWindowController
         if (message is not CombatReport report)
             return false;
 
+        stopMessageAudio();
         closeWindow(session.Window);
         actions.OpenCombatReport(report);
         markDirty();
@@ -736,6 +752,7 @@ public sealed class MessagesWindowController
         if (ReferenceEquals(view, null) || !sessions.Remove(view))
             return;
 
+        stopMessageAudio();
         view.ChatRequested -= HandleChatRequested;
         view.CloseRequested -= HandleCloseRequested;
         view.ContextRequested -= HandleContextRequested;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/GameFlowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/GameFlowController.cs
@@ -76,7 +76,7 @@ public sealed class GameFlowController : MonoBehaviour
             if (GameLaunchContext.IsLoadGame)
             {
                 LoadGame();
-                GameManager gameManager = StartGameSession();
+                GameManager gameManager = StartGameSession(loadedGame: true);
                 InitializeStrategy(gameManager);
                 ActivateGameplay(gameManager, false);
             }
@@ -131,7 +131,7 @@ public sealed class GameFlowController : MonoBehaviour
         GameStartupTrace.Log("Game generation complete.");
         bool playBriefing = GameLaunchContext.PlayIntroCutscene;
         Task intro = PlayFactionIntroAsync(game.GetPlayerFaction());
-        GameManager gameManager = StartGameSession();
+        GameManager gameManager = StartGameSession(loadedGame: false);
         InitializeStrategy(gameManager);
         Task briefingReady = playBriefing
             ? strategyController.PrepareBriefingAsync()
@@ -193,13 +193,14 @@ public sealed class GameFlowController : MonoBehaviour
     /// <summary>
     /// Starts the built game in the active runtime.
     /// </summary>
+    /// <param name="loadedGame">Whether the game was restored from persisted state.</param>
     /// <returns>The active game manager.</returns>
-    private GameManager StartGameSession()
+    private GameManager StartGameSession(bool loadedGame)
     {
         AppBootstrap bootstrap = AppBootstrap.EnsureExists();
         GameRuntime runtime = bootstrap.GetRuntime();
         GameStartupTrace.Log("Creating the active game session.");
-        return runtime.StartGame(game);
+        return loadedGame ? runtime.StartLoadedGame(game) : runtime.StartGame(game);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -165,6 +165,7 @@ public sealed class StrategyController
         gameManager.TickCompleted += RefreshStrategyState;
         gameManager.MessageDelivered += HandleMessageDelivered;
         gameManager.BombardmentCompleted += HandleBombardmentCompleted;
+        gameManager.PlanetaryAssaultsResolved += HandlePlanetaryAssaultsResolved;
 
         InitializeScreenControllers();
         IContentAssetSource contentAssets = AppBootstrap.Instance.GetContentAssets();
@@ -749,6 +750,7 @@ public sealed class StrategyController
             gameManager.TickCompleted -= RefreshStrategyState;
             gameManager.MessageDelivered -= HandleMessageDelivered;
             gameManager.BombardmentCompleted -= HandleBombardmentCompleted;
+            gameManager.PlanetaryAssaultsResolved -= HandlePlanetaryAssaultsResolved;
         }
     }
 
@@ -1572,6 +1574,27 @@ public sealed class StrategyController
             return;
 
         PauseForGameplayOption(UserGameplayOption.PauseAfterEnemyBombardment);
+    }
+
+    /// <summary>
+    /// Plays the planetary-assault alert when an opposing faction invades a player-owned planet.
+    /// </summary>
+    /// <param name="results">The planetary assaults resolved in the current result batch.</param>
+    private void HandlePlanetaryAssaultsResolved(IReadOnlyList<PlanetaryAssaultResult> results)
+    {
+        string playerFactionId = gameManager?.GetPlayerFaction()?.InstanceID;
+        if (
+            string.IsNullOrEmpty(playerFactionId)
+            || results?.Any(result =>
+                result != null
+                && result.AttackerOwnerInstanceID != playerFactionId
+                && result.DefenderOwnerInstanceID == playerFactionId
+                && result.InitialAttackerRegimentCount > 0
+            ) != true
+        )
+            return;
+
+        PlaySfx(StrategyUISoundPaths.PlanetaryAssault);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -162,6 +162,7 @@ public sealed class StrategyController
         strategyContextMenu.Initialize(uiContext);
         gameManager.GameSpeedChanged += MarkDirty;
         gameManager.GameReplaced += HandleGameReplaced;
+        gameManager.CombatDecisionRequired += RefreshStrategyState;
         gameManager.TickCompleted += RefreshStrategyState;
         gameManager.MessageDelivered += HandleMessageDelivered;
         gameManager.BombardmentCompleted += HandleBombardmentCompleted;
@@ -381,6 +382,8 @@ public sealed class StrategyController
         );
         messagesWindowController = new MessagesWindowController(
             PlaySfx,
+            resourcePaths => AudioManager.EnsureExists().PlayMessageAudio(resourcePaths),
+            () => AudioManager.EnsureExists().StopMessageAudio(),
             () => uiContext,
             strategyWindowLayerView,
             strategyWindowManager,
@@ -435,6 +438,7 @@ public sealed class StrategyController
             windowPlacementController.GetOptionsWindowPosition,
             CloseWindow,
             bootstrap,
+            settingsRuntime.SaveGame,
             settingsRuntime.LoadGame,
             MarkDirty,
             SaveGameManager.Instance
@@ -747,6 +751,7 @@ public sealed class StrategyController
         {
             gameManager.GameSpeedChanged -= MarkDirty;
             gameManager.GameReplaced -= HandleGameReplaced;
+            gameManager.CombatDecisionRequired -= RefreshStrategyState;
             gameManager.TickCompleted -= RefreshStrategyState;
             gameManager.MessageDelivered -= HandleMessageDelivered;
             gameManager.BombardmentCompleted -= HandleBombardmentCompleted;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -382,8 +382,7 @@ public sealed class StrategyController
         );
         messagesWindowController = new MessagesWindowController(
             PlaySfx,
-            resourcePaths => AudioManager.EnsureExists().PlayMessageAudio(resourcePaths),
-            () => AudioManager.EnsureExists().StopMessageAudio(),
+            resourcePath => AudioManager.EnsureExists().PlaySfxInstance(resourcePath),
             () => uiContext,
             strategyWindowLayerView,
             strategyWindowManager,

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/FleetWaypointRouteResolver.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/FleetWaypointRouteResolver.cs
@@ -161,9 +161,21 @@ internal static class FleetWaypointRouteResolver
         )
             return;
 
-        foreach (Fleet selectedFleet in waypointPlan.Items.OfType<Fleet>())
+        IEnumerable<Fleet> selectedFleets = waypointPlan.Items.OfType<Fleet>();
+        if (!selectedFleets.Any())
         {
-            Fleet fleet = game.GetSceneNodeByInstanceID<Fleet>(selectedFleet.InstanceID);
+            selectedFleets = waypointPlan
+                .Items.OfType<CapitalShip>()
+                .Select(ship => game.GetSceneNodeByInstanceID<CapitalShip>(ship.InstanceID))
+                .Where(ship => ship != null)
+                .Select(ship => ship.GetParentOfType<Fleet>());
+        }
+
+        foreach (Fleet selectedFleet in selectedFleets)
+        {
+            Fleet fleet = string.IsNullOrEmpty(selectedFleet?.InstanceID)
+                ? null
+                : game.GetSceneNodeByInstanceID<Fleet>(selectedFleet.InstanceID);
             if (
                 fleet == null
                 || !string.Equals(fleet.OwnerInstanceID, playerFactionId, StringComparison.Ordinal)

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUnitCardView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUnitCardView.cs
@@ -49,6 +49,7 @@ public sealed class StrategyUnitCardView : MonoBehaviour, IStrategyStatusDoubleC
 
     private bool canDrag;
     private RectInt entityFrameRect;
+    private bool hideBackgroundWhenSelected;
     private bool layoutCaptured;
     private UIPointerGestureRelay pointerGestures;
 
@@ -124,6 +125,7 @@ public sealed class StrategyUnitCardView : MonoBehaviour, IStrategyStatusDoubleC
         VerifyReferences();
         CaptureLayout();
         canDrag = data.CanDrag;
+        hideBackgroundWhenSelected = data.HideBackgroundWhenSelected;
 
         RectInt entityRenderFrameRect = GetEntityRenderFrameRect(data.EntityFrameYOffset);
         SetOptionalImageTexture(backgroundImage, data.BackgroundTexture);
@@ -143,7 +145,7 @@ public sealed class StrategyUnitCardView : MonoBehaviour, IStrategyStatusDoubleC
             data.CapturedOverlayTexture,
             entityRenderFrameRect
         );
-        SetOptionalImageTexture(selectionImage, data.SelectionTexture);
+        RenderSelection(data.SelectionTexture);
         SetOptionalImageTexture(starfighterBadgeImage, data.StarfighterBadgeTexture);
         SetOptionalImageTexture(troopBadgeImage, data.TroopBadgeTexture);
         SetOptionalImageTexture(personnelBadgeImage, data.PersonnelBadgeTexture);
@@ -159,6 +161,8 @@ public sealed class StrategyUnitCardView : MonoBehaviour, IStrategyStatusDoubleC
     {
         VerifyReferences();
         SetOptionalImageTexture(selectionImage, texture);
+        if (backgroundImage != null && hideBackgroundWhenSelected)
+            backgroundImage.gameObject.SetActive(texture == null);
     }
 
     /// <summary>
@@ -418,6 +422,8 @@ public sealed class StrategyUnitCardRenderData
 
     public Texture PersonnelBadgeTexture { get; }
 
+    public bool HideBackgroundWhenSelected { get; }
+
     public bool CanDrag { get; }
 
     /// <summary>
@@ -437,6 +443,7 @@ public sealed class StrategyUnitCardRenderData
     /// <param name="starfighterBadgeTexture">The optional starfighter badge.</param>
     /// <param name="troopBadgeTexture">The optional troop badge.</param>
     /// <param name="personnelBadgeTexture">The optional personnel badge.</param>
+    /// <param name="hideBackgroundWhenSelected">Whether selection replaces the card background.</param>
     /// <param name="canDrag">Whether the card can initiate a move drag.</param>
     public StrategyUnitCardRenderData(
         string name,
@@ -453,6 +460,7 @@ public sealed class StrategyUnitCardRenderData
         Texture starfighterBadgeTexture,
         Texture troopBadgeTexture,
         Texture personnelBadgeTexture,
+        bool hideBackgroundWhenSelected,
         bool canDrag
     )
     {
@@ -470,6 +478,7 @@ public sealed class StrategyUnitCardRenderData
         StarfighterBadgeTexture = starfighterBadgeTexture;
         TroopBadgeTexture = troopBadgeTexture;
         PersonnelBadgeTexture = personnelBadgeTexture;
+        HideBackgroundWhenSelected = hideBackgroundWhenSelected;
         CanDrag = canDrag;
     }
 }

--- a/Assets/Tests/EditMode/GameTests/App/GameRuntimeTests.cs
+++ b/Assets/Tests/EditMode/GameTests/App/GameRuntimeTests.cs
@@ -2,6 +2,9 @@ using System;
 using System.IO;
 using NUnit.Framework;
 using Rebellion.Game;
+using Rebellion.Game.Factions;
+using Rebellion.Game.Galaxy;
+using Rebellion.Game.Units;
 
 namespace Rebellion.Tests.App
 {
@@ -36,7 +39,59 @@ namespace Rebellion.Tests.App
         }
 
         [Test]
-        public void QuickSaveThenQuickLoad_ReplacesMutatedGameWithSavedState()
+        public void StartGame_PendingCombat_DefersAutosaveUntilResolution()
+        {
+            GameRoot game = CreateContestedGame();
+            game.CurrentTick = 39;
+            _gameplaySettings.AutosaveIntervalTicks = 40;
+            GameManager manager = _runtime.StartGame(game);
+            string autosavePath = _saveGameManager.GetSaveFilePath(
+                SaveGameManager.AutosaveFilePrefix + "0000000040"
+            );
+
+            manager.ProcessTick();
+
+            Assert.IsFalse(File.Exists(autosavePath));
+            Assert.IsFalse(_runtime.CanSave);
+
+            manager.ResolveCombat(true);
+
+            Assert.IsTrue(File.Exists(autosavePath));
+            Assert.IsTrue(_runtime.CanSave);
+        }
+
+        [Test]
+        public void QuickSave_PendingCombat_DoesNotWriteSave()
+        {
+            GameRoot game = CreateContestedGame();
+            _runtime.StartLoadedGame(game);
+
+            bool saved = _runtime.QuickSave();
+
+            Assert.IsFalse(saved);
+            Assert.IsFalse(
+                File.Exists(_saveGameManager.GetSaveFilePath(SaveGameManager.QuickSaveFileName))
+            );
+        }
+
+        [Test]
+        public void SaveGame_PendingCombat_DoesNotWriteSave()
+        {
+            GameRoot game = CreateContestedGame();
+            game.CurrentTick = 40;
+            GameManager manager = _runtime.StartLoadedGame(game);
+
+            bool saved = _runtime.SaveGame("pending_combat", "Pending Combat");
+
+            Assert.IsTrue(manager.SpaceCombatSystem.HasPendingDecision);
+            Assert.IsFalse(_runtime.CanSave);
+            Assert.IsFalse(saved);
+            Assert.IsFalse(File.Exists(_saveGameManager.GetSaveFilePath("pending_combat")));
+            Assert.AreEqual(40, game.CurrentTick);
+        }
+
+        [Test]
+        public void QuickLoad_AfterQuickSave_ReplacesMutatedGameWithSavedState()
         {
             GameRoot game = CreateGame();
             game.CurrentTick = 123;
@@ -108,6 +163,59 @@ namespace Rebellion.Tests.App
                     ScenarioID = _contentPack.Scenario.ID,
                 },
             };
+        }
+
+        private GameRoot CreateContestedGame()
+        {
+            GameRoot game = CreateGame();
+            Faction alliance = new Faction
+            {
+                InstanceID = "FNALL1",
+                DisplayName = "Alliance",
+                PlayerID = "player",
+            };
+            Faction empire = new Faction { InstanceID = "FNEMP1", DisplayName = "Empire" };
+            game.GetFactions().Add(alliance);
+            game.GetFactions().Add(empire);
+            PlanetSector sector = new PlanetSector { InstanceID = "SECTOR" };
+            Planet planet = new Planet
+            {
+                InstanceID = "PLANET",
+                DisplayName = "Planet",
+                OwnerInstanceID = empire.InstanceID,
+                IsColonized = true,
+            };
+            game.AttachNode(sector, game.GetGalaxyMap());
+            game.AttachNode(planet, sector);
+            AddFleet(game, planet, "ALLIANCE_FLEET", alliance.InstanceID);
+            AddFleet(game, planet, "EMPIRE_FLEET", empire.InstanceID);
+            return game;
+        }
+
+        private static void AddFleet(
+            GameRoot game,
+            Planet planet,
+            string instanceId,
+            string ownerId
+        )
+        {
+            Fleet fleet = new Fleet
+            {
+                InstanceID = instanceId,
+                DisplayName = instanceId,
+                OwnerInstanceID = ownerId,
+            };
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = instanceId + "_SHIP",
+                DisplayName = instanceId + " Ship",
+                OwnerInstanceID = ownerId,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                CurrentHullStrength = 100,
+                MaxHullStrength = 100,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
         }
     }
 }

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionSerializationTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionSerializationTests.cs
@@ -93,6 +93,7 @@ namespace Rebellion.Tests.Game.Events
                                         RecipientFactionInstanceID = "FNALL1",
                                         SubjectInstanceID = "LUKE",
                                         RelatedSubjectInstanceID = "VADER",
+                                        ShowSubjectImage = true,
                                         MessageType = MessageType.Advice,
                                         BackgroundAudio = new MessageAudio
                                         {
@@ -134,6 +135,7 @@ namespace Rebellion.Tests.Game.Events
             Assert.IsNotNull(message);
             Assert.AreEqual("LUKE", message.SubjectInstanceID);
             Assert.AreEqual("VADER", message.RelatedSubjectInstanceID);
+            Assert.IsTrue(message.ShowSubjectImage);
             Assert.AreEqual("Story/dialogue", message.BackgroundAudio.Path);
             Assert.AreEqual("Story/advisor", message.AdvisorNotification.Protocol.AnimationPath);
             Assert.AreEqual(3, message.AdvisorNotification.Protocol.FrameCount);

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
@@ -675,6 +675,71 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
+        public void SendMessage_OfficerSubject_DoesNotIncludeSubjectImageByDefault()
+        {
+            GameRoot game = BuildGame(out _, out Planet rebelPlanet);
+            Officer luke = EntityFactory.CreateOfficer("luke", "rebels");
+            luke.MessageImagePath = "Officers/Luke/message";
+            game.AttachNode(luke, rebelPlanet);
+            SendMessageAction action = new SendMessageAction
+            {
+                RecipientFactionInstanceID = "rebels",
+                SubjectInstanceID = luke.InstanceID,
+            };
+
+            MessageDeliveryRequest result = action
+                .ExecuteRequests(game)
+                .OfType<MessageDeliveryRequest>()
+                .Single();
+
+            Assert.IsNull(result.OverlayImagePath);
+        }
+
+        [Test]
+        public void SendMessage_ShowSubjectImage_IncludesOfficerMessageImage()
+        {
+            GameRoot game = BuildGame(out _, out Planet rebelPlanet);
+            Officer luke = EntityFactory.CreateOfficer("luke", "rebels");
+            luke.MessageImagePath = "Officers/Luke/message";
+            game.AttachNode(luke, rebelPlanet);
+            SendMessageAction action = new SendMessageAction
+            {
+                RecipientFactionInstanceID = "rebels",
+                SubjectInstanceID = luke.InstanceID,
+                ShowSubjectImage = true,
+            };
+
+            MessageDeliveryRequest result = action
+                .ExecuteRequests(game)
+                .OfType<MessageDeliveryRequest>()
+                .Single();
+
+            Assert.AreEqual("Officers/Luke/message", result.OverlayImagePath);
+        }
+
+        [Test]
+        public void SendMessage_ExplicitOverlayImage_UsesAuthoredImage()
+        {
+            GameRoot game = BuildGame(out _, out Planet rebelPlanet);
+            Officer luke = EntityFactory.CreateOfficer("luke", "rebels");
+            luke.MessageImagePath = "Officers/Luke/message";
+            game.AttachNode(luke, rebelPlanet);
+            SendMessageAction action = new SendMessageAction
+            {
+                RecipientFactionInstanceID = "rebels",
+                SubjectInstanceID = luke.InstanceID,
+                OverlayImage = new MessageImage { Path = "Story/portrait" },
+            };
+
+            MessageDeliveryRequest result = action
+                .ExecuteRequests(game)
+                .OfType<MessageDeliveryRequest>()
+                .Single();
+
+            Assert.AreEqual("Story/portrait", result.OverlayImagePath);
+        }
+
+        [Test]
         public void SendMessage_RecipientOmitted_ThrowsException()
         {
             GameRoot game = BuildGame(out _, out _);
@@ -1065,6 +1130,7 @@ namespace Rebellion.Tests.Game.Events
                 OfficerInstanceID = luke.InstanceID,
                 DisplayImagePath = "jedi-display",
                 SmallDisplayImagePath = "jedi-small-display",
+                MessageImagePath = "jedi-message",
                 EncyclopediaImagePath = "jedi-encyclopedia",
             };
 
@@ -1072,6 +1138,7 @@ namespace Rebellion.Tests.Game.Events
 
             Assert.AreEqual("jedi-display", luke.DisplayImagePath);
             Assert.AreEqual("jedi-small-display", luke.SmallDisplayImagePath);
+            Assert.AreEqual("jedi-message", luke.MessageImagePath);
             Assert.AreEqual("jedi-encyclopedia", luke.EncyclopediaImagePath);
         }
 

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameEventSchemaTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameEventSchemaTests.cs
@@ -114,6 +114,7 @@ namespace Rebellion.Tests.Game.Events
 <GameEvents>
   <GameEvent>
     <InstanceID>EVENT</InstanceID>
+    <Schedule><At Tick=""1""/></Schedule>
     <Actions>
       <SendMessage RecipientFactionInstanceID=""FACTION"" SubjectInstanceID=""OFFICER"" ShowSubjectImage=""true""/>
     </Actions>

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameEventSchemaTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameEventSchemaTests.cs
@@ -107,6 +107,23 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
+        public void Validate_SendMessageSubjectImageToggle_AcceptsDocument()
+        {
+            const string xml =
+                @"
+<GameEvents>
+  <GameEvent>
+    <InstanceID>EVENT</InstanceID>
+    <Actions>
+      <SendMessage RecipientFactionInstanceID=""FACTION"" SubjectInstanceID=""OFFICER"" ShowSubjectImage=""true""/>
+    </Actions>
+  </GameEvent>
+</GameEvents>";
+
+            Assert.DoesNotThrow(() => Validate(xml));
+        }
+
+        [Test]
         public void Validate_TriggerArgumentBinding_AcceptsDocument()
         {
             const string xml =

--- a/Assets/Tests/EditMode/GameTests/Game/Factions/FactionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Factions/FactionTests.cs
@@ -205,6 +205,28 @@ namespace Rebellion.Tests.Game.Factions
         }
 
         [Test]
+        public void GetOwnedUnitsByType_DisabledUnit_ExcludesUnitByDefault()
+        {
+            _fleet.IsEnabled = false;
+            _faction.AddOwnedUnit(_fleet);
+
+            List<Fleet> fleets = _faction.GetOwnedUnitsByType<Fleet>();
+
+            CollectionAssert.DoesNotContain(fleets, _fleet);
+        }
+
+        [Test]
+        public void GetOwnedUnitsByType_DisabledUnitAndIncludedDisabled_ReturnsUnit()
+        {
+            _fleet.IsEnabled = false;
+            _faction.AddOwnedUnit(_fleet);
+
+            List<Fleet> fleets = _faction.GetOwnedUnitsByType<Fleet>(includeDisabled: true);
+
+            CollectionAssert.Contains(fleets, _fleet);
+        }
+
+        [Test]
         public void GetOwnedColonizedPlanets_FactionWithUncolonizedOwnedPlanet_ReturnsOnlyColonizedPlanets()
         {
             _planet1.IsColonized = true;

--- a/Assets/Tests/EditMode/GameTests/Generation/OfficerSeederTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Generation/OfficerSeederTests.cs
@@ -292,6 +292,40 @@ namespace Rebellion.Tests.Generation
         }
 
         [Test]
+        public void Seed_WithMaximumVariance_IncludesConfiguredExtent()
+        {
+            Officer officer = MakeOfficer("O1", "FNALL1");
+            officer.Ratings[OfficerRating.Espionage] = 5;
+            officer.EspionageVariance = 10;
+            PlanetSector sector = MakeSector(("p1", "FNALL1"));
+
+            Deploy(new[] { officer }, new[] { sector }, _rules, _summary, new MaximumRNG());
+
+            Assert.AreEqual(15, officer.Ratings[OfficerRating.Espionage]);
+        }
+
+        [Test]
+        public void Seed_UnrecruitedOfficer_RollsRatings()
+        {
+            _rules.Officers.NumStartingOfficers.Small = 0;
+            Officer officer = MakeOfficer("O1", "FNALL1");
+            officer.Ratings[OfficerRating.Espionage] = 5;
+            officer.EspionageVariance = 10;
+            PlanetSector sector = MakeSector(("p1", "FNALL1"));
+
+            (Officer[] Deployed, Officer[] Unrecruited) results = Deploy(
+                new[] { officer },
+                new[] { sector },
+                _rules,
+                _summary,
+                new MaximumRNG()
+            );
+
+            Assert.Contains(officer, results.Unrecruited);
+            Assert.AreEqual(15, officer.Ratings[OfficerRating.Espionage]);
+        }
+
+        [Test]
         public void Seed_WithOwnedPlanet_OfficerAddedToPlanet()
         {
             Officer officer = MakeOfficer("O1", "FNALL1");

--- a/Assets/Tests/EditMode/GameTests/Managers/AudioManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/AudioManagerTests.cs
@@ -25,7 +25,7 @@ public sealed class AudioManagerTests
 
         Assert.IsNotNull(manager);
         Assert.AreSame(manager, AudioManager.Instance);
-        Assert.GreaterOrEqual(manager.GetComponents<AudioSource>().Length, 3);
+        Assert.GreaterOrEqual(manager.GetComponents<AudioSource>().Length, 4);
         Assert.AreEqual(1f, manager.MasterVolume);
         Assert.AreEqual(1f, manager.MusicVolume);
         Assert.AreEqual(1f, manager.SfxVolume);
@@ -87,6 +87,7 @@ public sealed class AudioManagerTests
         Assert.AreEqual(0.875f, snapshot.VideoVolume);
         Assert.AreEqual(0.65625f, manager.EffectiveVideoVolume);
         Assert.AreEqual(0.375f, GetAudioSource(manager, "sfxSource").volume);
+        Assert.AreEqual(0.375f, GetAudioSource(manager, "messageSource").volume);
     }
 
     [Test]

--- a/Assets/Tests/EditMode/GameTests/Managers/AudioManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/AudioManagerTests.cs
@@ -25,7 +25,7 @@ public sealed class AudioManagerTests
 
         Assert.IsNotNull(manager);
         Assert.AreSame(manager, AudioManager.Instance);
-        Assert.GreaterOrEqual(manager.GetComponents<AudioSource>().Length, 4);
+        Assert.GreaterOrEqual(manager.GetComponents<AudioSource>().Length, 3);
         Assert.AreEqual(1f, manager.MasterVolume);
         Assert.AreEqual(1f, manager.MusicVolume);
         Assert.AreEqual(1f, manager.SfxVolume);
@@ -87,7 +87,6 @@ public sealed class AudioManagerTests
         Assert.AreEqual(0.875f, snapshot.VideoVolume);
         Assert.AreEqual(0.65625f, manager.EffectiveVideoVolume);
         Assert.AreEqual(0.375f, GetAudioSource(manager, "sfxSource").volume);
-        Assert.AreEqual(0.375f, GetAudioSource(manager, "messageSource").volume);
     }
 
     [Test]
@@ -178,6 +177,97 @@ public sealed class AudioManagerTests
             GetLoadedSfx(manager).Add("Audio/SFX/Missing/retained_on_demand", clip);
 
             Assert.DoesNotThrow(() => manager.PlaySfx(" Audio/SFX/Missing/retained_on_demand "));
+        }
+        finally
+        {
+            Object.DestroyImmediate(clip);
+        }
+    }
+
+    [Test]
+    public void PlaySfxInstance_PreloadedPaths_UsesIndependentSources()
+    {
+        AudioManager manager = AudioManager.EnsureExists();
+        AudioClip firstClip = AudioClip.Create("First", 1, 1, 44100, false);
+        AudioClip secondClip = AudioClip.Create("Second", 1, 1, 44100, false);
+        try
+        {
+            GetPreloadedSfx(manager).Add("Audio/SFX/first", firstClip);
+            GetPreloadedSfx(manager).Add("Audio/SFX/second", secondClip);
+
+            AudioPlaybackHandle firstPlayback = manager.PlaySfxInstance("Audio/SFX/first");
+            AudioPlaybackHandle secondPlayback = manager.PlaySfxInstance("Audio/SFX/second");
+
+            Assert.AreSame(firstClip, firstPlayback.Source.clip);
+            Assert.AreSame(secondClip, secondPlayback.Source.clip);
+            Assert.AreNotSame(firstPlayback.Source, secondPlayback.Source);
+
+            firstPlayback.Stop();
+
+            Assert.IsNull(firstPlayback.Source);
+            Assert.AreSame(secondClip, secondPlayback.Source.clip);
+            secondPlayback.Stop();
+        }
+        finally
+        {
+            Object.DestroyImmediate(firstClip);
+            Object.DestroyImmediate(secondClip);
+        }
+    }
+
+    [Test]
+    public void PlaySfxInstance_ReusedSource_AppliesCurrentSfxVolume()
+    {
+        AudioManager manager = AudioManager.EnsureExists();
+        AudioClip clip = AudioClip.Create("Tracked", 1, 1, 44100, false);
+        try
+        {
+            GetPreloadedSfx(manager).Add("Audio/SFX/tracked", clip);
+            AudioPlaybackHandle firstPlayback = manager.PlaySfxInstance("Audio/SFX/tracked");
+            AudioSource source = firstPlayback.Source;
+            firstPlayback.Stop();
+            manager.SetMasterVolume(0.5f);
+            manager.SetSfxVolume(0.25f);
+
+            AudioPlaybackHandle secondPlayback = manager.PlaySfxInstance("Audio/SFX/tracked");
+
+            Assert.AreSame(source, secondPlayback.Source);
+            Assert.AreEqual(0.125f, secondPlayback.Source.volume);
+            secondPlayback.Stop();
+        }
+        finally
+        {
+            Object.DestroyImmediate(clip);
+        }
+    }
+
+    [Test]
+    public void PlaySfxInstance_MissingClipOrPath_ReturnsNull()
+    {
+        AudioManager manager = AudioManager.EnsureExists();
+
+        AudioPlaybackHandle clipPlayback = manager.PlaySfxInstance((AudioClip)null);
+        AudioPlaybackHandle pathPlayback = manager.PlaySfxInstance(" ");
+
+        Assert.IsNull(clipPlayback);
+        Assert.IsNull(pathPlayback);
+    }
+
+    [Test]
+    public void StopSfx_ActiveSfxInstances_StopsEveryInstance()
+    {
+        AudioManager manager = AudioManager.EnsureExists();
+        AudioClip clip = AudioClip.Create("Tracked", 1, 1, 44100, false);
+        try
+        {
+            GetPreloadedSfx(manager).Add("Audio/SFX/tracked", clip);
+            AudioPlaybackHandle firstPlayback = manager.PlaySfxInstance("Audio/SFX/tracked");
+            AudioPlaybackHandle secondPlayback = manager.PlaySfxInstance("Audio/SFX/tracked");
+
+            manager.StopSfx();
+
+            Assert.IsNull(firstPlayback.Source);
+            Assert.IsNull(secondPlayback.Source);
         }
         finally
         {

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -77,6 +77,59 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
+        public void ReconcileLoadedState_ContestedPlayerFleet_RestoresPendingCombat()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create()) { CurrentTick = 40 };
+            Faction alliance = new Faction
+            {
+                InstanceID = "FNALL1",
+                DisplayName = "Alliance",
+                PlayerID = "player",
+            };
+            Faction empire = new Faction { InstanceID = "FNEMP1", DisplayName = "Empire" };
+            game.GetFactions().Add(alliance);
+            game.GetFactions().Add(empire);
+            PlanetSector sector = new PlanetSector { InstanceID = "SECTOR" };
+            game.AttachNode(sector, game.GetGalaxyMap());
+            Planet planet = CreatePlanet("PLANET", empire.InstanceID, 0);
+            game.AttachNode(planet, sector);
+            CreateCombatFleet(
+                game,
+                "ALLIANCE_FLEET",
+                alliance.InstanceID,
+                planet,
+                hullStrength: 1000,
+                weaponPower: 100
+            );
+            CreateCombatFleet(
+                game,
+                "EMPIRE_FLEET",
+                empire.InstanceID,
+                planet,
+                hullStrength: 1000,
+                weaponPower: 100
+            );
+            GameManager manager = TestContent.CreateGameManager(game);
+            int decisionsRequired = 0;
+            int completedTicks = 0;
+            manager.CombatDecisionRequired += () => decisionsRequired++;
+            manager.TickCompleted += () => completedTicks++;
+
+            manager.ReconcileLoadedState();
+
+            Assert.AreEqual(40, game.CurrentTick);
+            Assert.IsTrue(manager.SpaceCombatSystem.HasPendingDecision);
+            Assert.IsFalse(manager.IsTickSettled);
+            Assert.AreEqual(1, decisionsRequired);
+
+            manager.ResolveCombat(true);
+
+            Assert.AreEqual(40, game.CurrentTick);
+            Assert.AreEqual(1, completedTicks);
+            Assert.IsTrue(manager.IsTickSettled);
+        }
+
+        [Test]
         public void ProcessFactionAutomation_ManageNaming_AssignsNameImmediately()
         {
             GameRoot game = new GameRoot();
@@ -669,7 +722,7 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
-        public void ProcessTick_PendingCombat_CompletesOnlyStartedTick()
+        public void ProcessTick_PendingCombat_CompletesTickAfterResolution()
         {
             GameRoot game = new GameRoot(TestConfig.Create());
             Faction alliance = new Faction
@@ -724,7 +777,13 @@ namespace Rebellion.Tests.Managers
             manager.ProcessTick();
 
             Assert.AreEqual(pendingCombatTick, game.CurrentTick);
+            Assert.AreEqual(0, completedTicks);
+            Assert.IsFalse(manager.IsTickSettled);
+
+            manager.ResolveCombat(true);
+
             Assert.AreEqual(1, completedTicks);
+            Assert.IsTrue(manager.IsTickSettled);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/GameEventSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/GameEventSystemTests.cs
@@ -147,6 +147,41 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void ValidateEvents_DependencyCompletedAndRemovedFromPool_DoesNotThrow()
+        {
+            GameEvent gameEvent = new GameEvent
+            {
+                InstanceID = "FOLLOW_UP",
+                Schedule = new GameEventScheduler
+                {
+                    After = new AfterEvent { EventInstanceID = "COMPLETED_EVENT", DelayTicks = 10 },
+                },
+            };
+            _game.EventRuntime.GetState("COMPLETED_EVENT").IsComplete = true;
+
+            Assert.DoesNotThrow(() => _system.ValidateEvents(new[] { gameEvent }));
+        }
+
+        [Test]
+        public void ValidateEvents_DependencyMissingFromPoolAndNotCompleted_ThrowsInvalidOperationException()
+        {
+            GameEvent gameEvent = new GameEvent
+            {
+                InstanceID = "FOLLOW_UP",
+                Schedule = new GameEventScheduler
+                {
+                    After = new AfterEvent { EventInstanceID = "UNKNOWN_EVENT", DelayTicks = 10 },
+                },
+            };
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                _system.ValidateEvents(new[] { gameEvent })
+            );
+
+            StringAssert.Contains("references unknown event 'UNKNOWN_EVENT'", exception.Message);
+        }
+
+        [Test]
         public void ProcessEvents_UnmetOneShotEvent_RemainsPending()
         {
             GameEvent gameEvent = CreateTickEvent("PENDING", targetTick: 10, repeatable: false);

--- a/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
@@ -3499,6 +3499,94 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void TrySetFleetWaypointRoute_CapitalShip_CreatesFleetAndCompletesRoute()
+        {
+            (
+                _,
+                _,
+                Planet firstDestination,
+                Planet secondDestination,
+                Fleet sourceFleet,
+                MovementSystem movement
+            ) = BuildWaypointScene();
+            CapitalShip ship = sourceFleet.GetChildren<CapitalShip>().Single();
+
+            bool routeSet = movement.TrySetFleetWaypointRoute(
+                new ISceneNode[] { ship },
+                new[] { firstDestination.InstanceID, secondDestination.InstanceID },
+                "empire"
+            );
+
+            Fleet routeFleet = ship.GetParentOfType<Fleet>();
+            Assert.IsTrue(routeSet);
+            Assert.AreNotSame(sourceFleet, routeFleet);
+            Assert.IsNull(sourceFleet.GetParent());
+            Assert.AreSame(firstDestination, routeFleet.GetParent());
+            Assert.IsNotNull(ship.Movement);
+            CollectionAssert.AreEqual(
+                new[] { firstDestination.InstanceID, secondDestination.InstanceID },
+                routeFleet.Waypoints
+            );
+
+            ship.Movement.TicksElapsed = ship.Movement.TransitTicks - 1;
+            movement.ProcessTick();
+            movement.ContinueFleetWaypointRoutes();
+
+            Assert.IsNotNull(routeFleet.Movement);
+            Assert.AreSame(secondDestination, routeFleet.GetParent());
+            CollectionAssert.AreEqual(new[] { secondDestination.InstanceID }, routeFleet.Waypoints);
+
+            routeFleet.Movement.TicksElapsed = routeFleet.Movement.TransitTicks - 1;
+            List<GameResult> finalResults = movement.ProcessTick();
+
+            FleetWaypointsCompletedResult completed = finalResults
+                .OfType<FleetWaypointsCompletedResult>()
+                .Single();
+            Assert.AreSame(routeFleet, completed.Fleet);
+            Assert.AreSame(secondDestination, completed.Destination);
+            Assert.IsEmpty(routeFleet.Waypoints);
+        }
+
+        [Test]
+        public void TrySetFleetWaypointRoute_CapitalShipUnderConstruction_PreservesRouteUntilComplete()
+        {
+            (
+                _,
+                _,
+                Planet firstDestination,
+                Planet secondDestination,
+                Fleet sourceFleet,
+                MovementSystem movement
+            ) = BuildWaypointScene();
+            CapitalShip ship = sourceFleet.GetChildren<CapitalShip>().Single();
+            ship.ManufacturingStatus = ManufacturingStatus.Building;
+
+            bool routeSet = movement.TrySetFleetWaypointRoute(
+                new ISceneNode[] { ship },
+                new[] { firstDestination.InstanceID, secondDestination.InstanceID },
+                "empire"
+            );
+            Fleet routeFleet = ship.GetParentOfType<Fleet>();
+            List<GameResult> buildingResults = movement.ContinueFleetWaypointRoutes();
+
+            Assert.IsTrue(routeSet);
+            Assert.IsEmpty(buildingResults);
+            Assert.AreSame(firstDestination, routeFleet.GetParent());
+            Assert.IsNull(routeFleet.Movement);
+            CollectionAssert.AreEqual(
+                new[] { firstDestination.InstanceID, secondDestination.InstanceID },
+                routeFleet.Waypoints
+            );
+
+            ship.ManufacturingStatus = ManufacturingStatus.Complete;
+            movement.ContinueFleetWaypointRoutes();
+
+            Assert.IsNotNull(routeFleet.Movement);
+            Assert.AreSame(secondDestination, routeFleet.GetParent());
+            CollectionAssert.AreEqual(new[] { secondDestination.InstanceID }, routeFleet.Waypoints);
+        }
+
+        [Test]
         public void CanSetFleetWaypointRoute_ValidRoute_DoesNotMutateFleet()
         {
             (
@@ -3519,6 +3607,31 @@ namespace Rebellion.Tests.Sectors
             Assert.IsTrue(canSetRoute);
             Assert.AreSame(origin, fleet.GetParent());
             Assert.IsNull(fleet.Movement);
+            Assert.IsEmpty(fleet.Waypoints);
+        }
+
+        [Test]
+        public void CanSetFleetWaypointRoute_CapitalShip_DoesNotChangeFleetMembership()
+        {
+            (
+                _,
+                _,
+                Planet firstDestination,
+                Planet secondDestination,
+                Fleet fleet,
+                MovementSystem movement
+            ) = BuildWaypointScene();
+            CapitalShip ship = fleet.GetChildren<CapitalShip>().Single();
+
+            bool canSetRoute = movement.CanSetFleetWaypointRoute(
+                new ISceneNode[] { ship },
+                new[] { firstDestination.InstanceID, secondDestination.InstanceID },
+                "empire"
+            );
+
+            Assert.IsTrue(canSetRoute);
+            Assert.AreSame(fleet, ship.GetParent());
+            Assert.IsNull(ship.Movement);
             Assert.IsEmpty(fleet.Waypoints);
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsMenuControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsMenuControllerTests.cs
@@ -423,6 +423,15 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 () => new Vector2Int(12, 34),
                 _windowManager.DestroyWindow,
                 _bootstrap,
+                (fileName, displayName) =>
+                {
+                    GameRoot game = _bootstrap.GetRuntime().GetActiveGame();
+                    if (game == null)
+                        return false;
+
+                    _saveGameManager.SaveGameData(game, fileName, displayName);
+                    return true;
+                },
                 fileName =>
                 {
                     _loadedFileName = fileName;

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsMenuViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsMenuViewTests.cs
@@ -193,6 +193,38 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
         }
 
         /// <summary>
+        /// Verifies an unsettled simulation disables overwriting the selected save.
+        /// </summary>
+        [Test]
+        public void SaveLoadPage_UnsettledGame_DisablesSaveButton()
+        {
+            OptionsMenuRenderData data = new OptionsMenuRenderData(
+                0,
+                0,
+                OptionsMenuTab.SaveLoad,
+                string.Empty,
+                string.Empty,
+                new Dictionary<UserTacticalOption, bool>(),
+                Array.Empty<float>(),
+                Array.Empty<OptionsBindingRow>(),
+                new[] { new OptionsSaveSlot("Save", "Today", null, false, "save") },
+                0,
+                true,
+                false,
+                -1,
+                false
+            );
+
+            _view.Render(data);
+
+            Button saveButton = (Button)
+                typeof(OptionsSaveListView)
+                    .GetField("_saveButton", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(_saveListView);
+            Assert.IsFalse(saveButton.interactable);
+        }
+
+        /// <summary>
         /// Verifies autosave numbers render in directly editable integer fields.
         /// </summary>
         [Test]
@@ -213,6 +245,7 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 Array.Empty<OptionsBindingRow>(),
                 Array.Empty<OptionsSaveSlot>(),
                 -1,
+                true,
                 true,
                 -1,
                 false,
@@ -269,6 +302,7 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 Array.Empty<OptionsBindingRow>(),
                 Array.Empty<OptionsSaveSlot>(),
                 -1,
+                true,
                 true,
                 -1,
                 false,
@@ -694,6 +728,7 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 Array.Empty<OptionsSaveSlot>(),
                 -1,
                 false,
+                false,
                 -1,
                 false
             );
@@ -738,6 +773,7 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 },
                 Array.Empty<OptionsSaveSlot>(),
                 -1,
+                true,
                 true,
                 -1,
                 false
@@ -796,6 +832,7 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 bindings ?? Array.Empty<OptionsBindingRow>(),
                 saveSlots ?? Array.Empty<OptionsSaveSlot>(),
                 -1,
+                true,
                 true,
                 -1,
                 false

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowViewTests.cs
@@ -141,7 +141,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Combat
             Assert.IsFalse(title.GetComponent<Shadow>().enabled);
             Assert.AreEqual("Victory", summary.text);
             Assert.AreEqual(
-                new RectInt(25, 225, 350, 70),
+                new RectInt(25, 215, 350, 70),
                 UILayout.GetSourceRect(summary.rectTransform)
             );
             Assert.AreEqual(18f, summary.fontSize);

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowProjectorTests.cs
@@ -217,6 +217,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
             Assert.IsNull(card.DamagedOverlayTexture);
             Assert.IsNotNull(card.BackgroundTexture);
             Assert.IsNotNull(card.EntityTexture);
+            Assert.IsTrue(card.HideBackgroundWhenSelected);
             Assert.IsFalse(card.CanDrag);
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowRenderDataTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowRenderDataTests.cs
@@ -113,6 +113,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
                 null,
                 null,
                 null,
+                false,
                 false
             );
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowViewTests.cs
@@ -104,6 +104,35 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
         }
 
         [Test]
+        public void RenderItemSelection_UnderConstructionItem_ReplacesConstructionBackground()
+        {
+            _view.Render(
+                CreateRenderData(
+                    DefenseWindowTab.Starfighters,
+                    new[]
+                    {
+                        CreateItem(
+                            "Fighter Squadron",
+                            backgroundTexture: _backgroundTexture,
+                            hideBackgroundWhenSelected: true
+                        ),
+                    }
+                )
+            );
+            StrategyUnitCardView card = FindItemCards()[0];
+
+            _view.RenderItemSelection(new[] { 0 }, _texture);
+
+            Assert.IsFalse(FindCardObject(card, "BackgroundImage").activeSelf);
+            Assert.IsTrue(FindCardObject(card, "SelectionImage").activeSelf);
+
+            _view.RenderItemSelection(Array.Empty<int>(), _texture);
+
+            Assert.IsTrue(FindCardObject(card, "BackgroundImage").activeSelf);
+            Assert.IsFalse(FindCardObject(card, "SelectionImage").activeSelf);
+        }
+
+        [Test]
         public void Render_InvalidTabCount_ThrowsArgumentException()
         {
             DefenseWindowRenderData data = new DefenseWindowRenderData(
@@ -518,7 +547,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
             bool canDrag = false,
             bool showOptionalImages = false,
             bool alternateNameLayout = false,
-            Texture backgroundTexture = null
+            Texture backgroundTexture = null,
+            bool hideBackgroundWhenSelected = false
         )
         {
             Texture optionalTexture = showOptionalImages ? _texture : null;
@@ -538,6 +568,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
                 optionalTexture,
                 optionalTexture,
                 optionalTexture,
+                hideBackgroundWhenSelected,
                 canDrag
             );
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Facility/FacilityWindowContextMenuBuilderTests.cs
@@ -88,7 +88,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
             );
             Assert.IsTrue(reserve.Enabled);
             Assert.AreEqual(StrategyContextMenuIconKeys.None, reserve.IconKey);
-            Assert.IsTrue(reserve.UsesIconColumn);
+            Assert.IsFalse(reserve.UsesIconColumn);
         }
 
         [TestCase(FacilityWindowTab.Shipyards, ManufacturingType.Ship)]
@@ -114,6 +114,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Facility
                 command.Action == StrategyMenuAction.Reserve
             );
             Assert.AreEqual(StrategyContextMenuIconKeys.CheckMark, reserve.IconKey);
+            Assert.IsTrue(reserve.UsesIconColumn);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Finder/FinderWindowRowBuilderTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Finder/FinderWindowRowBuilderTests.cs
@@ -419,7 +419,61 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Finder
                 FinderWindowTab.Faction(_playerFactionId, "Player")
             );
 
-            Assert.AreEqual("Retired Officer - Unknown ( Retired )", rows.Single().Name);
+            Assert.AreEqual("Retired Officer - Location Unknown ( Retired )", rows.Single().Name);
+        }
+
+        [Test]
+        public void GetRows_DisabledPlayerPersonnelOutsideGalaxy_IncludesOwnedOfficer()
+        {
+            Officer inactiveOfficer = new Officer
+            {
+                InstanceID = "inactive-officer",
+                DisplayName = "Inactive Officer",
+                DisplayStatus = "Away on an event",
+                OwnerInstanceID = _playerFactionId,
+                IsEnabled = false,
+            };
+            _playerFaction.AddOwnedUnit(inactiveOfficer);
+
+            List<FinderWindowRow> rows = _builder.GetRows(
+                FinderMode.Personnel,
+                false,
+                FinderWindowTab.Faction(_playerFactionId, "Player")
+            );
+
+            Assert.AreEqual(
+                "Inactive Officer - Location Unknown ( On Mission )",
+                rows.Single().Name
+            );
+        }
+
+        [Test]
+        public void GetRows_DisabledPlayerPersonnelOnPlanet_HidesLocationAndNavigation()
+        {
+            Officer inactiveOfficer = new Officer
+            {
+                InstanceID = "inactive-officer",
+                DisplayName = "Inactive Officer",
+                DisplayStatus = "On Mission",
+                OwnerInstanceID = _playerFactionId,
+                IsEnabled = false,
+            };
+            _alpha.AddTestChild(inactiveOfficer);
+            _playerFaction.AddOwnedUnit(inactiveOfficer);
+
+            FinderWindowRow row = _builder
+                .GetRows(
+                    FinderMode.Personnel,
+                    false,
+                    FinderWindowTab.Faction(_playerFactionId, "Player")
+                )
+                .Single();
+
+            Assert.AreEqual("Inactive Officer - Location Unknown ( On Mission )", row.Name);
+            Assert.IsNull(row.Planet);
+            Assert.AreEqual(PlanetIcon.None, row.TargetIcon);
+            Assert.IsNull(row.Fleet);
+            Assert.IsNull(row.Mission);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowContextMenuBuilderTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowContextMenuBuilderTests.cs
@@ -214,6 +214,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
                 {
                     StrategyMenuAction.Move,
                     StrategyMenuAction.MoveConfirm,
+                    StrategyMenuAction.WaypointMove,
                     StrategyMenuAction.CreateFleet,
                     StrategyMenuAction.Rename,
                     StrategyMenuAction.Encyclopedia,
@@ -244,6 +245,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             Assert.IsTrue(commands[0].Enabled);
             Assert.IsTrue(commands[1].Enabled);
             Assert.IsTrue(commands[2].Enabled);
+            Assert.IsTrue(commands[3].Enabled);
             Assert.AreEqual(StrategyMenuAction.Stop, commands.Last().Action);
             Assert.AreEqual("Stop", commands.Last().Text);
             Assert.IsTrue(commands.Last().Enabled);
@@ -268,6 +270,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             Assert.IsFalse(commands[0].Enabled);
             Assert.IsFalse(commands[1].Enabled);
             Assert.IsFalse(commands[2].Enabled);
+            Assert.IsFalse(commands[3].Enabled);
             Assert.IsFalse(commands.Last().Enabled);
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowControllerTests.cs
@@ -237,7 +237,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
         }
 
         [Test]
-        public void FleetListDrop_ActiveTargeting_SelectsCurrentFleet()
+        public void FleetListDrop_ActiveTargeting_SelectsRepresentedPlanet()
         {
             FleetWindowView view = OpenWindow(out UIWindow window);
             UIComponentTestHelper.InvokeLifecycle(view, "Awake");
@@ -254,8 +254,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             Assert.IsInstanceOf<StrategyMissionTarget>(receiver.Target);
             StrategyMissionTarget target = (StrategyMissionTarget)receiver.Target;
             Assert.AreSame(_planet, target.Planet);
-            Assert.AreSame(_fleet, target.Item);
-            Assert.AreSame(_fleet, target.GetMoveDestination());
+            Assert.IsNull(target.Item);
+            Assert.AreSame(_planet.Planet, target.GetMoveDestination());
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowProjectorTests.cs
@@ -227,6 +227,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             Assert.IsNotNull(card.EntityTexture);
             Assert.IsNull(card.EnrouteOverlayTexture);
             Assert.IsNull(card.DamagedOverlayTexture);
+            Assert.IsTrue(card.HideBackgroundWhenSelected);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowRenderDataTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowRenderDataTests.cs
@@ -225,6 +225,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
                 null,
                 null,
                 null,
+                false,
                 true
             );
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowViewTests.cs
@@ -379,7 +379,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
         }
 
         [Test]
-        public void ScrollGestures_BothScrollAreas_RaiseSharedAndFleetListEvents()
+        public void ScrollGestures_BothScrollAreas_RaiseTheirDestinationEvents()
         {
             _view.Render(
                 CreateRenderData(
@@ -392,9 +392,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             int draggedCount = 0;
             int endedCount = 0;
             int destinationDropCount = 0;
+            int fleetListDropCount = 0;
             _view.ScrollDragged += (_, _) => draggedCount++;
             _view.ScrollDragEnded += (_, _) => endedCount++;
             _view.FleetDestinationDropped += (_, _) => destinationDropCount++;
+            _view.FleetListDropped += (_, _) => fleetListDropCount++;
             ScrollAreaView fleetScrollArea = FindFleetRows()[0]
                 .GetComponentInParent<ScrollAreaView>();
             ScrollAreaView detailScrollArea = FindDetailItems()[0]
@@ -409,7 +411,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
 
             Assert.AreEqual(2, draggedCount);
             Assert.AreEqual(2, endedCount);
-            Assert.AreEqual(2, destinationDropCount);
+            Assert.AreEqual(1, destinationDropCount);
+            Assert.AreEqual(1, fleetListDropCount);
         }
 
         [Test]
@@ -726,6 +729,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
                 optionalTexture,
                 optionalTexture,
                 optionalTexture,
+                false,
                 true
             );
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapProjectorTests.cs
@@ -7,6 +7,8 @@ using Rebellion.Game.Encyclopedia;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Movement;
+using Rebellion.Game.Units;
+using Rebellion.SceneGraph;
 using UnityEngine;
 using GalaxyPlanetSector = Rebellion.Game.Galaxy.PlanetSector;
 using GameFleet = Rebellion.Game.Units.Fleet;
@@ -136,6 +138,46 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             Assert.AreEqual(new Vector2Int(48, 58), routes[0].Waypoints[0].Position);
             Assert.IsEmpty(fleet.Waypoints);
             Assert.IsNull(fleet.Movement);
+        }
+
+        [Test]
+        public void ProjectWaypointRoutes_CapitalShipPlan_ReturnsSourceFleetPreview()
+        {
+            GalaxyPlanetSector sector = CreateSector("sector", "Sector", 0, 0);
+            Planet origin = CreatePlanet("origin", _playerFactionId, 10, 20);
+            Planet destination = CreatePlanet("destination", _playerFactionId, 40, 50);
+            _game.AttachNode(sector, _game.GetGalaxyMap());
+            _game.AttachNode(origin, sector);
+            _game.AttachNode(destination, sector);
+            GameFleet fleet = new GameFleet(_playerFactionId, "Player Fleet");
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "capital-ship",
+                OwnerInstanceID = _playerFactionId,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            _game.AttachNode(fleet, origin);
+            _game.AttachNode(ship, fleet);
+            StrategyWindowTargetingSource plan = new StrategyWindowTargetingSource(
+                null,
+                StrategyMenuAction.WaypointMove,
+                0,
+                0,
+                new ISceneNode[] { ship }
+            );
+            plan.TryAppendWaypoint(destination.InstanceID);
+
+            List<GalaxyMapWaypointRouteRenderData> routes = _projector.ProjectWaypointRoutes(
+                _playerFactionId,
+                plan
+            );
+
+            Assert.AreEqual(1, routes.Count);
+            Assert.AreEqual(fleet.InstanceID, routes[0].FleetInstanceId);
+            Assert.AreEqual(new Vector2Int(18, 28), routes[0].Origin);
+            Assert.AreEqual(new Vector2Int(48, 58), routes[0].Waypoints[0].Position);
+            Assert.AreSame(fleet, ship.GetParent());
+            Assert.IsEmpty(fleet.Waypoints);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Messages/MessagesWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Messages/MessagesWindowControllerTests.cs
@@ -233,6 +233,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
                 UIWindowManager windowManager = root.GetComponentInChildren<UIWindowManager>(true);
                 MessagesWindowController controller = new MessagesWindowController(
                     _ => { },
+                    _ => { },
+                    () => { },
                     () => uiContext,
                     windowLayer,
                     windowManager,
@@ -293,6 +295,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
                 UIWindowManager windowManager = root.GetComponentInChildren<UIWindowManager>(true);
                 MessagesWindowController controller = new MessagesWindowController(
                     _ => { },
+                    _ => { },
+                    () => { },
                     () => uiContext,
                     windowLayer,
                     windowManager,
@@ -346,6 +350,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
                 UIWindowManager windowManager = root.GetComponentInChildren<UIWindowManager>(true);
                 MessagesWindowController controller = new MessagesWindowController(
                     _ => { },
+                    _ => { },
+                    () => { },
                     () => uiContext,
                     windowLayer,
                     windowManager,

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Messages/MessagesWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Messages/MessagesWindowControllerTests.cs
@@ -18,7 +18,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
             "Assets/Prefabs/UI/StrategyView/StrategyViewRoot.prefab";
 
         [Test]
-        public void GetDetailAudioPaths_MessageAndOfficerPaths_ReturnsPlaybackOrder()
+        public void GetDetailAudioPaths_MessageAndOfficerPaths_ReturnsBothPaths()
         {
             Message message = new StatusMessage(MessageType.Fleet, "Fleet Arrived")
             {
@@ -35,7 +35,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
         }
 
         [Test]
-        public void GetDetailAudioPaths_MissingMessage_ReturnsEmptyPlaybackOrder()
+        public void GetDetailAudioPaths_MissingMessage_ReturnsEmptyCollection()
         {
             IReadOnlyList<string> paths = MessagesWindowController.GetDetailAudioPaths(null);
 
@@ -43,13 +43,82 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
         }
 
         [Test]
-        public void GetDetailAudioPaths_EmptyPaths_ReturnsEmptyPlaybackOrder()
+        public void GetDetailAudioPaths_EmptyPaths_ReturnsEmptyCollection()
         {
             Message message = new StatusMessage(MessageType.Fleet, "Fleet Arrived");
 
             IReadOnlyList<string> paths = MessagesWindowController.GetDetailAudioPaths(message);
 
             Assert.IsEmpty(paths);
+        }
+
+        [Test]
+        public void PlayMessageDetailAudio_NewMessage_StopsPreviousAudioAndStartsCurrentAudio()
+        {
+            DestroyAudioManagers();
+            AudioManager audioManager = AudioManager.EnsureExists();
+            AudioClip firstBackground = AudioClip.Create("FirstBackground", 1, 1, 44100, false);
+            AudioClip firstVoice = AudioClip.Create("FirstVoice", 1, 1, 44100, false);
+            AudioClip secondBackground = AudioClip.Create("SecondBackground", 1, 1, 44100, false);
+            Dictionary<string, AudioClip> clips = new Dictionary<string, AudioClip>
+            {
+                ["first-background"] = firstBackground,
+                ["first-voice"] = firstVoice,
+                ["second-background"] = secondBackground,
+            };
+            List<AudioPlaybackHandle> playbacks = new List<AudioPlaybackHandle>();
+            GameObject dependencies = new GameObject("MessagesDependencies");
+
+            try
+            {
+                MessagesWindowController controller = new MessagesWindowController(
+                    _ => { },
+                    path =>
+                    {
+                        AudioPlaybackHandle playback = audioManager.PlaySfxInstance(clips[path]);
+                        playbacks.Add(playback);
+                        return playback;
+                    },
+                    () => null,
+                    dependencies.AddComponent<StrategyWindowLayerView>(),
+                    dependencies.AddComponent<UIWindowManager>(),
+                    () => Vector2Int.zero,
+                    _ => { },
+                    () => { }
+                );
+                Message firstMessage = new StatusMessage(MessageType.Fleet, "First")
+                {
+                    BackgroundAudioPath = "first-background",
+                    OfficerVoicePath = "first-voice",
+                };
+                Message secondMessage = new StatusMessage(MessageType.Fleet, "Second")
+                {
+                    BackgroundAudioPath = "second-background",
+                };
+
+                controller.PlayMessageDetailAudio(firstMessage);
+
+                Assert.AreEqual(2, playbacks.Count);
+                Assert.AreSame(firstBackground, playbacks[0].Source.clip);
+                Assert.AreSame(firstVoice, playbacks[1].Source.clip);
+                Assert.AreNotSame(playbacks[0].Source, playbacks[1].Source);
+
+                controller.PlayMessageDetailAudio(secondMessage);
+
+                Assert.IsNull(playbacks[0].Source);
+                Assert.IsNull(playbacks[1].Source);
+                Assert.AreEqual(3, playbacks.Count);
+                Assert.AreSame(secondBackground, playbacks[2].Source.clip);
+            }
+            finally
+            {
+                audioManager.StopSfx();
+                UnityEngine.Object.DestroyImmediate(firstBackground);
+                UnityEngine.Object.DestroyImmediate(firstVoice);
+                UnityEngine.Object.DestroyImmediate(secondBackground);
+                UnityEngine.Object.DestroyImmediate(dependencies);
+                DestroyAudioManagers();
+            }
         }
 
         [Test]
@@ -233,8 +302,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
                 UIWindowManager windowManager = root.GetComponentInChildren<UIWindowManager>(true);
                 MessagesWindowController controller = new MessagesWindowController(
                     _ => { },
-                    _ => { },
-                    () => { },
+                    _ => null,
                     () => uiContext,
                     windowLayer,
                     windowManager,
@@ -295,8 +363,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
                 UIWindowManager windowManager = root.GetComponentInChildren<UIWindowManager>(true);
                 MessagesWindowController controller = new MessagesWindowController(
                     _ => { },
-                    _ => { },
-                    () => { },
+                    _ => null,
                     () => uiContext,
                     windowLayer,
                     windowManager,
@@ -350,8 +417,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
                 UIWindowManager windowManager = root.GetComponentInChildren<UIWindowManager>(true);
                 MessagesWindowController controller = new MessagesWindowController(
                     _ => { },
-                    _ => { },
-                    () => { },
+                    _ => null,
                     () => uiContext,
                     windowLayer,
                     windowManager,
@@ -380,6 +446,14 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Messages
             finally
             {
                 UnityEngine.Object.DestroyImmediate(root);
+            }
+        }
+
+        private static void DestroyAudioManagers()
+        {
+            foreach (AudioManager manager in UnityEngine.Object.FindObjectsByType<AudioManager>())
+            {
+                UnityEngine.Object.DestroyImmediate(manager.gameObject);
             }
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUnitCardRenderDataTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUnitCardRenderDataTests.cs
@@ -24,6 +24,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                 null,
                 null,
                 null,
+                true,
                 true
             );
 
@@ -32,6 +33,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
             Assert.IsTrue(card.ShowName);
             Assert.IsTrue(card.UseAlternateNameLayout);
             Assert.AreEqual(4, card.EntityFrameYOffset);
+            Assert.IsTrue(card.HideBackgroundWhenSelected);
             Assert.IsTrue(card.CanDrag);
         }
     }


### PR DESCRIPTION
## Summary

- Fixes strategy UI behavior across the Finder, fleet, defense, construction, options, and context-menu views.
- Prevents saves during unsettled ticks and reconciles pending combat when loading a game.
- Corrects capital-ship waypoint planning, fleet-list drops, arrival processing, and combat interruption behavior.
- Sequences message audio without overlap and restores planetary-assault notification playback.
- Supports event-controlled subject imagery and includes hidden player personnel without revealing their physical location.
- Corrects original-game officer stat generation and related presentation details.
- Pairs with davidadas/rebellion2-media#62 for the authored event, data, and artwork changes.

## Validation

- `./build.sh format` passes across 733 files.
- `./build.sh lint` passes with zero compiler, Roslynator, naming, or member-order diagnostics.
- Rebellion analyzer tests pass: 6/6.
- Focused Unity EditMode suites passed during implementation for officer seeding, fleet-list drops, and capital-ship waypoints.
- Both local and media event files validate against `game-events.xsd`.
- The complete Unity suite was not rerun because the active editor session was preserved for manual gameplay verification; pull-request CI will run it.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.