### PR TITLE
Addressing issues where all fleets were not involved with combat.

### DIFF
--- a/Assets/Scripts/Systems/SpaceCombatSystem.cs
+++ b/Assets/Scripts/Systems/SpaceCombatSystem.cs
@@ -672,6 +672,21 @@ namespace Rebellion.Systems
                 result.Planet,
                 result.DefenderOutcome
             );
+            UpdateCombatEncounterWinner(result);
+        }
+
+        /// <summary>
+        /// Aligns the encounter winner with the sides that remain active after resolution.
+        /// </summary>
+        /// <param name="result">The encounter result to update.</param>
+        private static void UpdateCombatEncounterWinner(SpaceCombatResult result)
+        {
+            bool attackerActive = result.AttackerOutcome == SpaceCombatSideOutcome.Active;
+            bool defenderActive = result.DefenderOutcome == SpaceCombatSideOutcome.Active;
+            if (attackerActive == defenderActive)
+                return;
+
+            result.Winner = attackerActive ? CombatSide.Attacker : CombatSide.Defender;
         }
 
         /// <summary>Returns the final destination ID recorded for a withdrawn fleet.</summary>
@@ -809,16 +824,8 @@ namespace Rebellion.Systems
             SpaceCombatResult encounterResult
         )
         {
-            bool attackerRetreated = TryRetreatFleets(
-                attackerFleets,
-                defenderFleets,
-                ignoreGravityWell: true
-            );
-            bool defenderRetreated = TryRetreatFleets(
-                defenderFleets,
-                attackerFleets,
-                ignoreGravityWell: true
-            );
+            TryRetreatFleets(attackerFleets, defenderFleets, ignoreGravityWell: true);
+            TryRetreatFleets(defenderFleets, attackerFleets, ignoreGravityWell: true);
 
             if (!AreForcesContestingPlanet(decision))
                 return;
@@ -832,32 +839,12 @@ namespace Rebellion.Systems
                 defenderFleets,
                 planet
             );
-            bool hasOperationalWeapons =
-                HasOperationalSpaceWeapons(
-                    strandedAttackerFleets,
-                    planet,
-                    decision.AttackerOwnerInstanceID
-                )
-                || HasOperationalSpaceWeapons(
-                    strandedDefenderFleets,
-                    planet,
-                    decision.DefenderOwnerInstanceID
-                );
-            if (!hasOperationalWeapons)
-            {
-                DestroyStalematedForces(
-                    decision,
-                    strandedAttackerFleets,
-                    strandedDefenderFleets,
-                    encounterResult
-                );
-                return;
-            }
-
-            if (!attackerRetreated)
-                RemoveFleetsUnableToRetreat(strandedAttackerFleets);
-            if (!defenderRetreated)
-                RemoveFleetsUnableToRetreat(strandedDefenderFleets);
+            DestroyStalematedForces(
+                decision,
+                strandedAttackerFleets,
+                strandedDefenderFleets,
+                encounterResult
+            );
         }
 
         /// <summary>
@@ -996,19 +983,6 @@ namespace Rebellion.Systems
         {
             List<ISceneNode> destroyedUnits = ships.Cast<ISceneNode>().Concat(fighters).ToList();
             CombatUnitSnapshot.RecordOutcomes(snapshots, destroyedUnits, destroyedUnits);
-        }
-
-        /// <summary>
-        /// Removes an armed stalemated fleet that cannot leave the contested planet.
-        /// </summary>
-        /// <param name="fleets">Fleets to remove.</param>
-        private void RemoveFleetsUnableToRetreat(IEnumerable<Fleet> fleets)
-        {
-            foreach (Fleet fleet in fleets.Where(fleet => fleet != null).ToList())
-            {
-                _game.DetachNode(fleet);
-                GameLogger.Log($"Fleet removed after stalemated combat: {fleet.GetDisplayName()}");
-            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/SpaceCombatSystem.cs
+++ b/Assets/Scripts/Systems/SpaceCombatSystem.cs
@@ -17,8 +17,8 @@ namespace Rebellion.Systems
     /// </summary>
     internal sealed class SpaceCombatDecision
     {
-        public string AttackerFleetInstanceID { get; set; }
-        public string DefenderFleetInstanceID { get; set; }
+        public List<string> AttackerFleetInstanceIDs { get; set; } = new List<string>();
+        public List<string> DefenderFleetInstanceIDs { get; set; } = new List<string>();
         public string AttackerOwnerInstanceID { get; set; }
         public string DefenderOwnerInstanceID { get; set; }
         public string PlanetInstanceID { get; set; }
@@ -120,27 +120,25 @@ namespace Rebellion.Systems
 
             if (IsEncounterStillContested(decision))
             {
-                if (!string.IsNullOrEmpty(decision.AttackerFleetInstanceID))
-                    resolvedFleetIds.Add(decision.AttackerFleetInstanceID);
-                if (!string.IsNullOrEmpty(decision.DefenderFleetInstanceID))
-                    resolvedFleetIds.Add(decision.DefenderFleetInstanceID);
+                resolvedFleetIds.UnionWith(decision.AttackerFleetInstanceIDs);
+                resolvedFleetIds.UnionWith(decision.DefenderFleetInstanceIDs);
             }
 
             return true;
         }
 
         /// <summary>
-        /// Checks whether both fleets in the encounter still occupy a contested planet.
+        /// Checks whether both sides in the encounter still occupy a contested planet.
         /// </summary>
         /// <param name="decision">The combat decision to evaluate.</param>
-        /// <returns>True when both fleets still contest the same planet.</returns>
+        /// <returns>True when both sides still contest the same planet.</returns>
         private bool IsEncounterStillContested(SpaceCombatDecision decision)
         {
             return AreForcesContestingPlanet(decision);
         }
 
         /// <summary>
-        /// Returns whether both fleets belong to AI-controlled factions.
+        /// Returns whether both sides belong to AI-controlled factions.
         /// </summary>
         /// <param name="decision">The combat decision to evaluate.</param>
         /// <returns>True when both sides are AI-controlled.</returns>
@@ -161,12 +159,10 @@ namespace Rebellion.Systems
         /// <returns>The pending-combat result.</returns>
         private PendingCombatResult BuildPendingCombatResult(SpaceCombatDecision decision)
         {
-            Fleet attacker = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.AttackerFleetInstanceID
-            );
-            Fleet defender = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.DefenderFleetInstanceID
-            );
+            List<Fleet> attackerFleets = GetFleets(decision.AttackerFleetInstanceIDs);
+            List<Fleet> defenderFleets = GetFleets(decision.DefenderFleetInstanceIDs);
+            Fleet attacker = GetRepresentativeFleet(attackerFleets);
+            Fleet defender = GetRepresentativeFleet(defenderFleets);
 
             return new PendingCombatResult
             {
@@ -175,8 +171,8 @@ namespace Rebellion.Systems
                 AttackerOwnerInstanceID = decision.AttackerOwnerInstanceID,
                 DefenderOwnerInstanceID = decision.DefenderOwnerInstanceID,
                 Planet = ResolveCombatPlanet(decision),
-                AttackerCanRetreat = CanRetreatFleet(attacker, defender),
-                DefenderCanRetreat = CanRetreatFleet(defender, attacker),
+                AttackerCanRetreat = CanRetreatFleets(attackerFleets, defenderFleets),
+                DefenderCanRetreat = CanRetreatFleets(defenderFleets, attackerFleets),
                 Tick = _game.CurrentTick,
             };
         }
@@ -207,24 +203,12 @@ namespace Rebellion.Systems
             if (_pendingDecision == null)
                 throw new InvalidOperationException("No pending combat to resolve.");
 
-            Fleet attacker = _game.GetSceneNodeByInstanceID<Fleet>(
-                _pendingDecision.AttackerFleetInstanceID
-            );
-            Fleet defender = _game.GetSceneNodeByInstanceID<Fleet>(
-                _pendingDecision.DefenderFleetInstanceID
-            );
-
-            string retreatingFleetInstanceId = null;
-            if (_pendingDecision.AttackerOwnerInstanceID == retreatingFactionInstanceId)
-                retreatingFleetInstanceId = attacker?.GetInstanceID();
-            else if (_pendingDecision.DefenderOwnerInstanceID == retreatingFactionInstanceId)
-                retreatingFleetInstanceId = defender?.GetInstanceID();
-
             if (
-                string.IsNullOrEmpty(retreatingFleetInstanceId)
+                retreatingFactionInstanceId != _pendingDecision.AttackerOwnerInstanceID
+                    && retreatingFactionInstanceId != _pendingDecision.DefenderOwnerInstanceID
                 || !TryResolveRetreat(
                     _pendingDecision,
-                    retreatingFleetInstanceId,
+                    retreatingFactionInstanceId,
                     out List<GameResult> results
                 )
             )
@@ -235,33 +219,41 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Attempts to resolve a pending combat decision by withdrawing one fleet.
+        /// Attempts to resolve a pending combat decision by withdrawing one side.
         /// </summary>
         /// <param name="decision">The pending combat decision.</param>
-        /// <param name="retreatingFleetInstanceId">The fleet requested to withdraw.</param>
+        /// <param name="retreatingFactionInstanceId">The faction requested to withdraw.</param>
         /// <param name="results">Receives the generated combat result.</param>
-        /// <returns>True when the fleet withdrew successfully.</returns>
+        /// <returns>True when the side withdrew successfully.</returns>
         private bool TryResolveRetreat(
             SpaceCombatDecision decision,
-            string retreatingFleetInstanceId,
+            string retreatingFactionInstanceId,
             out List<GameResult> results
         )
         {
-            Fleet attacker = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.AttackerFleetInstanceID
-            );
-            Fleet defender = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.DefenderFleetInstanceID
-            );
             Planet planet = ResolveCombatPlanet(decision);
             results = new List<GameResult>();
 
-            if (!TryRetreatFleet(decision, retreatingFleetInstanceId))
+            List<Fleet> attackerFleets = GetFleets(decision.AttackerFleetInstanceIDs);
+            List<Fleet> defenderFleets = GetFleets(decision.DefenderFleetInstanceIDs);
+            bool attackerRetreated =
+                retreatingFactionInstanceId == decision.AttackerOwnerInstanceID;
+            List<Fleet> retreatingFleets = attackerRetreated ? attackerFleets : defenderFleets;
+            List<Fleet> opposingFleets = attackerRetreated ? defenderFleets : attackerFleets;
+
+            if (!TryRetreatFleets(retreatingFleets, opposingFleets, ignoreGravityWell: false))
                 return false;
 
             results.Add(
-                BuildRetreatResult(decision, retreatingFleetInstanceId, attacker, defender, planet)
+                BuildRetreatResult(
+                    decision,
+                    attackerRetreated,
+                    attackerFleets,
+                    defenderFleets,
+                    planet
+                )
             );
+            ClearCombatFlags(decision);
             return true;
         }
 
@@ -269,20 +261,21 @@ namespace Rebellion.Systems
         /// Builds the combat result emitted after a successful fleet withdrawal.
         /// </summary>
         /// <param name="decision">The resolved combat decision.</param>
-        /// <param name="retreatingFleetInstanceId">The fleet that withdrew.</param>
-        /// <param name="attacker">The attacking fleet.</param>
-        /// <param name="defender">The defending fleet.</param>
+        /// <param name="attackerRetreated">Whether the attacking side withdrew.</param>
+        /// <param name="attackerFleets">The attacking fleets.</param>
+        /// <param name="defenderFleets">The defending fleets.</param>
         /// <param name="planet">The combat location.</param>
         /// <returns>The withdrawal combat result.</returns>
         private SpaceCombatResult BuildRetreatResult(
             SpaceCombatDecision decision,
-            string retreatingFleetInstanceId,
-            Fleet attacker,
-            Fleet defender,
+            bool attackerRetreated,
+            IReadOnlyList<Fleet> attackerFleets,
+            IReadOnlyList<Fleet> defenderFleets,
             Planet planet
         )
         {
-            bool attackerRetreated = retreatingFleetInstanceId == decision.AttackerFleetInstanceID;
+            Fleet attacker = GetRepresentativeFleet(attackerFleets);
+            Fleet defender = GetRepresentativeFleet(defenderFleets);
             SpaceCombatResult result = new SpaceCombatResult
             {
                 AttackerFleet = attacker,
@@ -308,13 +301,13 @@ namespace Rebellion.Systems
             };
 
             (List<ShipSnap> attackerShips, List<FighterSnap> attackerFighters) = SnapshotForce(
-                attacker,
+                attackerFleets,
                 planet,
                 decision.AttackerOwnerInstanceID,
                 _game.Config.Combat.SpaceCombat
             );
             (List<ShipSnap> defenderShips, List<FighterSnap> defenderFighters) = SnapshotForce(
-                defender,
+                defenderFleets,
                 planet,
                 decision.DefenderOwnerInstanceID,
                 _game.Config.Combat.SpaceCombat
@@ -344,19 +337,23 @@ namespace Rebellion.Systems
                     out Planet planet,
                     out string attackerOwnerInstanceId,
                     out string defenderOwnerInstanceId,
-                    out Fleet attacker,
-                    out Fleet defender
+                    out List<Fleet> attackerFleets,
+                    out List<Fleet> defenderFleets
                 )
             )
                 return false;
 
-            attacker?.SetCombatState(true);
-            defender?.SetCombatState(true);
+            foreach (Fleet fleet in attackerFleets.Concat(defenderFleets))
+                fleet.SetCombatState(true);
 
             decision = new SpaceCombatDecision
             {
-                AttackerFleetInstanceID = attacker?.GetInstanceID(),
-                DefenderFleetInstanceID = defender?.GetInstanceID(),
+                AttackerFleetInstanceIDs = attackerFleets.ConvertAll(fleet =>
+                    fleet.GetInstanceID()
+                ),
+                DefenderFleetInstanceIDs = defenderFleets.ConvertAll(fleet =>
+                    fleet.GetInstanceID()
+                ),
                 AttackerOwnerInstanceID = attackerOwnerInstanceId,
                 DefenderOwnerInstanceID = defenderOwnerInstanceId,
                 PlanetInstanceID = planet.GetInstanceID(),
@@ -372,23 +369,23 @@ namespace Rebellion.Systems
         /// <param name="contestedPlanet">The planet occupied by both sides.</param>
         /// <param name="attackerOwnerInstanceId">The attacking owner identifier.</param>
         /// <param name="defenderOwnerInstanceId">The defending owner identifier.</param>
-        /// <param name="attacker">The attacking fleet, when that side has one.</param>
-        /// <param name="defender">The defending fleet, when that side has one.</param>
+        /// <param name="attackerFleets">The attacking fleets.</param>
+        /// <param name="defenderFleets">The defending fleets.</param>
         /// <returns>True if hostile space forces were found.</returns>
         private bool TryFindContestedForces(
             HashSet<string> excludedFleetIds,
             out Planet contestedPlanet,
             out string attackerOwnerInstanceId,
             out string defenderOwnerInstanceId,
-            out Fleet attacker,
-            out Fleet defender
+            out List<Fleet> attackerFleets,
+            out List<Fleet> defenderFleets
         )
         {
             contestedPlanet = null;
             attackerOwnerInstanceId = null;
             defenderOwnerInstanceId = null;
-            attacker = null;
-            defender = null;
+            attackerFleets = null;
+            defenderFleets = null;
 
             foreach (Planet planet in _game.GetSceneNodesByType<Planet>())
             {
@@ -418,25 +415,25 @@ namespace Rebellion.Systems
 
                 string firstOwnerInstanceId = ownerInstanceIds[0];
                 string secondOwnerInstanceId = ownerInstanceIds[1];
-                Fleet firstFleet = fleets.FirstOrDefault(fleet =>
-                    fleet.GetOwnerInstanceID() == firstOwnerInstanceId
-                );
-                Fleet secondFleet = fleets.FirstOrDefault(fleet =>
-                    fleet.GetOwnerInstanceID() == secondOwnerInstanceId
-                );
+                List<Fleet> firstFleets = fleets
+                    .Where(fleet => fleet.GetOwnerInstanceID() == firstOwnerInstanceId)
+                    .ToList();
+                List<Fleet> secondFleets = fleets
+                    .Where(fleet => fleet.GetOwnerInstanceID() == secondOwnerInstanceId)
+                    .ToList();
 
                 attackerOwnerInstanceId = firstOwnerInstanceId;
                 defenderOwnerInstanceId = secondOwnerInstanceId;
-                attacker = firstFleet;
-                defender = secondFleet;
+                attackerFleets = firstFleets;
+                defenderFleets = secondFleets;
 
-                if (attacker == null && defender != null)
+                if (attackerFleets.Count == 0 && defenderFleets.Count > 0)
                 {
                     (attackerOwnerInstanceId, defenderOwnerInstanceId) = (
                         defenderOwnerInstanceId,
                         attackerOwnerInstanceId
                     );
-                    (attacker, defender) = (defender, attacker);
+                    (attackerFleets, defenderFleets) = (defenderFleets, attackerFleets);
                 }
 
                 contestedPlanet = planet;
@@ -448,7 +445,7 @@ namespace Rebellion.Systems
 
         /// <summary>
         /// Resolves a pending combat encounter. Applies damage to the game world and clears
-        /// IsInCombat on both fleets regardless of outcome.
+        /// IsInCombat on every participating fleet regardless of outcome.
         /// </summary>
         /// <param name="decision">The combat decision to resolve.</param>
         /// <param name="autoResolve">True to use auto-resolve; false to use manual combat.</param>
@@ -486,12 +483,8 @@ namespace Rebellion.Systems
         {
             List<GameResult> results = new List<GameResult>();
             SpaceCombatResult combatEncounterResult = null;
-            Fleet attacker = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.AttackerFleetInstanceID
-            );
-            Fleet defender = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.DefenderFleetInstanceID
-            );
+            List<Fleet> attackerFleets = GetFleets(decision.AttackerFleetInstanceIDs);
+            List<Fleet> defenderFleets = GetFleets(decision.DefenderFleetInstanceIDs);
             _battleHullStrengths.Clear();
             _battleShieldStrengths.Clear();
             _battleTacticalStateChanged = false;
@@ -503,14 +496,19 @@ namespace Rebellion.Systems
                     Planet planet = ResolveCombatPlanet(decision);
                     if (
                         allowRetreatBeforeCombat
-                        && TryRetreatOutmatchedFleet(decision, attacker, defender, planet)
+                        && TryRetreatOutmatchedFleets(
+                            decision,
+                            attackerFleets,
+                            defenderFleets,
+                            planet
+                        )
                     )
                         break;
 
                     SpaceCombatResult combatResult = ResolveCombatRound(
                         decision,
-                        attacker,
-                        defender,
+                        attackerFleets,
+                        defenderFleets,
                         _provider
                     );
                     if (combatResult != null)
@@ -519,19 +517,27 @@ namespace Rebellion.Systems
                         AddCombatRoundResult(combatEncounterResult, combatResult);
                     }
 
-                    attacker = _game.GetSceneNodeByInstanceID<Fleet>(
-                        decision.AttackerFleetInstanceID
-                    );
-                    defender = _game.GetSceneNodeByInstanceID<Fleet>(
-                        decision.DefenderFleetInstanceID
-                    );
+                    attackerFleets = GetFleets(decision.AttackerFleetInstanceIDs);
+                    defenderFleets = GetFleets(decision.DefenderFleetInstanceIDs);
 
                     if (!AreForcesContestingPlanet(decision))
                         break;
 
-                    if (IsSpaceCombatStalemated(decision, attacker, defender, combatResult))
+                    if (
+                        IsSpaceCombatStalemated(
+                            decision,
+                            attackerFleets,
+                            defenderFleets,
+                            combatResult
+                        )
+                    )
                     {
-                        SeparateStalematedFleets(attacker, defender);
+                        ResolveStalematedForces(
+                            decision,
+                            attackerFleets,
+                            defenderFleets,
+                            combatEncounterResult
+                        );
                         break;
                     }
                 }
@@ -544,7 +550,7 @@ namespace Rebellion.Systems
                 ClearCombatFlags(decision);
             }
 
-            UpdateCombatEncounterResultOutcomes(combatEncounterResult);
+            UpdateCombatEncounterResultOutcomes(combatEncounterResult, decision);
 
             if (combatEncounterResult != null)
                 results.Add(combatEncounterResult);
@@ -633,30 +639,36 @@ namespace Rebellion.Systems
         /// Updates encounter outcomes from each fleet's final runtime state.
         /// </summary>
         /// <param name="result">The encounter result to update.</param>
-        private static void UpdateCombatEncounterResultOutcomes(SpaceCombatResult result)
+        /// <param name="decision">The combat decision identifying both sides.</param>
+        private void UpdateCombatEncounterResultOutcomes(
+            SpaceCombatResult result,
+            SpaceCombatDecision decision
+        )
         {
             if (result == null)
                 return;
 
+            List<Fleet> attackerFleets = GetFleets(decision.AttackerFleetInstanceIDs);
+            List<Fleet> defenderFleets = GetFleets(decision.DefenderFleetInstanceIDs);
             result.AttackerOutcome = GetCombatSideOutcome(
-                result.AttackerFleet,
+                attackerFleets,
                 result.AttackerOwnerInstanceID,
                 result.Planet,
                 result.AttackerOutcome
             );
             result.DefenderOutcome = GetCombatSideOutcome(
-                result.DefenderFleet,
+                defenderFleets,
                 result.DefenderOwnerInstanceID,
                 result.Planet,
                 result.DefenderOutcome
             );
             result.AttackerRetreatPlanetInstanceID = GetRetreatPlanetInstanceID(
-                result.AttackerFleet,
+                attackerFleets,
                 result.Planet,
                 result.AttackerOutcome
             );
             result.DefenderRetreatPlanetInstanceID = GetRetreatPlanetInstanceID(
-                result.DefenderFleet,
+                defenderFleets,
                 result.Planet,
                 result.DefenderOutcome
             );
@@ -664,27 +676,29 @@ namespace Rebellion.Systems
 
         /// <summary>Returns the final destination ID recorded for a withdrawn fleet.</summary>
         private static string GetRetreatPlanetInstanceID(
-            Fleet fleet,
+            IReadOnlyList<Fleet> fleets,
             Planet battlePlanet,
             SpaceCombatSideOutcome outcome
         )
         {
             if (outcome != SpaceCombatSideOutcome.Withdrawn)
                 return null;
-            Planet destination = fleet?.GetParentOfType<Planet>();
+            Planet destination = fleets
+                ?.Select(fleet => fleet?.GetParentOfType<Planet>())
+                .FirstOrDefault(planet => planet != null && planet != battlePlanet);
             return destination == battlePlanet ? null : destination?.InstanceID;
         }
 
         /// <summary>
         /// Resolves a combat side's final encounter outcome.
         /// </summary>
-        /// <param name="fleet">The participating fleet.</param>
+        /// <param name="fleets">The participating fleets.</param>
         /// <param name="ownerInstanceId">The participating owner's identifier.</param>
         /// <param name="battlePlanet">The encounter location.</param>
         /// <param name="roundOutcome">The outcome recorded by the final combat round.</param>
         /// <returns>The final encounter outcome.</returns>
         private static SpaceCombatSideOutcome GetCombatSideOutcome(
-            Fleet fleet,
+            IReadOnlyList<Fleet> fleets,
             string ownerInstanceId,
             Planet battlePlanet,
             SpaceCombatSideOutcome roundOutcome
@@ -693,17 +707,22 @@ namespace Rebellion.Systems
             if (roundOutcome == SpaceCombatSideOutcome.Destroyed)
                 return SpaceCombatSideOutcome.Destroyed;
 
-            if (HasActiveSpaceUnits(fleet, battlePlanet, ownerInstanceId))
+            if (HasActiveSpaceUnits(fleets, battlePlanet, ownerInstanceId))
                 return SpaceCombatSideOutcome.Active;
 
-            if (fleet?.Movement != null)
+            if (fleets?.Any(fleet => fleet?.Movement != null) == true)
                 return SpaceCombatSideOutcome.Withdrawn;
 
-            Planet currentPlanet = fleet?.GetParentOfType<Planet>();
-            if (currentPlanet == null)
+            List<Planet> currentPlanets =
+                fleets
+                    ?.Select(fleet => fleet?.GetParentOfType<Planet>())
+                    .Where(planet => planet != null)
+                    .ToList()
+                ?? new List<Planet>();
+            if (currentPlanets.Count == 0)
                 return SpaceCombatSideOutcome.Destroyed;
 
-            if (battlePlanet != null && currentPlanet != battlePlanet)
+            if (battlePlanet != null && currentPlanets.Any(planet => planet != battlePlanet))
                 return SpaceCombatSideOutcome.Withdrawn;
 
             return SpaceCombatSideOutcome.Active;
@@ -776,35 +795,220 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Separates fleets that cannot produce a further combat outcome.
+        /// Attempts to withdraw stalemated forces and destroys any forces left contesting the
+        /// battle planet.
         /// </summary>
-        /// <param name="attacker">Attacking fleet.</param>
-        /// <param name="defender">Defending fleet.</param>
-        private void SeparateStalematedFleets(Fleet attacker, Fleet defender)
+        /// <param name="decision">The combat decision identifying both sides.</param>
+        /// <param name="attackerFleets">Attacking fleets.</param>
+        /// <param name="defenderFleets">Defending fleets.</param>
+        /// <param name="encounterResult">The encounter result that receives forced losses.</param>
+        private void ResolveStalematedForces(
+            SpaceCombatDecision decision,
+            IReadOnlyList<Fleet> attackerFleets,
+            IReadOnlyList<Fleet> defenderFleets,
+            SpaceCombatResult encounterResult
+        )
         {
-            bool attackerRetreated = TryRetreatFleet(attacker, defender, ignoreGravityWell: true);
-            bool defenderRetreated = TryRetreatFleet(defender, attacker, ignoreGravityWell: true);
+            bool attackerRetreated = TryRetreatFleets(
+                attackerFleets,
+                defenderFleets,
+                ignoreGravityWell: true
+            );
+            bool defenderRetreated = TryRetreatFleets(
+                defenderFleets,
+                attackerFleets,
+                ignoreGravityWell: true
+            );
 
-            if (!AreFleetsContestingPlanet(attacker, defender))
+            if (!AreForcesContestingPlanet(decision))
                 return;
 
+            Planet planet = ResolveCombatPlanet(decision);
+            List<Fleet> strandedAttackerFleets = GetStationaryFleetsAtPlanet(
+                attackerFleets,
+                planet
+            );
+            List<Fleet> strandedDefenderFleets = GetStationaryFleetsAtPlanet(
+                defenderFleets,
+                planet
+            );
+            bool hasOperationalWeapons =
+                HasOperationalSpaceWeapons(
+                    strandedAttackerFleets,
+                    planet,
+                    decision.AttackerOwnerInstanceID
+                )
+                || HasOperationalSpaceWeapons(
+                    strandedDefenderFleets,
+                    planet,
+                    decision.DefenderOwnerInstanceID
+                );
+            if (!hasOperationalWeapons)
+            {
+                DestroyStalematedForces(
+                    decision,
+                    strandedAttackerFleets,
+                    strandedDefenderFleets,
+                    encounterResult
+                );
+                return;
+            }
+
             if (!attackerRetreated)
-                RemoveFleetUnableToRetreat(attacker);
+                RemoveFleetsUnableToRetreat(strandedAttackerFleets);
             if (!defenderRetreated)
-                RemoveFleetUnableToRetreat(defender);
+                RemoveFleetsUnableToRetreat(strandedDefenderFleets);
         }
 
         /// <summary>
-        /// Removes a stalemated fleet that cannot leave the contested planet.
+        /// Records and applies destruction for every force unable to leave a stalemated battle.
         /// </summary>
-        /// <param name="fleet">Fleet to remove.</param>
-        private void RemoveFleetUnableToRetreat(Fleet fleet)
+        /// <param name="decision">The combat decision identifying both sides.</param>
+        /// <param name="attackerFleets">Attacking fleets.</param>
+        /// <param name="defenderFleets">Defending fleets.</param>
+        /// <param name="encounterResult">The encounter result that receives forced losses.</param>
+        private void DestroyStalematedForces(
+            SpaceCombatDecision decision,
+            IReadOnlyList<Fleet> attackerFleets,
+            IReadOnlyList<Fleet> defenderFleets,
+            SpaceCombatResult encounterResult
+        )
         {
-            if (fleet == null)
-                return;
+            Planet planet = ResolveCombatPlanet(decision);
+            List<CapitalShip> attackerShips = attackerFleets
+                .SelectMany(GetActiveCapitalShips)
+                .Distinct()
+                .ToList();
+            List<CapitalShip> defenderShips = defenderFleets
+                .SelectMany(GetActiveCapitalShips)
+                .Distinct()
+                .ToList();
+            List<Starfighter> attackerFighters = GetStalematedStarfighters(
+                attackerFleets,
+                planet,
+                decision.AttackerOwnerInstanceID
+            );
+            List<Starfighter> defenderFighters = GetStalematedStarfighters(
+                defenderFleets,
+                planet,
+                decision.DefenderOwnerInstanceID
+            );
 
-            _game.DetachNode(fleet);
-            GameLogger.Log($"Fleet removed after stalemated combat: {fleet.GetDisplayName()}");
+            RecordForcedDestruction(
+                encounterResult.AttackingUnits,
+                attackerShips,
+                attackerFighters
+            );
+            RecordForcedDestruction(
+                encounterResult.DefendingUnits,
+                defenderShips,
+                defenderFighters
+            );
+
+            List<ShipDamageResult> forcedShipDamage = attackerShips
+                .Concat(defenderShips)
+                .Select(ship => new ShipDamageResult
+                {
+                    Ship = ship,
+                    HullBefore = ship.CurrentHullStrength,
+                    HullAfter = 0,
+                })
+                .ToList();
+            List<FighterLossResult> forcedFighterLosses = attackerFighters
+                .Concat(defenderFighters)
+                .Select(fighter => new FighterLossResult
+                {
+                    Fighter = fighter,
+                    SquadsBefore = fighter.CurrentSquadronSize,
+                    SquadsAfter = 0,
+                })
+                .ToList();
+
+            AddShipDamage(encounterResult.ShipDamage, forcedShipDamage);
+            AddFighterLosses(encounterResult.FighterLosses, forcedFighterLosses);
+            encounterResult.Events.AddRange(
+                ApplyCombatLosses(
+                    forcedShipDamage,
+                    forcedFighterLosses,
+                    attackerFleets,
+                    defenderFleets
+                )
+            );
+
+            GameLogger.Log(
+                $"Stalemated forces destroyed at {planet.GetDisplayName()}: "
+                    + $"{attackerShips.Count + attackerFighters.Count} attacker units and "
+                    + $"{defenderShips.Count + defenderFighters.Count} defender units."
+            );
+        }
+
+        /// <summary>
+        /// Returns participating fleets that remain stationary at the battle planet.
+        /// </summary>
+        /// <param name="fleets">Fleets to inspect.</param>
+        /// <param name="planet">The battle planet.</param>
+        /// <returns>The stationary fleets at the battle planet.</returns>
+        private static List<Fleet> GetStationaryFleetsAtPlanet(
+            IReadOnlyList<Fleet> fleets,
+            Planet planet
+        )
+        {
+            return (fleets ?? Array.Empty<Fleet>())
+                .Where(fleet =>
+                    fleet != null
+                    && fleet.Movement == null
+                    && fleet.GetParentOfType<Planet>() == planet
+                )
+                .ToList();
+        }
+
+        /// <summary>
+        /// Returns active starfighters stranded in fleets or deployed at the battle planet.
+        /// </summary>
+        /// <param name="fleets">Stationary fleets to inspect.</param>
+        /// <param name="planet">The battle planet.</param>
+        /// <param name="ownerInstanceId">The owner of planetary starfighters to include.</param>
+        /// <returns>The stranded active starfighters.</returns>
+        private static List<Starfighter> GetStalematedStarfighters(
+            IReadOnlyList<Fleet> fleets,
+            Planet planet,
+            string ownerInstanceId
+        )
+        {
+            return (fleets ?? Array.Empty<Fleet>())
+                .SelectMany(GetActiveStarfighters)
+                .Concat(GetActivePlanetStarfighters(planet, ownerInstanceId))
+                .Distinct()
+                .ToList();
+        }
+
+        /// <summary>
+        /// Marks forced ship and fighter losses in one side's encounter snapshot.
+        /// </summary>
+        /// <param name="snapshots">The encounter snapshots to update.</param>
+        /// <param name="ships">Ships destroyed by the stalemate resolution.</param>
+        /// <param name="fighters">Starfighters destroyed by the stalemate resolution.</param>
+        private static void RecordForcedDestruction(
+            IEnumerable<CombatUnitSnapshot> snapshots,
+            IEnumerable<CapitalShip> ships,
+            IEnumerable<Starfighter> fighters
+        )
+        {
+            List<ISceneNode> destroyedUnits = ships.Cast<ISceneNode>().Concat(fighters).ToList();
+            CombatUnitSnapshot.RecordOutcomes(snapshots, destroyedUnits, destroyedUnits);
+        }
+
+        /// <summary>
+        /// Removes an armed stalemated fleet that cannot leave the contested planet.
+        /// </summary>
+        /// <param name="fleets">Fleets to remove.</param>
+        private void RemoveFleetsUnableToRetreat(IEnumerable<Fleet> fleets)
+        {
+            foreach (Fleet fleet in fleets.Where(fleet => fleet != null).ToList())
+            {
+                _game.DetachNode(fleet);
+                GameLogger.Log($"Fleet removed after stalemated combat: {fleet.GetDisplayName()}");
+            }
         }
 
         /// <summary>
@@ -813,112 +1017,84 @@ namespace Rebellion.Systems
         /// <param name="decision">Encounter identifying the affected fleets.</param>
         private void ClearCombatFlags(SpaceCombatDecision decision)
         {
-            Fleet attacker = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.AttackerFleetInstanceID
-            );
-            Fleet defender = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.DefenderFleetInstanceID
-            );
-            attacker?.SetCombatState(false);
-            defender?.SetCombatState(false);
+            foreach (
+                Fleet fleet in GetFleets(decision.AttackerFleetInstanceIDs)
+                    .Concat(GetFleets(decision.DefenderFleetInstanceIDs))
+            )
+            {
+                fleet.SetCombatState(false);
+            }
         }
 
         /// <summary>
         /// Attempts to retreat the weaker fleet before combat begins.
         /// </summary>
         /// <param name="decision">The combat decision identifying both sides.</param>
-        /// <param name="attacker">Attacking fleet.</param>
-        /// <param name="defender">Defending fleet.</param>
+        /// <param name="attackerFleets">Attacking fleets.</param>
+        /// <param name="defenderFleets">Defending fleets.</param>
         /// <param name="planet">The combat location.</param>
         /// <returns>True when at least one fleet retreats.</returns>
-        private bool TryRetreatOutmatchedFleet(
+        private bool TryRetreatOutmatchedFleets(
             SpaceCombatDecision decision,
-            Fleet attacker,
-            Fleet defender,
+            IReadOnlyList<Fleet> attackerFleets,
+            IReadOnlyList<Fleet> defenderFleets,
             Planet planet
         )
         {
             int attackerPower = GetCombatValue(
-                attacker,
+                attackerFleets,
                 GetActivePlanetStarfighters(planet, decision.AttackerOwnerInstanceID)
             );
             int defenderPower = GetCombatValue(
-                defender,
+                defenderFleets,
                 GetActivePlanetStarfighters(planet, decision.DefenderOwnerInstanceID)
             );
+            Fleet attacker = GetRepresentativeFleet(attackerFleets);
+            Fleet defender = GetRepresentativeFleet(defenderFleets);
 
             if (attackerPower == defenderPower)
             {
                 bool attackerRetreated =
                     _aiCombatPolicy.ShouldRetreat(attacker, planet, attackerPower, defenderPower)
-                    && TryRetreatFleet(attacker, defender, ignoreGravityWell: false);
+                    && TryRetreatFleets(attackerFleets, defenderFleets, ignoreGravityWell: false);
                 bool defenderRetreated =
                     _aiCombatPolicy.ShouldRetreat(defender, planet, defenderPower, attackerPower)
-                    && TryRetreatFleet(defender, attacker, ignoreGravityWell: false);
+                    && TryRetreatFleets(defenderFleets, attackerFleets, ignoreGravityWell: false);
                 return attackerRetreated || defenderRetreated;
             }
 
             if (attackerPower < defenderPower)
             {
                 return _aiCombatPolicy.ShouldRetreat(attacker, planet, attackerPower, defenderPower)
-                    && TryRetreatFleet(attacker, defender, ignoreGravityWell: false);
+                    && TryRetreatFleets(attackerFleets, defenderFleets, ignoreGravityWell: false);
             }
 
             return _aiCombatPolicy.ShouldRetreat(defender, planet, defenderPower, attackerPower)
-                && TryRetreatFleet(defender, attacker, ignoreGravityWell: false);
+                && TryRetreatFleets(defenderFleets, attackerFleets, ignoreGravityWell: false);
         }
 
         /// <summary>
         /// Reports whether a fleet can withdraw from its opponent.
         /// </summary>
-        /// <param name="fleet">The fleet requesting withdrawal.</param>
-        /// <param name="opponent">The opposing fleet.</param>
+        /// <param name="fleets">The fleets requesting withdrawal.</param>
+        /// <param name="opponents">The opposing fleets.</param>
         /// <returns>True when no opposing gravity well prevents withdrawal.</returns>
-        private static bool CanRetreatFleet(Fleet fleet, Fleet opponent)
+        private static bool CanRetreatFleets(
+            IReadOnlyList<Fleet> fleets,
+            IReadOnlyList<Fleet> opponents
+        )
         {
-            return fleet != null && !IsRetreatBlockedByGravityWell(fleet, opponent);
-        }
-
-        /// <summary>
-        /// Withdraws one side from an encounter and clears its combat flags.
-        /// </summary>
-        /// <param name="decision">The encounter context.</param>
-        /// <param name="retreatingFleetInstanceId">The withdrawing fleet identifier.</param>
-        /// <returns>True when the fleet withdrew successfully.</returns>
-        private bool TryRetreatFleet(SpaceCombatDecision decision, string retreatingFleetInstanceId)
-        {
-            Fleet attacker = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.AttackerFleetInstanceID
-            );
-            Fleet defender = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.DefenderFleetInstanceID
-            );
-
-            bool retreated =
-                retreatingFleetInstanceId == decision.AttackerFleetInstanceID
-                    ? TryRetreatFleet(attacker, defender, ignoreGravityWell: false)
-                    : retreatingFleetInstanceId == decision.DefenderFleetInstanceID
-                        && TryRetreatFleet(defender, attacker, ignoreGravityWell: false);
-
-            if (retreated)
-                ClearCombatFlags(decision);
-
-            return retreated;
+            return fleets?.Count > 0 && !IsRetreatBlockedByGravityWell(fleets, opponents);
         }
 
         /// <summary>
         /// Attempts to evacuate a fleet to the nearest friendly planet.
         /// </summary>
         /// <param name="fleet">Fleet attempting to retreat.</param>
-        /// <param name="opponent">Opposing fleet that may block retreat.</param>
-        /// <param name="ignoreGravityWell">Whether gravity-well interdiction is ignored.</param>
         /// <returns>True when the fleet leaves or begins movement away from the planet.</returns>
-        private bool TryRetreatFleet(Fleet fleet, Fleet opponent, bool ignoreGravityWell)
+        private bool TryRetreatFleet(Fleet fleet)
         {
             if (fleet == null)
-                return false;
-
-            if (!ignoreGravityWell && IsRetreatBlockedByGravityWell(fleet, opponent))
                 return false;
 
             Planet originalPlanet = fleet.GetParentOfType<Planet>();
@@ -927,21 +1103,50 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Determines whether an opposing gravity-well ship prevents retreat.
+        /// Attempts to evacuate every fleet on one combat side.
         /// </summary>
-        /// <param name="fleet">Fleet attempting to retreat.</param>
-        /// <param name="opponent">Opposing fleet.</param>
-        /// <returns>True when an active opposing ship projects a gravity well at the planet.</returns>
-        private static bool IsRetreatBlockedByGravityWell(Fleet fleet, Fleet opponent)
+        /// <param name="fleets">The fleets attempting to retreat.</param>
+        /// <param name="opponents">The opposing fleets that may block retreat.</param>
+        /// <param name="ignoreGravityWell">Whether gravity-well interdiction is ignored.</param>
+        /// <returns>True when every fleet leaves or begins movement away from the planet.</returns>
+        private bool TryRetreatFleets(
+            IReadOnlyList<Fleet> fleets,
+            IReadOnlyList<Fleet> opponents,
+            bool ignoreGravityWell
+        )
         {
-            if (fleet == null || opponent == null)
+            if (fleets == null || fleets.Count == 0)
                 return false;
 
-            Planet fleetPlanet = fleet.GetParentOfType<Planet>();
-            if (fleetPlanet == null || fleetPlanet != opponent.GetParentOfType<Planet>())
+            if (!ignoreGravityWell && IsRetreatBlockedByGravityWell(fleets, opponents))
                 return false;
 
-            return GetActiveCapitalShips(opponent).Any(ship => ship.HasGravityWell);
+            bool allRetreated = true;
+            foreach (Fleet fleet in fleets)
+                allRetreated &= TryRetreatFleet(fleet);
+
+            return allRetreated;
+        }
+
+        /// <summary>
+        /// Determines whether any opposing fleet projects a gravity well at the combat planet.
+        /// </summary>
+        /// <param name="fleets">The fleets attempting to retreat.</param>
+        /// <param name="opponents">The opposing fleets.</param>
+        /// <returns>True when an active opposing ship blocks withdrawal.</returns>
+        private static bool IsRetreatBlockedByGravityWell(
+            IReadOnlyList<Fleet> fleets,
+            IReadOnlyList<Fleet> opponents
+        )
+        {
+            Planet fleetPlanet = fleets
+                ?.Select(fleet => fleet?.GetParentOfType<Planet>())
+                .FirstOrDefault(planet => planet != null);
+            return fleetPlanet != null
+                && opponents?.Any(opponent =>
+                    opponent?.GetParentOfType<Planet>() == fleetPlanet
+                    && GetActiveCapitalShips(opponent).Any(ship => ship.HasGravityWell)
+                ) == true;
         }
 
         /// <summary>
@@ -955,17 +1160,36 @@ namespace Rebellion.Systems
             if (planet != null)
                 return planet;
 
-            Fleet attacker = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.AttackerFleetInstanceID
-            );
+            Fleet attacker = GetRepresentativeFleet(GetFleets(decision.AttackerFleetInstanceIDs));
             planet = attacker?.GetParentOfType<Planet>();
             if (planet != null)
                 return planet;
 
-            Fleet defender = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.DefenderFleetInstanceID
-            );
+            Fleet defender = GetRepresentativeFleet(GetFleets(decision.DefenderFleetInstanceIDs));
             return defender?.GetParentOfType<Planet>();
+        }
+
+        /// <summary>
+        /// Resolves the participating fleets that still exist in the scene graph.
+        /// </summary>
+        /// <param name="fleetInstanceIds">The participating fleet identifiers.</param>
+        /// <returns>The live fleets in encounter order.</returns>
+        private List<Fleet> GetFleets(IEnumerable<string> fleetInstanceIds)
+        {
+            return (fleetInstanceIds ?? Enumerable.Empty<string>())
+                .Select(fleetInstanceId => _game.GetSceneNodeByInstanceID<Fleet>(fleetInstanceId))
+                .Where(fleet => fleet != null)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Returns the fleet used to identify a multi-fleet combat side.
+        /// </summary>
+        /// <param name="fleets">The participating fleets.</param>
+        /// <returns>The first fleet in encounter order, or null.</returns>
+        private static Fleet GetRepresentativeFleet(IReadOnlyList<Fleet> fleets)
+        {
+            return fleets == null || fleets.Count == 0 ? null : fleets[0];
         }
 
         /// <summary>
@@ -1002,16 +1226,12 @@ namespace Rebellion.Systems
             if (planet == null)
                 return false;
 
-            Fleet attacker = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.AttackerFleetInstanceID
-            );
-            Fleet defender = _game.GetSceneNodeByInstanceID<Fleet>(
-                decision.DefenderFleetInstanceID
-            );
+            List<Fleet> attackerFleets = GetFleets(decision.AttackerFleetInstanceIDs);
+            List<Fleet> defenderFleets = GetFleets(decision.DefenderFleetInstanceIDs);
 
             return decision.AttackerOwnerInstanceID != decision.DefenderOwnerInstanceID
-                && HasActiveSpaceUnits(attacker, planet, decision.AttackerOwnerInstanceID)
-                && HasActiveSpaceUnits(defender, planet, decision.DefenderOwnerInstanceID);
+                && HasActiveSpaceUnits(attackerFleets, planet, decision.AttackerOwnerInstanceID)
+                && HasActiveSpaceUnits(defenderFleets, planet, decision.DefenderOwnerInstanceID);
         }
 
         /// <summary>
@@ -1028,21 +1248,24 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Returns whether an owner has active fleet or planetary space units at a planet.
+        /// Returns whether an owner has active units across any participating fleet or the planet.
         /// </summary>
-        /// <param name="fleet">The owner's participating fleet, when present.</param>
+        /// <param name="fleets">The owner's participating fleets.</param>
         /// <param name="planet">The encounter planet.</param>
         /// <param name="ownerInstanceId">The owner whose forces are being inspected.</param>
-        /// <returns>True when at least one active space unit remains at the planet.</returns>
-        private static bool HasActiveSpaceUnits(Fleet fleet, Planet planet, string ownerInstanceId)
+        /// <returns>True when at least one active space unit remains.</returns>
+        private static bool HasActiveSpaceUnits(
+            IReadOnlyList<Fleet> fleets,
+            Planet planet,
+            string ownerInstanceId
+        )
         {
-            bool hasActiveFleetUnits =
-                fleet != null
-                && fleet.Movement == null
-                && fleet.GetParentOfType<Planet>() == planet
-                && HasActiveSpaceUnits(fleet);
-
-            return hasActiveFleetUnits
+            return fleets?.Any(fleet =>
+                    fleet != null
+                    && fleet.Movement == null
+                    && fleet.GetParentOfType<Planet>() == planet
+                    && HasActiveSpaceUnits(fleet)
+                ) == true
                 || GetActivePlanetStarfighters(planet, ownerInstanceId).Any();
         }
 
@@ -1050,21 +1273,25 @@ namespace Rebellion.Systems
         /// Determines whether another combat round cannot change the encounter.
         /// </summary>
         /// <param name="decision">The combat decision identifying both sides.</param>
-        /// <param name="attacker">Attacking fleet after the round.</param>
-        /// <param name="defender">Defending fleet after the round.</param>
+        /// <param name="attackerFleets">Attacking fleets after the round.</param>
+        /// <param name="defenderFleets">Defending fleets after the round.</param>
         /// <param name="combatResult">Result of the latest combat round.</param>
         /// <returns>True when neither side can inflict damage or the round changed no state.</returns>
         private bool IsSpaceCombatStalemated(
             SpaceCombatDecision decision,
-            Fleet attacker,
-            Fleet defender,
+            IReadOnlyList<Fleet> attackerFleets,
+            IReadOnlyList<Fleet> defenderFleets,
             SpaceCombatResult combatResult
         )
         {
             Planet planet = combatResult?.Planet;
-            return !HasOperationalSpaceWeapons(attacker, planet, decision.AttackerOwnerInstanceID)
+            return !HasOperationalSpaceWeapons(
+                    attackerFleets,
+                    planet,
+                    decision.AttackerOwnerInstanceID
+                )
                     && !HasOperationalSpaceWeapons(
-                        defender,
+                        defenderFleets,
                         planet,
                         decision.DefenderOwnerInstanceID
                     )
@@ -1102,19 +1329,19 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Returns whether an owner has operational fleet or planetary space weapons.
+        /// Returns whether an owner has operational weapons across its fleets or planet.
         /// </summary>
-        /// <param name="fleet">The owner's participating fleet, when present.</param>
+        /// <param name="fleets">The owner's participating fleets.</param>
         /// <param name="planet">The encounter planet.</param>
         /// <param name="ownerInstanceId">The owner whose weapons are being inspected.</param>
         /// <returns>True when an active unit can attack.</returns>
         private static bool HasOperationalSpaceWeapons(
-            Fleet fleet,
+            IReadOnlyList<Fleet> fleets,
             Planet planet,
             string ownerInstanceId
         )
         {
-            return HasOperationalSpaceWeapons(fleet)
+            return fleets?.Any(HasOperationalSpaceWeapons) == true
                 || GetActivePlanetStarfighters(planet, ownerInstanceId).Any(IsArmedStarfighter);
         }
 
@@ -1171,17 +1398,17 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Calculates combined combat value for a fleet and its deployed planetary starfighters.
+        /// Calculates combined combat value for fleets and their deployed planetary starfighters.
         /// </summary>
-        /// <param name="fleet">The participating fleet, when present.</param>
+        /// <param name="fleets">The participating fleets, when present.</param>
         /// <param name="planetaryStarfighters">The deployed starfighters to include.</param>
         /// <returns>The combined current combat value.</returns>
         private static int GetCombatValue(
-            Fleet fleet,
+            IReadOnlyList<Fleet> fleets,
             IEnumerable<Starfighter> planetaryStarfighters
         )
         {
-            int combatValue = fleet?.GetCombatValue() ?? 0;
+            int combatValue = fleets?.Sum(fleet => fleet?.GetCombatValue() ?? 0) ?? 0;
             foreach (Starfighter fighter in planetaryStarfighters)
             {
                 int weaponStrength = fighter.LaserCannon + fighter.IonCannon + fighter.Torpedoes;
@@ -1242,14 +1469,14 @@ namespace Rebellion.Systems
         /// Resolves one space-combat round and applies it to the game state.
         /// </summary>
         /// <param name="decision">The combat decision identifying both sides.</param>
-        /// <param name="attacker">Attacking fleet.</param>
-        /// <param name="defender">Defending fleet.</param>
+        /// <param name="attackerFleets">Attacking fleets.</param>
+        /// <param name="defenderFleets">Defending fleets.</param>
         /// <param name="rng">Random-number provider for the round.</param>
         /// <returns>The applied round result, or null when the encounter is no longer valid.</returns>
         private SpaceCombatResult ResolveCombatRound(
             SpaceCombatDecision decision,
-            Fleet attacker,
-            Fleet defender,
+            IReadOnlyList<Fleet> attackerFleets,
+            IReadOnlyList<Fleet> defenderFleets,
             IRandomNumberProvider rng
         )
         {
@@ -1261,8 +1488,8 @@ namespace Rebellion.Systems
             }
 
             SpaceCombatResult result = ResolveSpace(
-                attacker,
-                defender,
+                attackerFleets,
+                defenderFleets,
                 decision.AttackerOwnerInstanceID,
                 decision.DefenderOwnerInstanceID,
                 planet,
@@ -1270,12 +1497,12 @@ namespace Rebellion.Systems
                 _game.CurrentTick,
                 _game.Config.Combat.SpaceCombat
             );
-            result.Events = ApplyCombatResult(result);
+            result.Events = ApplyCombatResult(result, attackerFleets, defenderFleets);
 
             GameLogger.Log(
                 $"Combat at {planet.GetDisplayName()}: "
-                    + $"{attacker?.GetDisplayName() ?? decision.AttackerOwnerInstanceID} vs "
-                    + $"{defender?.GetDisplayName() ?? decision.DefenderOwnerInstanceID} — "
+                    + $"{decision.AttackerOwnerInstanceID} vs "
+                    + $"{decision.DefenderOwnerInstanceID} — "
                     + $"Winner: {result.Winner}"
             );
 
@@ -1291,8 +1518,8 @@ namespace Rebellion.Systems
         /// 7-phase space combat pipeline: snapshot -> composition -> weapon fire -> fighter
         /// engagement -> result. Shield absorption and hull damage happen inside weapon fire.
         /// </summary>
-        /// <param name="attackerFleet">The attacking fleet.</param>
-        /// <param name="defenderFleet">The defending fleet.</param>
+        /// <param name="attackerFleets">The attacking fleets.</param>
+        /// <param name="defenderFleets">The defending fleets.</param>
         /// <param name="attackerOwnerInstanceId">The attacking owner identifier.</param>
         /// <param name="defenderOwnerInstanceId">The defending owner identifier.</param>
         /// <param name="planet">Planet where combat occurs.</param>
@@ -1301,8 +1528,8 @@ namespace Rebellion.Systems
         /// <param name="config">Combat configuration supplying damage/variance tuning values.</param>
         /// <returns>The combat result with winner, per-ship damage, and fighter losses.</returns>
         private SpaceCombatResult ResolveSpace(
-            Fleet attackerFleet,
-            Fleet defenderFleet,
+            IReadOnlyList<Fleet> attackerFleets,
+            IReadOnlyList<Fleet> defenderFleets,
             string attackerOwnerInstanceId,
             string defenderOwnerInstanceId,
             Planet planet,
@@ -1313,13 +1540,13 @@ namespace Rebellion.Systems
         {
             _battleTacticalStateChanged = false;
             (List<ShipSnap> atkShips, List<FighterSnap> atkFighters) = SnapshotForce(
-                attackerFleet,
+                attackerFleets,
                 planet,
                 attackerOwnerInstanceId,
                 config
             );
             (List<ShipSnap> defShips, List<FighterSnap> defFighters) = SnapshotForce(
-                defenderFleet,
+                defenderFleets,
                 planet,
                 defenderOwnerInstanceId,
                 config
@@ -1329,8 +1556,8 @@ namespace Rebellion.Systems
             RechargeShields(defShips);
 
             bool anyArmed =
-                HasOperationalSpaceWeapons(attackerFleet, planet, attackerOwnerInstanceId)
-                || HasOperationalSpaceWeapons(defenderFleet, planet, defenderOwnerInstanceId);
+                HasOperationalSpaceWeapons(attackerFleets, planet, attackerOwnerInstanceId)
+                || HasOperationalSpaceWeapons(defenderFleets, planet, defenderOwnerInstanceId);
 
             if (anyArmed)
             {
@@ -1343,8 +1570,8 @@ namespace Rebellion.Systems
             StoreShieldStrengths(defShips);
 
             return BuildSpaceResult(
-                attackerFleet,
-                defenderFleet,
+                GetRepresentativeFleet(attackerFleets),
+                GetRepresentativeFleet(defenderFleets),
                 attackerOwnerInstanceId,
                 defenderOwnerInstanceId,
                 planet,
@@ -1385,13 +1612,13 @@ namespace Rebellion.Systems
         /// <summary>
         /// Builds mutable per-battle snapshots for one side's fleet and planetary starfighters.
         /// </summary>
-        /// <param name="fleet">Fleet to snapshot.</param>
+        /// <param name="fleets">Fleets to snapshot.</param>
         /// <param name="planet">The combat planet.</param>
         /// <param name="ownerInstanceId">The side's owner identifier.</param>
         /// <param name="config">Combat configuration supplying fighter durability.</param>
         /// <returns>Ship and fighter snapshots for the represented side.</returns>
         private (List<ShipSnap> ships, List<FighterSnap> fighters) SnapshotForce(
-            Fleet fleet,
+            IReadOnlyList<Fleet> fleets,
             Planet planet,
             string ownerInstanceId,
             GameConfig.SpaceCombatConfig config
@@ -1399,7 +1626,11 @@ namespace Rebellion.Systems
         {
             List<ShipSnap> ships = new List<ShipSnap>();
 
-            foreach (CapitalShip ship in GetActiveCapitalShips(fleet))
+            foreach (
+                CapitalShip ship in (fleets ?? Array.Empty<Fleet>()).SelectMany(
+                    GetActiveCapitalShips
+                )
+            )
             {
                 int shieldMax = Math.Max(ship.MaxShieldStrength, 0);
                 float shieldCurrent = shieldMax;
@@ -1958,16 +2189,50 @@ namespace Rebellion.Systems
         /// destroyed ships and depleted fighter squadrons, cleans up empty fleets.
         /// </summary>
         /// <param name="result">The combat result to apply.</param>
+        /// <param name="attackerFleets">The attacking fleets to clean up.</param>
+        /// <param name="defenderFleets">The defending fleets to clean up.</param>
         /// <returns>Events generated from ship damage and destruction.</returns>
-        private List<GameResult> ApplyCombatResult(SpaceCombatResult result)
+        private List<GameResult> ApplyCombatResult(
+            SpaceCombatResult result,
+            IReadOnlyList<Fleet> attackerFleets,
+            IReadOnlyList<Fleet> defenderFleets
+        )
         {
-            List<GameResult> events = ApplyShipDamage(result.ShipDamage);
-            ApplyFighterSquadronLosses(result.FighterLosses);
+            return ApplyCombatLosses(
+                result.ShipDamage,
+                result.FighterLosses,
+                attackerFleets,
+                defenderFleets
+            );
+        }
 
-            if (result.AttackerFleet?.GetChildren<CapitalShip>().Count == 0)
-                RemoveFleetFromScene(result.AttackerFleet);
-            if (result.DefenderFleet?.GetChildren<CapitalShip>().Count == 0)
-                RemoveFleetFromScene(result.DefenderFleet);
+        /// <summary>
+        /// Applies ship and fighter losses and removes fleet containers left without capital ships.
+        /// </summary>
+        /// <param name="shipDamage">Ship damage to apply.</param>
+        /// <param name="fighterLosses">Fighter losses to apply.</param>
+        /// <param name="attackerFleets">The attacking fleets to clean up.</param>
+        /// <param name="defenderFleets">The defending fleets to clean up.</param>
+        /// <returns>Events generated from ship damage and destruction.</returns>
+        private List<GameResult> ApplyCombatLosses(
+            List<ShipDamageResult> shipDamage,
+            List<FighterLossResult> fighterLosses,
+            IReadOnlyList<Fleet> attackerFleets,
+            IReadOnlyList<Fleet> defenderFleets
+        )
+        {
+            List<GameResult> events = ApplyShipDamage(shipDamage);
+            ApplyFighterSquadronLosses(fighterLosses);
+
+            foreach (
+                Fleet fleet in attackerFleets
+                    .Concat(defenderFleets)
+                    .Where(fleet => fleet?.GetChildren<CapitalShip>().Count == 0)
+                    .ToList()
+            )
+            {
+                RemoveFleetFromScene(fleet);
+            }
 
             return events;
         }

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
@@ -595,6 +596,122 @@ namespace Rebellion.Tests.Managers
             Assert.IsTrue(
                 conflictMessages.Any(message => message.Title == "Battle at Destination")
             );
+        }
+
+        [Test]
+        public void ProcessTick_LoadedConvergingMultipleFleets_ResolvesSingleCombinedCombat()
+        {
+            string saveDirectoryPath = Path.Combine(
+                Path.GetTempPath(),
+                nameof(GameManagerTests),
+                Guid.NewGuid().ToString("N")
+            );
+
+            try
+            {
+                GameConfig config = TestConfig.Create();
+                GameRoot game = new GameRoot(config);
+                Faction alliance = new Faction
+                {
+                    InstanceID = "FNALL1",
+                    DisplayName = "Alliance",
+                    PlayerID = "player",
+                };
+                Faction empire = new Faction { InstanceID = "FNEMP1", DisplayName = "Empire" };
+                game.GetFactions().Add(alliance);
+                game.GetFactions().Add(empire);
+
+                PlanetSector sector = new PlanetSector { InstanceID = "SECTOR" };
+                game.AttachNode(sector, game.GetGalaxyMap());
+                Planet origin = CreatePlanet("ORIGIN", alliance.InstanceID, 0);
+                Planet destination = CreatePlanet("DESTINATION", empire.InstanceID, 1);
+                game.AttachNode(origin, sector);
+                game.AttachNode(destination, sector);
+
+                List<Fleet> attackingFleets = new List<Fleet>
+                {
+                    CreateCombatFleet(game, "ATTACKER_1", alliance.InstanceID, origin, 1, 0),
+                    CreateCombatFleet(game, "ATTACKER_2", alliance.InstanceID, origin, 1, 0),
+                    CreateCombatFleet(game, "ATTACKER_3", alliance.InstanceID, origin, 1, 0),
+                };
+                List<Fleet> defendingFleets = new List<Fleet>
+                {
+                    CreateCombatFleet(
+                        game,
+                        "DEFENDER_1",
+                        empire.InstanceID,
+                        destination,
+                        1000,
+                        100
+                    ),
+                    CreateCombatFleet(
+                        game,
+                        "DEFENDER_2",
+                        empire.InstanceID,
+                        destination,
+                        1000,
+                        100
+                    ),
+                };
+                foreach (Fleet fleet in defendingFleets)
+                    fleet.GetChildren<CapitalShip>().Single().HasGravityWell = true;
+
+                GameManager initialManager = new GameManager(game, TestGameData.Create(config));
+                foreach (Fleet fleet in attackingFleets)
+                {
+                    initialManager.MovementSystem.RequestMove(
+                        new List<IMovable> { fleet },
+                        destination
+                    );
+                }
+
+                HashSet<string> expectedShipIds = attackingFleets
+                    .Concat(defendingFleets)
+                    .SelectMany(fleet => fleet.GetChildren<CapitalShip>())
+                    .Select(ship => ship.InstanceID)
+                    .ToHashSet();
+                SaveGameManager saveManager = new SaveGameManager(saveDirectoryPath);
+                saveManager.SaveGameData(game, "multi-fleet-combat");
+
+                GameRoot loadedGame = saveManager.LoadGameData("multi-fleet-combat");
+                GameManager loadedManager = new GameManager(
+                    loadedGame,
+                    TestGameData.Create(config)
+                );
+                for (
+                    int tick = 0;
+                    tick < 100 && !loadedManager.SpaceCombatSystem.HasPendingDecision;
+                    tick++
+                )
+                {
+                    loadedManager.ProcessTick();
+                }
+
+                Assert.IsTrue(loadedManager.SpaceCombatSystem.HasPendingDecision);
+                SpaceCombatResult result = loadedManager.ResolveCombat(autoResolve: true);
+                HashSet<string> participatingShipIds = result
+                    .AttackingUnits.Concat(result.DefendingUnits)
+                    .Select(unit => unit.Unit)
+                    .OfType<CapitalShip>()
+                    .Select(ship => ship.InstanceID)
+                    .ToHashSet();
+                CollectionAssert.AreEquivalent(expectedShipIds, participatingShipIds);
+                Assert.IsTrue(
+                    attackingFleets.All(fleet =>
+                        loadedGame.GetSceneNodeByInstanceID<Fleet>(fleet.InstanceID) == null
+                    )
+                );
+                Assert.IsTrue(
+                    defendingFleets.All(fleet =>
+                        loadedGame.GetSceneNodeByInstanceID<Fleet>(fleet.InstanceID) != null
+                    )
+                );
+            }
+            finally
+            {
+                if (Directory.Exists(saveDirectoryPath))
+                    Directory.Delete(saveDirectoryPath, recursive: true);
+            }
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
@@ -1421,6 +1421,81 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_MultipleUnarmedFleetsWithRetreatDestinations_RetreatsEveryFleet()
+        {
+            GameRoot game = CreateGame();
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat");
+            (Planet empireHome, _) = CreatePlanet(game, "empireHome", owner: "empire");
+            (Planet allianceHome, _) = CreatePlanet(game, "allianceHome", owner: "alliance");
+            List<Fleet> empireFleets = new List<Fleet>
+            {
+                CreateFleet(game, "ef1", "empire", combatPlanet, 1, 100, 0),
+                CreateFleet(game, "ef2", "empire", combatPlanet, 1, 100, 0),
+            };
+            List<Fleet> allianceFleets = new List<Fleet>
+            {
+                CreateFleet(game, "af1", "alliance", combatPlanet, 1, 100, 0),
+                CreateFleet(game, "af2", "alliance", combatPlanet, 1, 100, 0),
+            };
+            SpaceCombatSystem manager = MakeSpaceCombat(game, new QueueRNG());
+
+            manager.ProcessTick();
+
+            Assert.IsTrue(empireFleets.All(fleet => fleet.GetParentOfType<Planet>() == empireHome));
+            Assert.IsTrue(
+                allianceFleets.All(fleet => fleet.GetParentOfType<Planet>() == allianceHome)
+            );
+            Assert.IsTrue(empireFleets.Concat(allianceFleets).All(fleet => !fleet.IsInCombat));
+            Assert.IsFalse(HasHostileFleets(combatPlanet));
+        }
+
+        [Test]
+        public void ProcessTick_MultipleUnarmedFleetsWithoutRetreatDestinations_DestroysEveryFleetAndReportsEveryShip()
+        {
+            GameRoot game = CreateGame();
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat");
+            List<Fleet> fleets = new List<Fleet>
+            {
+                CreateFleet(game, "ef1", "empire", combatPlanet, 1, 100, 0),
+                CreateFleet(game, "ef2", "empire", combatPlanet, 1, 100, 0),
+                CreateFleet(game, "af1", "alliance", combatPlanet, 1, 100, 0),
+                CreateFleet(game, "af2", "alliance", combatPlanet, 1, 100, 0),
+            };
+            HashSet<string> expectedFleetIds = fleets.Select(fleet => fleet.InstanceID).ToHashSet();
+            HashSet<string> expectedShipIds = fleets
+                .SelectMany(fleet => fleet.GetChildren<CapitalShip>())
+                .Select(ship => ship.InstanceID)
+                .ToHashSet();
+            SpaceCombatSystem manager = MakeSpaceCombat(game, new QueueRNG());
+
+            List<GameResult> results = manager.ProcessTick();
+
+            SpaceCombatResult combatResult = GetCombatResult(results);
+            Assert.IsTrue(
+                expectedFleetIds.All(fleetId =>
+                    game.GetSceneNodeByInstanceID<Fleet>(fleetId) == null
+                )
+            );
+            Assert.AreEqual(CombatSide.Draw, combatResult.Winner);
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, combatResult.AttackerOutcome);
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, combatResult.DefenderOutcome);
+            CollectionAssert.AreEquivalent(
+                expectedShipIds,
+                combatResult
+                    .AttackingUnits.Concat(combatResult.DefendingUnits)
+                    .Where(unit => unit.Destroyed)
+                    .Select(unit => unit.Unit.GetInstanceID())
+            );
+            CollectionAssert.AreEquivalent(
+                expectedShipIds,
+                combatResult
+                    .ShipDamage.Where(damage => damage.HullAfter == 0)
+                    .Select(damage => damage.Ship.InstanceID)
+            );
+            Assert.IsFalse(HasHostileFleets(combatPlanet));
+        }
+
+        [Test]
         public void ProcessTick_PlayerInvolvedEncounter_ReturnsPendingDecision()
         {
             GameRoot game = new GameRoot(TestConfig.Create());
@@ -1628,6 +1703,109 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ResolvePending_MultipleColocatedFleets_DestroysEveryLosingFleetAndReportsEveryShip()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            game.GetFactions().Add(new Faction { InstanceID = "empire", PlayerID = "player1" });
+            game.GetFactions().Add(new Faction { InstanceID = "alliance" });
+            PlanetSector planetSector = new PlanetSector { InstanceID = "sector1" };
+            Planet planet = new Planet { InstanceID = "p1" };
+            game.AttachNode(planetSector, game.Galaxy);
+            game.AttachNode(planet, planetSector);
+            List<Fleet> winningFleets = new List<Fleet>
+            {
+                CreateFleet(game, "ef1", "empire", planet, 1, 1000, 100, 0),
+                CreateFleet(game, "ef2", "empire", planet, 1, 1000, 100, 0),
+            };
+            List<Fleet> losingFleets = new List<Fleet>
+            {
+                CreateFleet(game, "af1", "alliance", planet, 1, 1, 0, 0),
+                CreateFleet(game, "af2", "alliance", planet, 1, 1, 0, 0),
+            };
+            HashSet<string> expectedLosingShipIds = losingFleets
+                .SelectMany(fleet => fleet.GetChildren<CapitalShip>())
+                .Select(ship => ship.InstanceID)
+                .ToHashSet();
+            SpaceCombatSystem manager = MakeSpaceCombat(game, new QueueRNG(0.5));
+
+            manager.ProcessTick();
+            SpaceCombatResult result = manager
+                .ResolvePending(autoResolve: true)
+                .OfType<SpaceCombatResult>()
+                .Single();
+
+            Assert.IsTrue(
+                losingFleets.All(fleet =>
+                    game.GetSceneNodeByInstanceID<Fleet>(fleet.InstanceID) == null
+                )
+            );
+            Assert.IsTrue(
+                winningFleets.All(fleet =>
+                    game.GetSceneNodeByInstanceID<Fleet>(fleet.InstanceID) == fleet
+                    && fleet.GetParentOfType<Planet>() == planet
+                    && !fleet.IsInCombat
+                )
+            );
+            IEnumerable<CombatUnitSnapshot> losingSnapshots =
+                result.AttackerOwnerInstanceID == "alliance"
+                    ? result.AttackingUnits
+                    : result.DefendingUnits;
+            SpaceCombatSideOutcome losingOutcome =
+                result.AttackerOwnerInstanceID == "alliance"
+                    ? result.AttackerOutcome
+                    : result.DefenderOutcome;
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, losingOutcome);
+            CollectionAssert.AreEquivalent(
+                expectedLosingShipIds,
+                losingSnapshots
+                    .Where(snapshot => snapshot.Destroyed)
+                    .Select(snapshot => snapshot.Unit.GetInstanceID())
+            );
+            Assert.IsFalse(HasHostileFleets(planet));
+        }
+
+        [Test]
+        public void ResolvePending_MultipleColocatedFleets_ExcludesInTransitSiblingFleet()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            game.GetFactions().Add(new Faction { InstanceID = "empire", PlayerID = "player1" });
+            game.GetFactions().Add(new Faction { InstanceID = "alliance" });
+            PlanetSector planetSector = new PlanetSector { InstanceID = "sector1" };
+            Planet planet = new Planet { InstanceID = "p1" };
+            game.AttachNode(planetSector, game.Galaxy);
+            game.AttachNode(planet, planetSector);
+            Fleet stationaryFleet = CreateFleet(game, "ef1", "empire", planet, 1, 1000, 100, 0);
+            Fleet inTransitFleet = CreateFleet(game, "ef2", "empire", planet, 1, 1000, 100, 0);
+            Fleet opposingFleet = CreateFleet(game, "af1", "alliance", planet, 1, 1, 0, 0);
+            inTransitFleet.Movement = new MovementState
+            {
+                TransitTicks = 5,
+                TicksElapsed = 1,
+                OriginPosition = planet.GetPosition(),
+                CurrentPosition = planet.GetPosition(),
+            };
+            string inTransitShipId = inTransitFleet.GetChildren<CapitalShip>().Single().InstanceID;
+            SpaceCombatSystem manager = MakeSpaceCombat(game, new QueueRNG(0.5));
+
+            manager.ProcessTick();
+
+            Assert.IsTrue(stationaryFleet.IsInCombat);
+            Assert.IsFalse(inTransitFleet.IsInCombat);
+            Assert.IsTrue(opposingFleet.IsInCombat);
+            SpaceCombatResult result = manager
+                .ResolvePending(autoResolve: true)
+                .OfType<SpaceCombatResult>()
+                .Single();
+            HashSet<string> participatingShipIds = result
+                .AttackingUnits.Concat(result.DefendingUnits)
+                .Select(snapshot => snapshot.Unit.GetInstanceID())
+                .ToHashSet();
+            Assert.IsFalse(participatingShipIds.Contains(inTransitShipId));
+            Assert.AreSame(inTransitFleet, game.GetSceneNodeByInstanceID<Fleet>("ef2"));
+            Assert.IsFalse(inTransitFleet.IsInCombat);
+        }
+
+        [Test]
         public void ResolvePending_PlanetaryStarfighters_ParticipateInCombat()
         {
             GameRoot game = CreateGame();
@@ -1775,6 +1953,57 @@ namespace Rebellion.Tests.Systems
                 SpaceCombatSideOutcome.Active,
                 empireWasAttacker ? combatResult.DefenderOutcome : combatResult.AttackerOutcome
             );
+        }
+
+        [Test]
+        public void ResolvePendingRetreat_MultipleColocatedFleets_RetreatsEveryFleetAndReportsEveryShip()
+        {
+            GameRoot game = CreateGame();
+            game.GetFactions().First(faction => faction.InstanceID == "empire").PlayerID =
+                "player1";
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat");
+            (Planet empireHome, _) = CreatePlanet(game, "empireHome", owner: "empire");
+            empireHome.PositionX = 100;
+            CreatePlanet(game, "allianceHome", owner: "alliance");
+            List<Fleet> retreatingFleets = new List<Fleet>
+            {
+                CreateFleet(game, "ef1", "empire", combatPlanet, 1, 100, 1),
+                CreateFleet(game, "ef2", "empire", combatPlanet, 1, 100, 1),
+            };
+            Fleet opposingFleet = CreateFleet(game, "af1", "alliance", combatPlanet, 1, 1000, 100);
+            HashSet<string> expectedRetreatingShipIds = retreatingFleets
+                .SelectMany(fleet => fleet.GetChildren<CapitalShip>())
+                .Select(ship => ship.InstanceID)
+                .ToHashSet();
+            SpaceCombatSystem manager = MakeSpaceCombat(game, new QueueRNG());
+
+            manager.ProcessTick();
+            List<GameResult> results = manager.ResolvePendingRetreat("empire");
+
+            Assert.IsTrue(
+                retreatingFleets.All(fleet =>
+                    fleet.GetParentOfType<Planet>() == empireHome
+                    && fleet.Movement != null
+                    && !fleet.IsInCombat
+                )
+            );
+            Assert.AreSame(combatPlanet, opposingFleet.GetParentOfType<Planet>());
+            Assert.IsFalse(opposingFleet.IsInCombat);
+            SpaceCombatResult combatResult = results.OfType<SpaceCombatResult>().Single();
+            IEnumerable<CombatUnitSnapshot> retreatingSnapshots =
+                combatResult.AttackerOwnerInstanceID == "empire"
+                    ? combatResult.AttackingUnits
+                    : combatResult.DefendingUnits;
+            SpaceCombatSideOutcome retreatingOutcome =
+                combatResult.AttackerOwnerInstanceID == "empire"
+                    ? combatResult.AttackerOutcome
+                    : combatResult.DefenderOutcome;
+            CollectionAssert.AreEquivalent(
+                expectedRetreatingShipIds,
+                retreatingSnapshots.Select(snapshot => snapshot.Unit.GetInstanceID())
+            );
+            Assert.AreEqual(SpaceCombatSideOutcome.Withdrawn, retreatingOutcome);
+            Assert.IsFalse(HasHostileFleets(combatPlanet));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
@@ -609,6 +609,45 @@ namespace Rebellion.Tests.Systems
             Assert.IsFalse(HasOpposingReadyFleets(planet));
         }
 
+        [TestCase(true, CombatSide.Defender)]
+        [TestCase(false, CombatSide.Attacker)]
+        public void Resolve_OnlyOneUnarmedSideCanEvacuate_ReportsRemainingSideVictory(
+            bool attackerCanEvacuate,
+            CombatSide expectedWinner
+        )
+        {
+            GameRoot game = CreateGame();
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat");
+            string fallbackOwner = attackerCanEvacuate ? "empire" : "alliance";
+            (Planet fallbackPlanet, _) = CreatePlanet(game, "fallback", owner: fallbackOwner);
+            Fleet attacker = CreateFleet(game, "attacker", "empire", combatPlanet, 1, 100, 0);
+            Fleet defender = CreateFleet(game, "defender", "alliance", combatPlanet, 1, 100, 0);
+            SpaceCombatSystem manager = MakeSpaceCombat(game, new QueueRNG());
+
+            TryResolveCombat(manager, attacker, defender, out List<GameResult> results);
+
+            SpaceCombatResult combatResult = GetCombatResult(results);
+            Fleet retreatingFleet = attackerCanEvacuate ? attacker : defender;
+            Fleet remainingFleet = attackerCanEvacuate ? defender : attacker;
+            Assert.AreEqual(expectedWinner, combatResult.Winner);
+            Assert.AreEqual(
+                attackerCanEvacuate
+                    ? SpaceCombatSideOutcome.Withdrawn
+                    : SpaceCombatSideOutcome.Active,
+                combatResult.AttackerOutcome
+            );
+            Assert.AreEqual(
+                attackerCanEvacuate
+                    ? SpaceCombatSideOutcome.Active
+                    : SpaceCombatSideOutcome.Withdrawn,
+                combatResult.DefenderOutcome
+            );
+            Assert.AreSame(fallbackPlanet, retreatingFleet.GetParentOfType<Planet>());
+            Assert.IsNotNull(retreatingFleet.Movement);
+            Assert.AreSame(combatPlanet, remainingFleet.GetParentOfType<Planet>());
+            Assert.IsNull(remainingFleet.Movement);
+        }
+
         [Test]
         public void Resolve_WeaponFire_DamagesTargets()
         {
@@ -740,6 +779,8 @@ namespace Rebellion.Tests.Systems
             Planet planet = new Planet { InstanceID = "p1" };
             game.AttachNode(planetSector, game.Galaxy);
             game.AttachNode(planet, planetSector);
+            CreatePlanet(game, "empireFallback", owner: "empire");
+            CreatePlanet(game, "allianceFallback", owner: "alliance");
 
             Fleet attacker = CreateFleet(
                 game,
@@ -821,7 +862,7 @@ namespace Rebellion.Tests.Systems
 
         [Test]
         [Timeout(5000)]
-        public void Resolve_ShieldDamageFullyRecharged_EndsAsStalemate()
+        public void Resolve_ShieldDamageFullyRecharged_DestroysStrandedFleetsAndRecordsLosses()
         {
             GameRoot game = new GameRoot(TestConfig.Create());
             Faction empire = new Faction { InstanceID = "empire" };
@@ -854,14 +895,44 @@ namespace Rebellion.Tests.Systems
                 1,
                 shieldRechargeRate: 4
             );
-            attacker.GetChildren<CapitalShip>()[0].MaxShieldStrength = 100;
-            defender.GetChildren<CapitalShip>()[0].MaxShieldStrength = 100;
+            CapitalShip attackerShip = attacker.GetChildren<CapitalShip>().Single();
+            CapitalShip defenderShip = defender.GetChildren<CapitalShip>().Single();
+            attackerShip.MaxShieldStrength = 100;
+            defenderShip.MaxShieldStrength = 100;
             SpaceCombatSystem manager = MakeSpaceCombat(game, new QueueRNG(0.5, 0.5, 0.5, 0.5));
 
             TryResolveCombat(manager, attacker, defender, out List<GameResult> results);
 
             SpaceCombatResult result = GetCombatResult(results);
-            Assert.That(result.ShipDamage, Is.Empty);
+            string[] expectedShipIds = { attackerShip.InstanceID, defenderShip.InstanceID };
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Fleet>(attacker.InstanceID));
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Fleet>(defender.InstanceID));
+            CollectionAssert.AreEquivalent(
+                expectedShipIds,
+                result
+                    .ShipDamage.Where(damage => damage.HullAfter == 0)
+                    .Select(damage => damage.Ship.InstanceID)
+            );
+            CollectionAssert.AreEquivalent(
+                expectedShipIds,
+                result
+                    .AttackingUnits.Concat(result.DefendingUnits)
+                    .Where(unit => unit.Destroyed)
+                    .Select(unit => unit.Unit.GetInstanceID())
+            );
+            CombatReport report = CombatReport.Capture(
+                result,
+                "empire",
+                "Battle",
+                "Both fleets were destroyed."
+            );
+            CollectionAssert.AreEquivalent(
+                expectedShipIds,
+                report
+                    .AttackingUnits.Concat(report.DefendingUnits)
+                    .Where(unit => unit.Destroyed)
+                    .Select(unit => unit.InstanceID)
+            );
             Assert.That(HasOpposingReadyFleets(planet), Is.False);
         }
 
@@ -879,6 +950,8 @@ namespace Rebellion.Tests.Systems
             Planet planet = new Planet { InstanceID = "p1" };
             game.AttachNode(planetSector, game.Galaxy);
             game.AttachNode(planet, planetSector);
+            CreatePlanet(game, "empireFallback", owner: "empire");
+            CreatePlanet(game, "allianceFallback", owner: "alliance");
 
             Fleet attacker = CreateFleet(
                 game,
@@ -971,6 +1044,8 @@ namespace Rebellion.Tests.Systems
             Planet planet = new Planet { InstanceID = "p1" };
             game.AttachNode(planetSector, game.Galaxy);
             game.AttachNode(planet, planetSector);
+            CreatePlanet(game, "empireFallback", owner: "empire");
+            CreatePlanet(game, "allianceFallback", owner: "alliance");
 
             Fleet attacker = CreateFleetWithFighters(game, "f1", "empire", planet, 1, 100, 0, 12);
             Fleet defender = CreateFleet(

--- a/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Rebellion.Game;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
+using Rebellion.Game.Messages;
 using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
@@ -269,7 +270,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void Resolve_MultipleAttackerFleets_OnlyFirstPairFights()
+        public void Resolve_MultipleAttackerFleets_IncludesEveryFleet()
         {
             GameRoot game = new GameRoot(TestConfig.Create());
             Faction empire = new Faction { InstanceID = "empire" };
@@ -292,16 +293,17 @@ namespace Rebellion.Tests.Systems
             QueueRNG rng = new QueueRNG(0.5, 0.5, 0.5, 0.5);
             SpaceCombatSystem manager = MakeSpaceCombat(game, rng);
 
-            TryResolveCombat(manager, empireFleet1, allianceFleet, out List<GameResult> results);
+            TryRunCombat(manager, out List<GameResult> results);
 
-            bool firstPairFought =
-                HasDamageFor(results, empireShip1) || HasDamageFor(results, allianceShip);
-            Assert.IsTrue(firstPairFought, "First fleet fights");
-            Assert.IsFalse(HasDamageFor(results, empireShip2), "Second fleet does not fight");
-            Assert.AreEqual(
-                100,
-                empireFleet2.GetChildren<CapitalShip>()[0].CurrentHullStrength,
-                "Second fleet does not fight"
+            HashSet<string> participatingShipIds = GetCombatResult(results)
+                .AttackingUnits.Concat(GetCombatResult(results).DefendingUnits)
+                .Select(unit => unit.Unit)
+                .OfType<CapitalShip>()
+                .Select(ship => ship.InstanceID)
+                .ToHashSet();
+            CollectionAssert.AreEquivalent(
+                new[] { empireShip1.InstanceID, empireShip2.InstanceID, allianceShip.InstanceID },
+                participatingShipIds
             );
         }
 
@@ -572,7 +574,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void Resolve_BothSidesZeroWeapons_AppliesNoDamageAndSeparatesFleets()
+        public void Resolve_BothSidesZeroWeapons_DestroysFleetsAndRecordsLosses()
         {
             GameRoot game = new GameRoot(TestConfig.Create());
             Faction empire = new Faction { InstanceID = "empire" };
@@ -587,29 +589,24 @@ namespace Rebellion.Tests.Systems
 
             Fleet empireFleet = CreateFleet(game, "f1", "empire", planet, 1, 100, 0);
             Fleet allianceFleet = CreateFleet(game, "f2", "alliance", planet, 1, 100, 0);
-
-            empireFleet.GetChildren<CapitalShip>()[0].PrimaryWeapons.Clear();
-            allianceFleet.GetChildren<CapitalShip>()[0].PrimaryWeapons.Clear();
-
+            CapitalShip empireShip = empireFleet.GetChildren<CapitalShip>().Single();
+            CapitalShip allianceShip = allianceFleet.GetChildren<CapitalShip>().Single();
+            empireShip.PrimaryWeapons.Clear();
+            allianceShip.PrimaryWeapons.Clear();
             QueueRNG rng = new QueueRNG(0.5, 0.5, 0.5, 0.5);
             SpaceCombatSystem manager = MakeSpaceCombat(game, rng);
 
-            RunCombat(manager);
+            TryResolveCombat(manager, empireFleet, allianceFleet, out List<GameResult> results);
 
-            Assert.AreEqual(
-                100,
-                empireFleet.GetChildren<CapitalShip>()[0].CurrentHullStrength,
-                "No damage without weapons"
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Fleet>(empireFleet.InstanceID));
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Fleet>(allianceFleet.InstanceID));
+            CollectionAssert.AreEquivalent(
+                new[] { empireShip.InstanceID, allianceShip.InstanceID },
+                GetCombatResult(results)
+                    .ShipDamage.Where(damage => damage.HullAfter == 0)
+                    .Select(damage => damage.Ship.InstanceID)
             );
-            Assert.AreEqual(
-                100,
-                allianceFleet.GetChildren<CapitalShip>()[0].CurrentHullStrength,
-                "No damage without weapons"
-            );
-            Assert.IsFalse(
-                HasOpposingReadyFleets(planet),
-                "Opposing fleets should not remain ready at the same planet"
-            );
+            Assert.IsFalse(HasOpposingReadyFleets(planet));
         }
 
         [Test]
@@ -1376,6 +1373,54 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_UnarmedFleetsWithoutRetreatDestinations_DestroysAndReportsBoth()
+        {
+            GameRoot game = CreateGame();
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat");
+            Fleet empireFleet = CreateFleet(game, "ef1", "empire", combatPlanet, 1, 100, 0);
+            Fleet allianceFleet = CreateFleet(game, "af1", "alliance", combatPlanet, 1, 100, 0);
+            CapitalShip empireShip = empireFleet.GetChildren<CapitalShip>().Single();
+            CapitalShip allianceShip = allianceFleet.GetChildren<CapitalShip>().Single();
+            SpaceCombatSystem manager = MakeSpaceCombat(game, new QueueRNG());
+
+            List<GameResult> results = manager.ProcessTick();
+
+            SpaceCombatResult combatResult = GetCombatResult(results);
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Fleet>(empireFleet.InstanceID));
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Fleet>(allianceFleet.InstanceID));
+            Assert.AreEqual(CombatSide.Draw, combatResult.Winner);
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, combatResult.AttackerOutcome);
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, combatResult.DefenderOutcome);
+            CollectionAssert.AreEquivalent(
+                new[] { empireShip.InstanceID, allianceShip.InstanceID },
+                combatResult
+                    .ShipDamage.Where(damage => damage.HullAfter == 0)
+                    .Select(damage => damage.Ship.InstanceID)
+            );
+            CollectionAssert.AreEquivalent(
+                new[] { empireShip.InstanceID, allianceShip.InstanceID },
+                combatResult
+                    .AttackingUnits.Concat(combatResult.DefendingUnits)
+                    .Where(unit => unit.Destroyed)
+                    .Select(unit => unit.Unit.GetInstanceID())
+            );
+
+            CombatReport report = CombatReport.Capture(
+                combatResult,
+                "empire",
+                "Battle",
+                "Both fleets were destroyed."
+            );
+            CollectionAssert.AreEquivalent(
+                new[] { empireShip.InstanceID, allianceShip.InstanceID },
+                report
+                    .AttackingUnits.Concat(report.DefendingUnits)
+                    .Where(unit => unit.Destroyed)
+                    .Select(unit => unit.InstanceID)
+            );
+        }
+
+        [Test]
         public void ProcessTick_PlayerInvolvedEncounter_ReturnsPendingDecision()
         {
             GameRoot game = new GameRoot(TestConfig.Create());
@@ -1530,6 +1575,56 @@ namespace Rebellion.Tests.Systems
 
             Assert.IsFalse(empireCanRetreat);
             Assert.IsTrue(allianceCanRetreat);
+        }
+
+        [Test]
+        public void ResolvePending_MultipleColocatedFleets_IncludesEveryFleet()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            game.GetFactions().Add(new Faction { InstanceID = "empire", PlayerID = "player1" });
+            game.GetFactions().Add(new Faction { InstanceID = "alliance" });
+            PlanetSector planetSector = new PlanetSector { InstanceID = "sector1" };
+            Planet planet = new Planet { InstanceID = "p1" };
+            game.AttachNode(planetSector, game.Galaxy);
+            game.AttachNode(planet, planetSector);
+
+            Fleet firstEmpireFleet = CreateFleet(game, "ef1", "empire", planet, 1, 100, 10);
+            Fleet secondEmpireFleet = CreateFleet(game, "ef2", "empire", planet, 1, 100, 10);
+            Fleet firstAllianceFleet = CreateFleet(game, "af1", "alliance", planet, 1, 100, 10);
+            Fleet secondAllianceFleet = CreateFleet(game, "af2", "alliance", planet, 1, 100, 10);
+            List<Fleet> fleets = new List<Fleet>
+            {
+                firstEmpireFleet,
+                secondEmpireFleet,
+                firstAllianceFleet,
+                secondAllianceFleet,
+            };
+            HashSet<string> expectedShipIds = fleets
+                .SelectMany(fleet => fleet.GetChildren<CapitalShip>())
+                .Select(ship => ship.InstanceID)
+                .ToHashSet();
+            SpaceCombatSystem manager = MakeSpaceCombat(game, new QueueRNG(0.5));
+
+            PendingCombatResult pending = manager
+                .ProcessTick()
+                .OfType<PendingCombatResult>()
+                .Single();
+            Assert.IsTrue(fleets.All(fleet => fleet.IsInCombat));
+
+            SpaceCombatResult result = manager
+                .ResolvePending(autoResolve: true)
+                .OfType<SpaceCombatResult>()
+                .Single();
+
+            HashSet<string> actualShipIds = result
+                .AttackingUnits.Concat(result.DefendingUnits)
+                .Select(unit => unit.Unit)
+                .OfType<CapitalShip>()
+                .Select(ship => ship.InstanceID)
+                .ToHashSet();
+            CollectionAssert.AreEquivalent(expectedShipIds, actualShipIds);
+            Assert.AreSame(planet, pending.Planet);
+            Assert.IsFalse(HasHostileFleets(planet));
         }
 
         [Test]
@@ -1833,8 +1928,8 @@ namespace Rebellion.Tests.Systems
             results = manager.Resolve(
                 new SpaceCombatDecision
                 {
-                    AttackerFleetInstanceID = attacker.InstanceID,
-                    DefenderFleetInstanceID = defender.InstanceID,
+                    AttackerFleetInstanceIDs = new List<string> { attacker.InstanceID },
+                    DefenderFleetInstanceIDs = new List<string> { defender.InstanceID },
                     AttackerOwnerInstanceID = attacker.OwnerInstanceID,
                     DefenderOwnerInstanceID = defender.OwnerInstanceID,
                     PlanetInstanceID = planet?.InstanceID,


### PR DESCRIPTION
## Summary

- Resolve space combat with every colocated friendly and enemy fleet.
- Destroy unarmed fleets that cannot retreat instead of leaving combat unresolved.
- Preserve complete destroyed-unit reporting for multi-fleet and mutual-destruction outcomes.

## Validation

- Space combat tests: 58 passed.
- Game manager tests: 25 passed.
- Combat presentation tests: 74 passed.
- Message factory tests: 94 passed.
- Local build and lint checks pass.
- A generated multi-fleet save confirms that every fleet participates and the losing side leaves no units behind.
- Unarmed-fleet scenarios pass with and without valid fallback planets.
- Multi-fleet tests verify full participation, losing-fleet cleanup, report completeness, side-wide retreat, combat-state cleanup, and exclusion of in-transit sibling fleets.
- Stalemate tests verify one-sided evacuation winners and complete destruction reporting for stranded armed and unarmed forces.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [ ] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded. (Awaiting repository-owner review.)
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable; no UI builder changes.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable; no content path or structure changes.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable; no documentation-facing behavior changed.)
