### PR TITLE
Preventing event deactivation during active missions.

### DIFF
--- a/Assets/Scripts/Game/Events/GameActions.cs
+++ b/Assets/Scripts/Game/Events/GameActions.cs
@@ -2407,11 +2407,10 @@ namespace Rebellion.Game.Events
                     && mission.GetParent() != null
                 )
                 {
-                    GameLogger.Warning(
-                        $"SetNodeState ignored deactivation of mission participant "
+                    throw new InvalidOperationException(
+                        $"SetNodeState cannot deactivate mission participant "
                             + $"'{node.InstanceID}' on active mission '{mission.InstanceID}'."
                     );
-                    continue;
                 }
 
                 node.IsEnabled = State == SceneNodeState.Active;

--- a/Assets/Scripts/Game/Events/GameActions.cs
+++ b/Assets/Scripts/Game/Events/GameActions.cs
@@ -2399,7 +2399,23 @@ namespace Rebellion.Game.Events
                 );
 
             foreach (ISceneNode node in nodes)
+            {
+                if (
+                    State == SceneNodeState.Inactive
+                    && node is IMissionParticipant
+                    && node.GetParent() is Mission mission
+                    && mission.GetParent() != null
+                )
+                {
+                    GameLogger.Warning(
+                        $"SetNodeState ignored deactivation of mission participant "
+                            + $"'{node.InstanceID}' on active mission '{mission.InstanceID}'."
+                    );
+                    continue;
+                }
+
                 node.IsEnabled = State == SceneNodeState.Active;
+            }
             return;
         }
     }

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
@@ -435,7 +435,7 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
-        public void SetNodeState_InactiveMissionParticipant_DoesNotDisableOfficer()
+        public void SetNodeState_InactiveMissionParticipant_ThrowsInvalidOperationException()
         {
             GameRoot game = BuildGame(out _, out Planet rebelPlanet);
             Officer officer = EntityFactory.CreateOfficer("officer", "rebels");
@@ -450,12 +450,13 @@ namespace Rebellion.Tests.Game.Events
             game.MoveNode(officer, mission);
             mission.Initiate(100);
 
-            new SetNodeStateAction
+            TestDelegate execute = () => new SetNodeStateAction
             {
                 InstanceID = officer.InstanceID,
                 State = SceneNodeState.Inactive,
             }.Execute(game);
 
+            Assert.Throws<InvalidOperationException>(execute);
             Assert.AreSame(mission, officer.GetParent());
             Assert.IsTrue(officer.IsActive());
         }

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
@@ -450,11 +450,12 @@ namespace Rebellion.Tests.Game.Events
             game.MoveNode(officer, mission);
             mission.Initiate(100);
 
-            TestDelegate execute = () => new SetNodeStateAction
-            {
-                InstanceID = officer.InstanceID,
-                State = SceneNodeState.Inactive,
-            }.Execute(game);
+            TestDelegate execute = () =>
+                new SetNodeStateAction
+                {
+                    InstanceID = officer.InstanceID,
+                    State = SceneNodeState.Inactive,
+                }.Execute(game);
 
             Assert.Throws<InvalidOperationException>(execute);
             Assert.AreSame(mission, officer.GetParent());

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
@@ -435,6 +435,32 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
+        public void SetNodeState_InactiveMissionParticipant_DoesNotDisableOfficer()
+        {
+            GameRoot game = BuildGame(out _, out Planet rebelPlanet);
+            Officer officer = EntityFactory.CreateOfficer("officer", "rebels");
+            DiplomacyMission mission = new DiplomacyMission
+            {
+                InstanceID = "mission",
+                OwnerInstanceID = "rebels",
+                LocationInstanceID = rebelPlanet.InstanceID,
+            };
+            game.AttachNode(officer, rebelPlanet);
+            game.AttachNode(mission, rebelPlanet);
+            game.MoveNode(officer, mission);
+            mission.Initiate(100);
+
+            new SetNodeStateAction
+            {
+                InstanceID = officer.InstanceID,
+                State = SceneNodeState.Inactive,
+            }.Execute(game);
+
+            Assert.AreSame(mission, officer.GetParent());
+            Assert.IsTrue(officer.IsActive());
+        }
+
+        [Test]
         public void SetNodeState_Selector_DisablesEveryMatchingOfficer()
         {
             GameRoot game = BuildGame(out _, out Planet rebelPlanet);


### PR DESCRIPTION
## Summary

- Prevents event actions from deactivating participants attached to active missions.
- Rejects invalid deactivation with `InvalidOperationException`, matching other invalid event-action states.
- Covers the mission-participant guard with a synthetic engine test.
- Pairs with davidadas/rebellion2-media#64, which delays Luke's Dagobah event while he is assigned to a mission.

## Validation

- `dotnet build GameAssembly.csproj --no-restore -m:1`
- `git diff --check`
- The focused Unity test was not executed because the interactive Unity Editor remains open. The generated standalone `GameTests.csproj` reaches the test assembly but cannot resolve Unity's `InputTestFixture` outside the Unity test runner.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. Not applicable; this change does not modify UI builders.
- [x] Content path or structure changes were also made in `rebellion2-media`. The paired content change is davidadas/rebellion2-media#64.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. Not applicable; this is an internal runtime guard.