### PR TITLE
Preventing event failures from crashing the game.

### DIFF
--- a/Assets/Scripts/Game/Events/GameAction.cs
+++ b/Assets/Scripts/Game/Events/GameAction.cs
@@ -36,8 +36,7 @@ namespace Rebellion.Game.Events
                 }
                 catch (Exception exception)
                 {
-                    string eventInstanceId =
-                        context?.Evaluation?.Event?.InstanceID ?? "unknown";
+                    string eventInstanceId = context?.Evaluation?.Event?.InstanceID ?? "unknown";
                     string actionName = action?.GetType().Name ?? "null";
                     GameLogger.Log(
                         $"Event '{eventInstanceId}' action '{actionName}' failed: {exception}",

--- a/Assets/Scripts/Game/Events/GameAction.cs
+++ b/Assets/Scripts/Game/Events/GameAction.cs
@@ -21,12 +21,30 @@ namespace Rebellion.Game.Events
         internal abstract void Execute(GameActionContext context);
 
         /// <summary>
-        /// Executes an ordered action collection against one shared action context.
+        /// Executes an ordered action collection, logging failed actions before continuing with
+        /// the remaining work.
         /// </summary>
+        /// <param name="actions">The actions to execute in authored order.</param>
+        /// <param name="context">The shared event activation context.</param>
         internal static void ExecuteAll(IEnumerable<GameAction> actions, GameActionContext context)
         {
             foreach (GameAction action in actions ?? Enumerable.Empty<GameAction>())
-                action.Execute(context);
+            {
+                try
+                {
+                    action.Execute(context);
+                }
+                catch (Exception exception)
+                {
+                    string eventInstanceId =
+                        context?.Evaluation?.Event?.InstanceID ?? "unknown";
+                    string actionName = action?.GetType().Name ?? "null";
+                    GameLogger.Log(
+                        $"Event '{eventInstanceId}' action '{actionName}' failed: {exception}",
+                        GameLogger.LogLevel.Error
+                    );
+                }
+            }
         }
     }
 

--- a/Assets/Scripts/Systems/GameRequestDispatcher.cs
+++ b/Assets/Scripts/Systems/GameRequestDispatcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Rebellion.Game.Requests;
 using Rebellion.Game.Results;
+using Rebellion.Util.Common;
 
 namespace Rebellion.Systems
 {
@@ -52,7 +53,8 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Executes requests in authored order and returns only their factual results.
+        /// Executes requests in authored order, logging failed requests before continuing, and
+        /// returns only their factual results.
         /// </summary>
         /// <param name="requests">The requests to dispatch.</param>
         /// <returns>The factual results produced by all matching handlers.</returns>
@@ -64,25 +66,36 @@ namespace Rebellion.Systems
                     ?? Enumerable.Empty<GameRequest>()
             )
             {
-                if (
-                    !_handlers.TryGetValue(
-                        request.GetType(),
-                        out Func<GameRequest, List<GameResult>> handler
-                    )
-                )
-                    throw new InvalidOperationException(
-                        $"No request handler is registered for '{request.GetType().Name}'."
-                    );
-
-                List<GameResult> produced = handler(request);
-                if (produced == null)
-                    continue;
-
-                foreach (GameResult result in produced.Where(result => result != null))
+                try
                 {
-                    if (string.IsNullOrWhiteSpace(result.SourceEventInstanceID))
-                        result.SourceEventInstanceID = request.SourceEventInstanceID;
-                    results.Add(result);
+                    if (
+                        !_handlers.TryGetValue(
+                            request.GetType(),
+                            out Func<GameRequest, List<GameResult>> handler
+                        )
+                    )
+                        throw new InvalidOperationException(
+                            $"No request handler is registered for '{request.GetType().Name}'."
+                        );
+
+                    List<GameResult> produced = handler(request);
+                    if (produced == null)
+                        continue;
+
+                    foreach (GameResult result in produced.Where(result => result != null))
+                    {
+                        if (string.IsNullOrWhiteSpace(result.SourceEventInstanceID))
+                            result.SourceEventInstanceID = request.SourceEventInstanceID;
+                        results.Add(result);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    string eventInstanceId = request.SourceEventInstanceID ?? "unknown";
+                    GameLogger.Log(
+                        $"Event '{eventInstanceId}' request '{request.GetType().Name}' failed: {exception}",
+                        GameLogger.LogLevel.Error
+                    );
                 }
             }
             return results;

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using Rebellion.Game;
+using Rebellion.Game.Events;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Rebellion.Tests.Game.Events
+{
+    [TestFixture]
+    public sealed class GameActionTests
+    {
+        [Test]
+        public void ExecuteAll_ActionThrows_ExecutesRemainingActions()
+        {
+            GameRoot game = new GameRoot();
+            GameEvent gameEvent = new GameEvent { InstanceID = "test-event" };
+            GameEventEvaluationContext evaluation = new GameEventEvaluationContext(
+                gameEvent,
+                new GameEventState()
+            );
+            GameActionContext context = new GameActionContext(game, game.Random, evaluation);
+            RecordingAction firstAction = new RecordingAction();
+            RecordingAction finalAction = new RecordingAction();
+            List<GameAction> actions = new List<GameAction>
+            {
+                firstAction,
+                new ThrowingAction(),
+                finalAction,
+            };
+            LogAssert.Expect(
+                LogType.Error,
+                new Regex("Event 'test-event' action 'ThrowingAction' failed:")
+            );
+
+            GameAction.ExecuteAll(actions, context);
+
+            Assert.IsTrue(firstAction.Executed);
+            Assert.IsTrue(finalAction.Executed);
+        }
+
+        private sealed class RecordingAction : GameAction
+        {
+            public bool Executed { get; private set; }
+
+            internal override void Execute(GameActionContext context)
+            {
+                Executed = true;
+            }
+        }
+
+        private sealed class ThrowingAction : GameAction
+        {
+            internal override void Execute(GameActionContext context)
+            {
+                throw new InvalidOperationException("test failure");
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionTests.cs.meta
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a695ed8a61db43749d83a048e91db01e

--- a/Assets/Tests/EditMode/GameTests/Systems/GameRequestDispatcherTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/GameRequestDispatcherTests.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Rebellion.Game.Requests;
 using Rebellion.Game.Results;
 using Rebellion.Systems;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Rebellion.Tests.Systems
 {
@@ -27,24 +30,62 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void Process_UnregisteredRequest_ThrowsInvalidOperationException()
+        public void Process_UnregisteredRequest_ReturnsNoResults()
         {
             GameRequestDispatcher dispatcher = new GameRequestDispatcher();
+            LogAssert.Expect(
+                LogType.Error,
+                new Regex("Event 'unknown' request 'TestRequest' failed:")
+            );
 
-            TestDelegate process = () => dispatcher.Process(new[] { new TestRequest() });
+            List<GameResult> results = dispatcher.Process(new[] { new TestRequest() });
 
-            Assert.Throws<InvalidOperationException>(process);
+            Assert.IsEmpty(results);
         }
 
-        private sealed class TestRequest : GameRequest { }
+        [Test]
+        public void Process_HandlerThrows_ProcessesRemainingRequests()
+        {
+            GameRequestDispatcher dispatcher = new GameRequestDispatcher();
+            dispatcher.Subscribe(new TestRequestHandler());
+            LogAssert.Expect(
+                LogType.Error,
+                new Regex("Event 'failed-event' request 'TestRequest' failed:")
+            );
+
+            List<GameResult> results = dispatcher.Process(
+                new[]
+                {
+                    new TestRequest
+                    {
+                        SourceEventInstanceID = "failed-event",
+                        Throws = true,
+                    },
+                    new TestRequest { SourceEventInstanceID = "successful-event" },
+                }
+            );
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual("successful-event", results[0].SourceEventInstanceID);
+        }
+
+        private sealed class TestRequest : GameRequest
+        {
+            public bool Throws { get; set; }
+        }
 
         private sealed class TestRequestHandler : IGameRequestHandler<TestRequest>
         {
             /// <summary>
             /// Produces one factual result for each test request.
             /// </summary>
-            public List<GameResult> HandleRequests(IReadOnlyList<TestRequest> requests) =>
-                new List<GameResult> { new PlanetStatChangedResult() };
+            public List<GameResult> HandleRequests(IReadOnlyList<TestRequest> requests)
+            {
+                if (requests[0].Throws)
+                    throw new InvalidOperationException("test failure");
+
+                return new List<GameResult> { new PlanetStatChangedResult() };
+            }
         }
     }
 }

--- a/Assets/Tests/EditMode/GameTests/Systems/GameRequestDispatcherTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/GameRequestDispatcherTests.cs
@@ -56,11 +56,7 @@ namespace Rebellion.Tests.Systems
             List<GameResult> results = dispatcher.Process(
                 new[]
                 {
-                    new TestRequest
-                    {
-                        SourceEventInstanceID = "failed-event",
-                        Throws = true,
-                    },
+                    new TestRequest { SourceEventInstanceID = "failed-event", Throws = true },
                     new TestRequest { SourceEventInstanceID = "successful-event" },
                 }
             );


### PR DESCRIPTION
## Summary

- continue executing later event actions when one action fails
- continue dispatching later event requests when one request fails
- log the event ID, failed operation type, exception, and stack trace

## Validation

- `bash build.sh lint`
- `bash build.sh build` (`StandaloneWindows64`, successful)
- Unity EditMode: 74/74 passed (`GameActionTests`, `GameActionsTests`, `GameEventSystemTests`, and `GameRequestDispatcherTests`)
- `dotnet csharpier check Assets/` (735 files)
- `git diff --check`

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. Not applicable; no UI builder changed.
- [x] Content path or structure changes were also made in `rebellion2-media`. Not applicable; no content path or structure changed.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. Not applicable; no user-facing setup or documented contract changed.