### PR TITLE
Restores the original main-menu exit audio

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout media metadata
         uses: actions/checkout@v4
         with:
-          repository: davidadas/rebellion2-media
+          repository: adasgames/rebellion2-media
           ref: main
           ssh-key: ${{ secrets.REBELLION2_MEDIA_SSH_KEY }}
           lfs: false
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout media (git only, no LFS)
         uses: actions/checkout@v4
         with:
-          repository: davidadas/rebellion2-media
+          repository: adasgames/rebellion2-media
           ref: ${{ needs.resolve-media.outputs.revision }}
           ssh-key: ${{ secrets.REBELLION2_MEDIA_SSH_KEY }}
           lfs: false
@@ -254,7 +254,7 @@ jobs:
       - name: Checkout media (git only, no LFS)
         uses: actions/checkout@v4
         with:
-          repository: davidadas/rebellion2-media
+          repository: adasgames/rebellion2-media
           ref: ${{ needs.resolve-media.outputs.revision }}
           ssh-key: ${{ secrets.REBELLION2_MEDIA_SSH_KEY }}
           lfs: false

--- a/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/MainMenu/MainMenuPrefabBuilder.cs
@@ -35,11 +35,11 @@ public static class MainMenuPrefabBuilder
     private const string _empireFactionId = "FNEMP1";
     private const string _rebelFactionId = "FNALL1";
 
-    // Resource paths for the SFX cues authored on the pointer-up event triggers.
+    // Resource paths for the SFX cues authored on pointer event triggers.
     private const string _selectSfxPath = "Application/MainMenu/Audio/select";
-    private const string _exitSelectSfxPath = "Application/MainMenu/Audio/exit-select";
     private const string _galaxySizeSelectSfxPath = "Application/MainMenu/Audio/galaxysize-select";
     private const string _factionSelectSfxPath = "Application/MainMenu/Audio/faction-select";
+    private const string _exitSelectSfxPath = _factionSelectSfxPath;
 
     // Icon turntable speed: one full revolution per second (matched the original 2D flipbook loop).
     private const float _iconTurnDegreesPerSecond = 360f;
@@ -290,7 +290,7 @@ public static class MainMenuPrefabBuilder
     }
 
     /// <summary>
-    /// Collects the authored pointer-up audio-cue bindings in the same control order the prefab
+    /// Collects the authored pointer audio-cue bindings in the same control order the prefab
     /// serializes: the difficulty toggles, galaxy toggles, then the command controls.
     /// </summary>
     /// <param name="root">The prefab root.</param>
@@ -301,32 +301,28 @@ public static class MainMenuPrefabBuilder
         string ResourcePath
     )> CollectAudioCueBindings(GameObject root)
     {
-        (string Name, string ResourcePath)[] order =
+        (string Name, EventTriggerType EventType, string ResourcePath)[] order =
         {
-            ("EasyDifficultyToggle", _selectSfxPath),
-            ("MediumDifficultyToggle", _selectSfxPath),
-            ("HardDifficultyToggle", _selectSfxPath),
-            ("SmallGalaxyToggle", _galaxySizeSelectSfxPath),
-            ("MediumGalaxyToggle", _galaxySizeSelectSfxPath),
-            ("LargeGalaxyToggle", _galaxySizeSelectSfxPath),
-            ("ExitButton", _exitSelectSfxPath),
-            ("CreditsButton", _selectSfxPath),
-            ("LeftFactionLaunchButton", _factionSelectSfxPath),
-            ("RightFactionLaunchButton", _factionSelectSfxPath),
-            ("VictoryConditionButton", _selectSfxPath),
-            ("VictoryConditionIcon", _selectSfxPath),
+            ("EasyDifficultyToggle", EventTriggerType.PointerUp, _selectSfxPath),
+            ("MediumDifficultyToggle", EventTriggerType.PointerUp, _selectSfxPath),
+            ("HardDifficultyToggle", EventTriggerType.PointerUp, _selectSfxPath),
+            ("SmallGalaxyToggle", EventTriggerType.PointerUp, _galaxySizeSelectSfxPath),
+            ("MediumGalaxyToggle", EventTriggerType.PointerUp, _galaxySizeSelectSfxPath),
+            ("LargeGalaxyToggle", EventTriggerType.PointerUp, _galaxySizeSelectSfxPath),
+            ("ExitButton", EventTriggerType.PointerDown, _exitSelectSfxPath),
+            ("CreditsButton", EventTriggerType.PointerUp, _selectSfxPath),
+            ("LeftFactionLaunchButton", EventTriggerType.PointerUp, _factionSelectSfxPath),
+            ("RightFactionLaunchButton", EventTriggerType.PointerUp, _factionSelectSfxPath),
+            ("VictoryConditionButton", EventTriggerType.PointerUp, _selectSfxPath),
+            ("VictoryConditionIcon", EventTriggerType.PointerUp, _selectSfxPath),
         };
 
         List<(EventTrigger Trigger, EventTriggerType EventType, string ResourcePath)> bindings =
             new List<(EventTrigger Trigger, EventTriggerType EventType, string ResourcePath)>();
-        foreach ((string name, string resourcePath) in order)
+        foreach ((string name, EventTriggerType eventType, string resourcePath) in order)
         {
             bindings.Add(
-                (
-                    FindRequiredComponent<EventTrigger>(root, name),
-                    EventTriggerType.PointerUp,
-                    resourcePath
-                )
+                (FindRequiredComponent<EventTrigger>(root, name), eventType, resourcePath)
             );
         }
 
@@ -816,7 +812,11 @@ public static class MainMenuPrefabBuilder
         );
         pressed.GetComponent<RectTransform>().pivot = new Vector2(1f, 1f);
 
-        AddPointerUpTrigger(buttonObject.GetComponent<EventTrigger>(), _exitSelectSfxPath);
+        AddPointerTrigger(
+            buttonObject.GetComponent<EventTrigger>(),
+            EventTriggerType.PointerDown,
+            _exitSelectSfxPath
+        );
     }
 
     /// <summary>
@@ -1112,13 +1112,28 @@ public static class MainMenuPrefabBuilder
     /// <param name="resourcePath">The cue resource path recorded on the view binding.</param>
     private static void AddPointerUpTrigger(EventTrigger trigger, string resourcePath)
     {
+        AddPointerTrigger(trigger, EventTriggerType.PointerUp, resourcePath);
+    }
+
+    /// <summary>
+    /// Adds one authored pointer event-trigger entry with an empty persistent callback.
+    /// </summary>
+    /// <param name="trigger">The event trigger to populate.</param>
+    /// <param name="eventType">The pointer event that emits the cue.</param>
+    /// <param name="resourcePath">The cue resource path recorded on the view binding.</param>
+    private static void AddPointerTrigger(
+        EventTrigger trigger,
+        EventTriggerType eventType,
+        string resourcePath
+    )
+    {
         _ = resourcePath;
         if (trigger.triggers == null)
             trigger.triggers = new List<EventTrigger.Entry>();
         trigger.triggers.Add(
             new EventTrigger.Entry
             {
-                eventID = EventTriggerType.PointerUp,
+                eventID = eventType,
                 callback = new EventTrigger.TriggerEvent(),
             }
         );
@@ -1851,6 +1866,7 @@ public static class MainMenuPrefabBuilder
         foreach ((EventTrigger trigger, EventTriggerType eventType, _) in audioCues)
             AddEventType(eventTypes, trigger, eventType);
         AddEventType(eventTypes, exitTrigger, EventTriggerType.PointerDown);
+        AddEventType(eventTypes, exitTrigger, EventTriggerType.PointerUp);
         AddEventType(eventTypes, exitTrigger, EventTriggerType.PointerExit);
 
         EventTriggerType[] authoredOrder =

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/MainMenu/MainMenuViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/MainMenu/MainMenuViewTests.cs
@@ -360,17 +360,31 @@ namespace Rebellion.Tests.UI.SceneUI.MainMenu
         }
 
         [Test]
-        public void ExitLever_PointerUp_RaisesExitAudioCue()
+        public void ExitLever_PointerDown_RaisesExitAudioCue()
         {
             string requestedPath = null;
             _view.AudioCueRequested += path => requestedPath = path;
 
             InvokeTrigger(
                 GetField<Button>("exitButton").GetComponent<EventTrigger>(),
+                EventTriggerType.PointerDown
+            );
+
+            Assert.AreEqual("Application/MainMenu/Audio/faction-select", requestedPath);
+        }
+
+        [Test]
+        public void ExitLever_PointerUp_DoesNotRaiseAudioCue()
+        {
+            int cueCount = 0;
+            _view.AudioCueRequested += _ => cueCount++;
+
+            InvokeTrigger(
+                GetField<Button>("exitButton").GetComponent<EventTrigger>(),
                 EventTriggerType.PointerUp
             );
 
-            Assert.AreEqual("Application/MainMenu/Audio/exit-select", requestedPath);
+            Assert.AreEqual(0, cueCount);
         }
 
         [Test]
@@ -381,7 +395,6 @@ namespace Rebellion.Tests.UI.SceneUI.MainMenu
                 {
                     "Application/MainMenu/Audio/select",
                     "Application/MainMenu/Audio/galaxysize-select",
-                    "Application/MainMenu/Audio/exit-select",
                     "Application/MainMenu/Audio/faction-select",
                 },
                 _view.GetAudioCuePaths()


### PR DESCRIPTION
## Summary

- Restores the original main-menu exit lever audio.
- Plays the exit cue on pointer-down instead of pointer-up while preserving the lever's release animation.
- Updates the main-menu tests to cover immediate playback and prevent duplicate playback on release.
- Updates CI to resolve media from its transferred `adasgames` repository.

## Validation

- `./build.sh format`
- `./build.sh lint`
- `./build.sh test` — 4,522 passed, 0 failed
- Rebuilt all generated UI through the Unity test command's `UIBuilderMenu.BuildAll` execution.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`. Not applicable; this change reuses existing media.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. No documentation change is required for restoring the original cue behavior.