### PR TITLE
Injecting release versions into Unity builds

### DIFF
--- a/Assets/Editor/Build/StandalonePlayerBuild.cs
+++ b/Assets/Editor/Build/StandalonePlayerBuild.cs
@@ -16,7 +16,7 @@ public static class StandalonePlayerBuild
     private const string _buildTargetArgument = "-buildTarget";
     private const string _buildPlayerPathArgument = "-buildPlayerPath";
     private const string _gameCIBuildPathArgument = "-customBuildPath";
-    private const string _buildVersionEnvironmentVariable = "REB2_BUILD_VERSION";
+    private const string _buildVersionArgument = "-buildVersion";
 
     /// <summary>
     /// Builds an external-content player for the active desktop target from the Unity editor.
@@ -111,7 +111,7 @@ public static class StandalonePlayerBuild
     /// </summary>
     private static void ApplyBuildVersion()
     {
-        string buildVersion = Environment.GetEnvironmentVariable(_buildVersionEnvironmentVariable);
+        string buildVersion = GetOptionalArgument(_buildVersionArgument);
         if (string.IsNullOrWhiteSpace(buildVersion))
             return;
 
@@ -285,6 +285,19 @@ public static class StandalonePlayerBuild
     /// <returns>The non-empty value following the argument.</returns>
     private static string GetRequiredArgument(params string[] arguments)
     {
+        return GetOptionalArgument(arguments)
+            ?? throw new InvalidOperationException(
+                $"Required argument missing: {string.Join(" or ", arguments)}."
+            );
+    }
+
+    /// <summary>
+    /// Reads an optional command-line argument value.
+    /// </summary>
+    /// <param name="arguments">The equivalent argument names to find.</param>
+    /// <returns>The non-empty value following the argument, or null when it is absent.</returns>
+    private static string GetOptionalArgument(params string[] arguments)
+    {
         string[] args = Environment.GetCommandLineArgs();
         for (int i = 0; i < args.Length - 1; i++)
         {
@@ -302,9 +315,7 @@ public static class StandalonePlayerBuild
             }
         }
 
-        throw new InvalidOperationException(
-            $"Required argument missing: {string.Join(" or ", arguments)}."
-        );
+        return null;
     }
 
     /// <summary>

--- a/Assets/Editor/Build/StandalonePlayerBuild.cs
+++ b/Assets/Editor/Build/StandalonePlayerBuild.cs
@@ -16,6 +16,7 @@ public static class StandalonePlayerBuild
     private const string _buildTargetArgument = "-buildTarget";
     private const string _buildPlayerPathArgument = "-buildPlayerPath";
     private const string _gameCIBuildPathArgument = "-customBuildPath";
+    private const string _buildVersionEnvironmentVariable = "REB2_BUILD_VERSION";
 
     /// <summary>
     /// Builds an external-content player for the active desktop target from the Unity editor.
@@ -93,7 +94,28 @@ public static class StandalonePlayerBuild
         string outputPath = ResolveProjectPath(
             GetRequiredArgument(_buildPlayerPathArgument, _gameCIBuildPathArgument)
         );
-        BuildPlayer(target, outputPath);
+        string originalVersion = UnityEditor.PlayerSettings.bundleVersion;
+        try
+        {
+            ApplyBuildVersion();
+            BuildPlayer(target, outputPath);
+        }
+        finally
+        {
+            UnityEditor.PlayerSettings.bundleVersion = originalVersion;
+        }
+    }
+
+    /// <summary>
+    /// Applies the release version supplied by the build environment, when present.
+    /// </summary>
+    private static void ApplyBuildVersion()
+    {
+        string buildVersion = Environment.GetEnvironmentVariable(_buildVersionEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(buildVersion))
+            return;
+
+        UnityEditor.PlayerSettings.bundleVersion = buildVersion.Trim();
     }
 
     /// <summary>

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.0.4
+  bundleVersion: 0.0.3
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.0.2
+  bundleVersion: 0.0.4
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.0.3
+  bundleVersion: 0.0.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
## Summary

- Reads `-buildVersion` during command-line player builds.
- Applies the supplied version only for the build and restores the editor setting afterward.
- Keeps the source-controlled Unity version at the fixed development value `0.0.0`.
- Lets release tags stamp future game versions without source-code version bumps.

## Validation

- `bash build.sh lint` — passed, including compilation, analyzer tests, formatting, naming, Roslynator, and member-order checks.
- [Exact 0.0.3 non-production installer run](https://github.com/adasgames/rebellion2-installers/actions/runs/33342531571) — queued from current installer `main`.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable; no UI changed.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable; no content path changed.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (The installer build documentation is updated on installer main.)