### PR TITLE
Addressing a number of issues with the Events schema validation.

### DIFF
--- a/Assets/Scripts/Game/Events/GameActions.cs
+++ b/Assets/Scripts/Game/Events/GameActions.cs
@@ -443,7 +443,8 @@ namespace Rebellion.Game.Events
                     includeDisabled: true
                 );
             ISceneNode relatedSubject = game.GetSceneNodeByInstanceID<ISceneNode>(
-                RelatedSubjectInstanceID
+                RelatedSubjectInstanceID,
+                includeDisabled: true
             );
             if (string.IsNullOrWhiteSpace(RecipientFactionInstanceID))
                 throw new InvalidOperationException(
@@ -453,7 +454,10 @@ namespace Rebellion.Game.Events
             Faction recipient = game.GetFactionByOwnerInstanceID(RecipientFactionInstanceID);
             Planet location = !string.IsNullOrWhiteSpace(LocationBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(LocationBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(LocationInstanceID);
+                : game.GetSceneNodeByInstanceID<Planet>(
+                    LocationInstanceID,
+                    includeDisabled: true
+                );
             if (location == null && subject != null)
                 location = subject as Planet ?? subject.GetParentOfType<Planet>();
 
@@ -1760,7 +1764,10 @@ namespace Rebellion.Game.Events
             GameRoot game = context.Game;
             Planet planet = !string.IsNullOrWhiteSpace(PlanetBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(PlanetBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID);
+                : game.GetSceneNodeByInstanceID<Planet>(
+                    PlanetInstanceID,
+                    includeDisabled: true
+                );
             if (planet == null)
                 throw new InvalidOperationException("DamagePlanetResources requires a planet.");
 
@@ -1918,7 +1925,10 @@ namespace Rebellion.Game.Events
             ).SelectMany(selector => selector.Select(game, context.Random, context.Evaluation));
             Planet explicitPlanet = !string.IsNullOrWhiteSpace(planetBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(planetBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(planetInstanceID);
+                : game.GetSceneNodeByInstanceID<Planet>(
+                    planetInstanceID,
+                    includeDisabled: true
+                );
             if (explicitPlanet != null)
                 selected = new ISceneNode[] { explicitPlanet }.Concat(selected);
             List<ISceneNode> nodes = selected.Distinct().ToList();
@@ -1973,7 +1983,10 @@ namespace Rebellion.Game.Events
 
             Planet planet = !string.IsNullOrWhiteSpace(PlanetBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(PlanetBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID);
+                : game.GetSceneNodeByInstanceID<Planet>(
+                    PlanetInstanceID,
+                    includeDisabled: true
+                );
 
             context.Record(
                 destroyed.ConvertAll<GameResult>(unit => new GameObjectDestroyedResult
@@ -2213,7 +2226,13 @@ namespace Rebellion.Game.Events
             string actionName
         ) =>
             (
-                UnitActionTargets.ResolveUnits(UnitInstanceID, Units, context, actionName),
+                UnitActionTargets.ResolveUnits(
+                    UnitInstanceID,
+                    Units,
+                    context,
+                    actionName,
+                    includeDisabled: true
+                ),
                 UnitActionTargets.ResolveDestinations(
                     DestinationInstanceID,
                     Destination,
@@ -2245,7 +2264,8 @@ namespace Rebellion.Game.Events
                 Units,
                 context,
                 "PlaceUnits",
-                allowSpawn: true
+                allowSpawn: true,
+                includeDisabled: true
             );
             context.Request(
                 new UnitPlacementRequest

--- a/Assets/Scripts/Game/Events/GameActions.cs
+++ b/Assets/Scripts/Game/Events/GameActions.cs
@@ -454,10 +454,7 @@ namespace Rebellion.Game.Events
             Faction recipient = game.GetFactionByOwnerInstanceID(RecipientFactionInstanceID);
             Planet location = !string.IsNullOrWhiteSpace(LocationBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(LocationBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(
-                    LocationInstanceID,
-                    includeDisabled: true
-                );
+                : game.GetSceneNodeByInstanceID<Planet>(LocationInstanceID, includeDisabled: true);
             if (location == null && subject != null)
                 location = subject as Planet ?? subject.GetParentOfType<Planet>();
 
@@ -1764,10 +1761,7 @@ namespace Rebellion.Game.Events
             GameRoot game = context.Game;
             Planet planet = !string.IsNullOrWhiteSpace(PlanetBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(PlanetBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(
-                    PlanetInstanceID,
-                    includeDisabled: true
-                );
+                : game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID, includeDisabled: true);
             if (planet == null)
                 throw new InvalidOperationException("DamagePlanetResources requires a planet.");
 
@@ -1925,10 +1919,7 @@ namespace Rebellion.Game.Events
             ).SelectMany(selector => selector.Select(game, context.Random, context.Evaluation));
             Planet explicitPlanet = !string.IsNullOrWhiteSpace(planetBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(planetBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(
-                    planetInstanceID,
-                    includeDisabled: true
-                );
+                : game.GetSceneNodeByInstanceID<Planet>(planetInstanceID, includeDisabled: true);
             if (explicitPlanet != null)
                 selected = new ISceneNode[] { explicitPlanet }.Concat(selected);
             List<ISceneNode> nodes = selected.Distinct().ToList();
@@ -1983,10 +1974,7 @@ namespace Rebellion.Game.Events
 
             Planet planet = !string.IsNullOrWhiteSpace(PlanetBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(PlanetBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(
-                    PlanetInstanceID,
-                    includeDisabled: true
-                );
+                : game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID, includeDisabled: true);
 
             context.Record(
                 destroyed.ConvertAll<GameResult>(unit => new GameObjectDestroyedResult
@@ -2267,6 +2255,14 @@ namespace Rebellion.Game.Events
                 allowSpawn: true,
                 includeDisabled: true
             );
+            if (
+                units.Any(unit =>
+                    unit is ISceneNode node && node.GetParent() != null && !node.IsActive()
+                )
+            )
+                throw new InvalidOperationException(
+                    "PlaceUnits requires existing units to be active."
+                );
             context.Request(
                 new UnitPlacementRequest
                 {

--- a/Assets/Scripts/Game/Events/GameConditionals.cs
+++ b/Assets/Scripts/Game/Events/GameConditionals.cs
@@ -502,7 +502,10 @@ namespace Rebellion.Game.Events
         /// <returns>True when the Force-rank comparison succeeds.</returns>
         public override bool IsMet(GameConditionContext context)
         {
-            Officer officer = context.Game.GetSceneNodeByInstanceID<Officer>(OfficerInstanceID);
+            Officer officer = context.Game.GetSceneNodeByInstanceID<Officer>(
+                OfficerInstanceID,
+                includeDisabled: true
+            );
             if (officer == null)
                 return false;
 
@@ -533,7 +536,10 @@ namespace Rebellion.Game.Events
         {
             Planet planet = !string.IsNullOrWhiteSpace(PlanetBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(PlanetBinding)
-                : context.Game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID);
+                : context.Game.GetSceneNodeByInstanceID<Planet>(
+                    PlanetInstanceID,
+                    includeDisabled: true
+                );
             return planet
                     ?.GetChildren<Building>()
                     .Any(building =>
@@ -562,7 +568,10 @@ namespace Rebellion.Game.Events
         {
             GameRoot game = context.Game;
             Planet planet = string.IsNullOrWhiteSpace(PlanetBinding)
-                ? game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID)
+                ? game.GetSceneNodeByInstanceID<Planet>(
+                    PlanetInstanceID,
+                    includeDisabled: true
+                )
                 : context.Evaluation?.GetBindingReference<Planet>(PlanetBinding);
             if (planet?.IsDestroyed != false)
                 return false;
@@ -596,7 +605,10 @@ namespace Rebellion.Game.Events
         {
             Planet planet = !string.IsNullOrWhiteSpace(PlanetBinding)
                 ? context.Evaluation?.GetBindingReference<Planet>(PlanetBinding)
-                : context.Game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID);
+                : context.Game.GetSceneNodeByInstanceID<Planet>(
+                    PlanetInstanceID,
+                    includeDisabled: true
+                );
             if (planet == null || string.IsNullOrWhiteSpace(FactionInstanceID))
                 return false;
 
@@ -688,7 +700,12 @@ namespace Rebellion.Game.Events
             List<string> ids = references.Select(reference => reference.UnitInstanceID).ToList();
             if (ids.Any(string.IsNullOrWhiteSpace) || ids.Distinct().Count() != ids.Count)
                 return null;
-            List<ISceneNode> nodes = game.GetSceneNodesByInstanceIDs(ids);
+            List<ISceneNode> nodes = ids
+                .Select(id =>
+                    game.GetSceneNodeByInstanceID<ISceneNode>(id, includeDisabled: true)
+                )
+                .Where(node => node != null)
+                .ToList();
             return nodes.Count == ids.Count ? nodes : null;
         }
     }
@@ -713,7 +730,12 @@ namespace Rebellion.Game.Events
         {
             GameRoot game = context.Game;
             // Get the scene nodes for the units.
-            List<ISceneNode> sceneNodes = game.GetSceneNodesByInstanceIDs(UnitInstanceIDs);
+            List<ISceneNode> sceneNodes = UnitInstanceIDs
+                .Select(id =>
+                    game.GetSceneNodeByInstanceID<ISceneNode>(id, includeDisabled: true)
+                )
+                .Where(node => node != null)
+                .ToList();
 
             // Check if the units are on opposing factions.
             return sceneNodes.Count == 2
@@ -738,7 +760,8 @@ namespace Rebellion.Game.Events
         public override bool IsMet(GameConditionContext context)
         {
             ISceneNode sceneNode = context.Game.GetSceneNodeByInstanceID<ISceneNode>(
-                UnitInstanceID
+                UnitInstanceID,
+                includeDisabled: true
             );
             // Check if the unit is on a mission.
             return sceneNode?.GetParent() is Mission;
@@ -779,7 +802,10 @@ namespace Rebellion.Game.Events
         public string UnitInstanceID { get; set; }
 
         public override bool IsMet(GameConditionContext context) =>
-            context.Game.GetSceneNodeByInstanceID<ISceneNode>(UnitInstanceID)
+            context.Game.GetSceneNodeByInstanceID<ISceneNode>(
+                UnitInstanceID,
+                includeDisabled: true
+            )
                 is IMovable { Movement: not null };
     }
 
@@ -800,8 +826,14 @@ namespace Rebellion.Game.Events
         public override bool IsMet(GameConditionContext context)
         {
             GameRoot game = context.Game;
-            ISceneNode unit = game.GetSceneNodeByInstanceID<ISceneNode>(UnitInstanceID);
-            ISceneNode location = game.GetSceneNodeByInstanceID<ISceneNode>(LocationInstanceID);
+            ISceneNode unit = game.GetSceneNodeByInstanceID<ISceneNode>(
+                UnitInstanceID,
+                includeDisabled: true
+            );
+            ISceneNode location = game.GetSceneNodeByInstanceID<ISceneNode>(
+                LocationInstanceID,
+                includeDisabled: true
+            );
             for (ISceneNode current = unit; current != null; current = current.GetParent())
             {
                 if (current == location)

--- a/Assets/Scripts/Game/Events/GameConditionals.cs
+++ b/Assets/Scripts/Game/Events/GameConditionals.cs
@@ -541,9 +541,10 @@ namespace Rebellion.Game.Events
                     includeDisabled: true
                 );
             return planet
-                    ?.GetChildren<Building>()
+                    ?.GetChildren<Building>(includeDisabled: true)
                     .Any(building =>
-                        building.BuildingType == Type
+                        building.IsEnabled
+                        && building.BuildingType == Type
                         && building.ManufacturingStatus == ManufacturingStatus.Complete
                     ) == true;
         }
@@ -568,10 +569,7 @@ namespace Rebellion.Game.Events
         {
             GameRoot game = context.Game;
             Planet planet = string.IsNullOrWhiteSpace(PlanetBinding)
-                ? game.GetSceneNodeByInstanceID<Planet>(
-                    PlanetInstanceID,
-                    includeDisabled: true
-                )
+                ? game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID, includeDisabled: true)
                 : context.Evaluation?.GetBindingReference<Planet>(PlanetBinding);
             if (planet?.IsDestroyed != false)
                 return false;
@@ -700,8 +698,7 @@ namespace Rebellion.Game.Events
             List<string> ids = references.Select(reference => reference.UnitInstanceID).ToList();
             if (ids.Any(string.IsNullOrWhiteSpace) || ids.Distinct().Count() != ids.Count)
                 return null;
-            List<ISceneNode> nodes = ids
-                .Select(id =>
+            List<ISceneNode> nodes = ids.Select(id =>
                     game.GetSceneNodeByInstanceID<ISceneNode>(id, includeDisabled: true)
                 )
                 .Where(node => node != null)
@@ -731,9 +728,7 @@ namespace Rebellion.Game.Events
             GameRoot game = context.Game;
             // Get the scene nodes for the units.
             List<ISceneNode> sceneNodes = UnitInstanceIDs
-                .Select(id =>
-                    game.GetSceneNodeByInstanceID<ISceneNode>(id, includeDisabled: true)
-                )
+                .Select(id => game.GetSceneNodeByInstanceID<ISceneNode>(id, includeDisabled: true))
                 .Where(node => node != null)
                 .ToList();
 
@@ -802,10 +797,7 @@ namespace Rebellion.Game.Events
         public string UnitInstanceID { get; set; }
 
         public override bool IsMet(GameConditionContext context) =>
-            context.Game.GetSceneNodeByInstanceID<ISceneNode>(
-                UnitInstanceID,
-                includeDisabled: true
-            )
+            context.Game.GetSceneNodeByInstanceID<ISceneNode>(UnitInstanceID, includeDisabled: true)
                 is IMovable { Movement: not null };
     }
 

--- a/Assets/Scripts/Game/Events/GameEventBinding.cs
+++ b/Assets/Scripts/Game/Events/GameEventBinding.cs
@@ -68,10 +68,7 @@ namespace Rebellion.Game.Events
                 );
             Officer officer = hasBinding
                 ? context?.GetBindingReference<Officer>(OfficerBinding)
-                : game.GetSceneNodeByInstanceID<Officer>(
-                    OfficerInstanceID,
-                    includeDisabled: true
-                );
+                : game.GetSceneNodeByInstanceID<Officer>(OfficerInstanceID, includeDisabled: true);
             if (officer == null)
                 throw new InvalidOperationException("OfficerRating could not resolve its officer.");
             return officer.GetEffectiveRating(Rating);
@@ -107,10 +104,7 @@ namespace Rebellion.Game.Events
                 );
             Officer officer = hasBinding
                 ? context?.GetBindingReference<Officer>(OfficerBinding)
-                : game.GetSceneNodeByInstanceID<Officer>(
-                    OfficerInstanceID,
-                    includeDisabled: true
-                );
+                : game.GetSceneNodeByInstanceID<Officer>(OfficerInstanceID, includeDisabled: true);
             if (officer == null)
                 throw new InvalidOperationException("OfficerForce could not resolve its officer.");
             return officer.ForceRank;
@@ -150,10 +144,7 @@ namespace Rebellion.Game.Events
                 );
             Planet planet = hasBinding
                 ? context?.GetBindingReference<Planet>(PlanetBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(
-                    PlanetInstanceID,
-                    includeDisabled: true
-                );
+                : game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID, includeDisabled: true);
             if (planet == null)
                 throw new InvalidOperationException("PlanetStat could not resolve its planet.");
             return planet.GetStatValue(Stat);

--- a/Assets/Scripts/Game/Events/GameEventBinding.cs
+++ b/Assets/Scripts/Game/Events/GameEventBinding.cs
@@ -68,7 +68,10 @@ namespace Rebellion.Game.Events
                 );
             Officer officer = hasBinding
                 ? context?.GetBindingReference<Officer>(OfficerBinding)
-                : game.GetSceneNodeByInstanceID<Officer>(OfficerInstanceID);
+                : game.GetSceneNodeByInstanceID<Officer>(
+                    OfficerInstanceID,
+                    includeDisabled: true
+                );
             if (officer == null)
                 throw new InvalidOperationException("OfficerRating could not resolve its officer.");
             return officer.GetEffectiveRating(Rating);
@@ -104,7 +107,10 @@ namespace Rebellion.Game.Events
                 );
             Officer officer = hasBinding
                 ? context?.GetBindingReference<Officer>(OfficerBinding)
-                : game.GetSceneNodeByInstanceID<Officer>(OfficerInstanceID);
+                : game.GetSceneNodeByInstanceID<Officer>(
+                    OfficerInstanceID,
+                    includeDisabled: true
+                );
             if (officer == null)
                 throw new InvalidOperationException("OfficerForce could not resolve its officer.");
             return officer.ForceRank;
@@ -144,7 +150,10 @@ namespace Rebellion.Game.Events
                 );
             Planet planet = hasBinding
                 ? context?.GetBindingReference<Planet>(PlanetBinding)
-                : game.GetSceneNodeByInstanceID<Planet>(PlanetInstanceID);
+                : game.GetSceneNodeByInstanceID<Planet>(
+                    PlanetInstanceID,
+                    includeDisabled: true
+                );
             if (planet == null)
                 throw new InvalidOperationException("PlanetStat could not resolve its planet.");
             return planet.GetStatValue(Stat);

--- a/Assets/Scripts/Game/Events/GameEventSelectors.cs
+++ b/Assets/Scripts/Game/Events/GameEventSelectors.cs
@@ -19,17 +19,23 @@ namespace Rebellion.Game.Events
         where T : class, ISceneNode
     {
         [PersistableAttribute]
+        public bool IncludeInactive { get; set; }
+
+        [PersistableAttribute]
         public string InstanceID { get; set; }
 
         [PersistableAttribute]
         public string OwnerFactionInstanceID { get; set; }
 
         /// <summary>
-        /// Returns active nodes that match the authored identity filters.
+        /// Returns registered nodes that match the authored activity and identity filters.
         /// </summary>
         protected IEnumerable<T> SelectOwned(GameRoot game)
         {
-            return SelectOwned(Active<T>(game));
+            IEnumerable<T> nodes = IncludeInactive
+                ? game.GetRegisteredSceneNodesByType<T>(includeDisabled: true)
+                : Active<T>(game);
+            return SelectOwned(nodes.Where(node => node.GetParent() != null));
         }
 
         /// <summary>
@@ -131,6 +137,9 @@ namespace Rebellion.Game.Events
     public sealed class SelectPlanetSectors : GameEventSelector
     {
         [PersistableAttribute]
+        public bool IncludeInactive { get; set; }
+
+        [PersistableAttribute]
         public string InstanceID { get; set; }
 
         [PersistableAttribute]
@@ -144,7 +153,10 @@ namespace Rebellion.Game.Events
             IRandomNumberProvider provider,
             GameEventEvaluationContext context
         ) =>
-            Active<PlanetSector>(game)
+            (IncludeInactive
+                ? game.GetRegisteredSceneNodesByType<PlanetSector>(includeDisabled: true)
+                : Active<PlanetSector>(game))
+                .Where(sector => sector.GetParent() != null)
                 .Where(sector =>
                     string.IsNullOrWhiteSpace(InstanceID) || sector.InstanceID == InstanceID
                 )
@@ -162,9 +174,6 @@ namespace Rebellion.Game.Events
     public sealed class SelectOfficers : LocatedSceneNodeSelector<Officer>
     {
         [PersistableAttribute]
-        public bool IncludeInactive { get; set; }
-
-        [PersistableAttribute]
         public bool? IsCaptured { get; set; }
 
         /// <summary>
@@ -176,10 +185,7 @@ namespace Rebellion.Game.Events
             GameEventEvaluationContext context
         )
         {
-            IEnumerable<Officer> officers = IncludeInactive
-                ? game.GetRegisteredSceneNodesByType<Officer>(includeDisabled: true)
-                : Active<Officer>(game);
-            return SelectOwned(officers)
+            return SelectOwned(game)
                 .Where(node => MatchesLocation(node, context, PlanetInstanceID, PlanetBinding))
                 .Where(officer => !IsCaptured.HasValue || officer.IsCaptured == IsCaptured.Value);
         }
@@ -334,6 +340,9 @@ namespace Rebellion.Game.Events
     public sealed class SelectManufacturingOrders : GameEventSelector
     {
         [PersistableAttribute]
+        public bool IncludeInactive { get; set; }
+
+        [PersistableAttribute]
         public string PlanetInstanceID { get; set; }
 
         [PersistableAttribute]
@@ -358,7 +367,10 @@ namespace Rebellion.Game.Events
                 ? context?.GetBindingReference<Planet>(PlanetBinding)
                 : null;
             string planetID = boundPlanet?.InstanceID ?? PlanetInstanceID;
-            IEnumerable<Planet> planets = Active<Planet>(game)
+            IEnumerable<Planet> planets = (IncludeInactive
+                ? game.GetRegisteredSceneNodesByType<Planet>(includeDisabled: true)
+                : Active<Planet>(game))
+                .Where(planet => planet.GetParent() != null)
                 .Where(planet =>
                     string.IsNullOrWhiteSpace(planetID) || planet.InstanceID == planetID
                 )
@@ -515,7 +527,10 @@ namespace Rebellion.Game.Events
                 ISceneNode canonical =
                     node == null
                         ? null
-                        : game.GetSceneNodeByInstanceID<ISceneNode>(node.InstanceID);
+                        : game.GetSceneNodeByInstanceID<ISceneNode>(
+                            node.InstanceID,
+                            includeDisabled: true
+                        );
                 if (canonical == null)
                     throw new InvalidOperationException(
                         $"SelectBinding '{Binding}' contains an unregistered scene node."
@@ -583,11 +598,15 @@ namespace Rebellion.Game.Events
                 );
             ISceneNode unit = hasBinding
                 ? context?.GetBindingReference<ISceneNode>(UnitBinding)
-                : game.GetSceneNodeByInstanceID<ISceneNode>(UnitInstanceID);
+                : game.GetSceneNodeByInstanceID<ISceneNode>(
+                    UnitInstanceID,
+                    includeDisabled: true
+                );
             if (unit == null)
                 return Enumerable.Empty<ISceneNode>();
             ISceneNode parent = game.GetSceneNodeByInstanceID<ISceneNode>(
-                unit.LastParentInstanceID
+                unit.LastParentInstanceID,
+                includeDisabled: true
             );
             return parent == null ? Enumerable.Empty<ISceneNode>() : new[] { parent };
         }

--- a/Assets/Scripts/Game/Events/GameEventSelectors.cs
+++ b/Assets/Scripts/Game/Events/GameEventSelectors.cs
@@ -153,9 +153,11 @@ namespace Rebellion.Game.Events
             IRandomNumberProvider provider,
             GameEventEvaluationContext context
         ) =>
-            (IncludeInactive
-                ? game.GetRegisteredSceneNodesByType<PlanetSector>(includeDisabled: true)
-                : Active<PlanetSector>(game))
+            (
+                IncludeInactive
+                    ? game.GetRegisteredSceneNodesByType<PlanetSector>(includeDisabled: true)
+                    : Active<PlanetSector>(game)
+            )
                 .Where(sector => sector.GetParent() != null)
                 .Where(sector =>
                     string.IsNullOrWhiteSpace(InstanceID) || sector.InstanceID == InstanceID
@@ -367,9 +369,11 @@ namespace Rebellion.Game.Events
                 ? context?.GetBindingReference<Planet>(PlanetBinding)
                 : null;
             string planetID = boundPlanet?.InstanceID ?? PlanetInstanceID;
-            IEnumerable<Planet> planets = (IncludeInactive
-                ? game.GetRegisteredSceneNodesByType<Planet>(includeDisabled: true)
-                : Active<Planet>(game))
+            IEnumerable<Planet> planets = (
+                IncludeInactive
+                    ? game.GetRegisteredSceneNodesByType<Planet>(includeDisabled: true)
+                    : Active<Planet>(game)
+            )
                 .Where(planet => planet.GetParent() != null)
                 .Where(planet =>
                     string.IsNullOrWhiteSpace(planetID) || planet.InstanceID == planetID
@@ -598,10 +602,7 @@ namespace Rebellion.Game.Events
                 );
             ISceneNode unit = hasBinding
                 ? context?.GetBindingReference<ISceneNode>(UnitBinding)
-                : game.GetSceneNodeByInstanceID<ISceneNode>(
-                    UnitInstanceID,
-                    includeDisabled: true
-                );
+                : game.GetSceneNodeByInstanceID<ISceneNode>(UnitInstanceID, includeDisabled: true);
             if (unit == null)
                 return Enumerable.Empty<ISceneNode>();
             ISceneNode parent = game.GetSceneNodeByInstanceID<ISceneNode>(

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -699,7 +699,7 @@ namespace Rebellion.Systems
         /// <param name="newOwner">The faction receiving ownership of the buildings.</param>
         private void TransferBuildings(Planet planet, Faction newOwner)
         {
-            foreach (Building building in planet.GetChildren<Building>())
+            foreach (Building building in planet.GetChildren<Building>(includeDisabled: true))
             {
                 _game.ChangeOwnership(building, newOwner.InstanceID);
             }

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameActionsTests.cs
@@ -273,6 +273,30 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
+        public void PlaceUnits_InactiveExistingUnit_ThrowsInvalidOperationException()
+        {
+            GameRoot game = BuildGame(out Planet destination, out _);
+            Officer officer = new Officer
+            {
+                InstanceID = "inactive-officer",
+                OwnerInstanceID = "empire",
+                IsEnabled = false,
+            };
+            game.AttachNode(officer, destination);
+            PlaceUnitsAction action = new PlaceUnitsAction
+            {
+                UnitInstanceID = officer.InstanceID,
+                DestinationInstanceID = destination.InstanceID,
+            };
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() =>
+                action.ExecuteRequests(game)
+            );
+
+            StringAssert.Contains("requires existing units to be active", exception.Message);
+        }
+
+        [Test]
         public void PlaceUnits_Selectors_RoundTripsTransferStructure()
         {
             PlaceUnitsAction action = new PlaceUnitsAction

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameEventBindingTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameEventBindingTests.cs
@@ -177,11 +177,7 @@ namespace Rebellion.Tests.Game.Events
         {
             GameRoot game = new GameRoot(TestConfig.Create());
             PlanetSector sector = new PlanetSector { InstanceID = "sector" };
-            Planet planet = new Planet
-            {
-                InstanceID = "planet",
-                NumRawResourceNodes = 7,
-            };
+            Planet planet = new Planet { InstanceID = "planet", NumRawResourceNodes = 7 };
             game.AttachNode(sector, game.Galaxy);
             game.AttachNode(planet, sector);
             planet.IsEnabled = false;

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameEventBindingTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameEventBindingTests.cs
@@ -120,6 +120,94 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
+        public void Bind_TypedOfficerSourcesWithInactiveOfficer_StoresResolvedValues()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            Faction faction = new Faction { InstanceID = "faction" };
+            game.GetFactions().Add(faction);
+            PlanetSector sector = new PlanetSector { InstanceID = "sector" };
+            Planet planet = new Planet
+            {
+                InstanceID = "planet",
+                OwnerInstanceID = faction.InstanceID,
+                IsColonized = true,
+            };
+            Officer officer = EntityFactory.CreateOfficer("officer", faction.InstanceID);
+            officer.SetBaseRating(OfficerRating.Combat, 82);
+            officer.ForceValue = 41;
+            game.AttachNode(sector, game.Galaxy);
+            game.AttachNode(planet, sector);
+            game.AttachNode(officer, planet);
+            officer.IsEnabled = false;
+            int expectedCombatRating = officer.GetEffectiveRating(OfficerRating.Combat);
+            int expectedForceRank = officer.ForceRank;
+            GameEventEvaluationContext context = new GameEventEvaluationContext(
+                new GameEvent(),
+                null
+            );
+            IRandomNumberProvider random = new FixedRandomProvider(new[] { 0.5 });
+
+            new GameEventBinding
+            {
+                As = "combat",
+                Sources = new List<GameEventBindingSource>
+                {
+                    new OfficerRatingBindingSource
+                    {
+                        OfficerInstanceID = officer.InstanceID,
+                        Rating = OfficerRating.Combat,
+                    },
+                },
+            }.Bind(game, random, context);
+            new GameEventBinding
+            {
+                As = "force",
+                Sources = new List<GameEventBindingSource>
+                {
+                    new OfficerForceBindingSource { OfficerInstanceID = officer.InstanceID },
+                },
+            }.Bind(game, random, context);
+
+            Assert.AreEqual(expectedCombatRating, context.GetBinding<int>("combat"));
+            Assert.AreEqual(expectedForceRank, context.GetBinding<int>("force"));
+        }
+
+        [Test]
+        public void Bind_PlanetStatWithInactivePlanet_StoresResolvedValue()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            PlanetSector sector = new PlanetSector { InstanceID = "sector" };
+            Planet planet = new Planet
+            {
+                InstanceID = "planet",
+                NumRawResourceNodes = 7,
+            };
+            game.AttachNode(sector, game.Galaxy);
+            game.AttachNode(planet, sector);
+            planet.IsEnabled = false;
+            GameEventEvaluationContext context = new GameEventEvaluationContext(
+                new GameEvent(),
+                null
+            );
+            GameEventBinding binding = new GameEventBinding
+            {
+                As = "resources",
+                Sources = new List<GameEventBindingSource>
+                {
+                    new PlanetStatBindingSource
+                    {
+                        PlanetInstanceID = planet.InstanceID,
+                        Stat = PlanetStat.RawResourceNodes,
+                    },
+                },
+            };
+
+            binding.Bind(game, new FixedRandomProvider(new[] { 0.5 }), context);
+
+            Assert.AreEqual(7, context.GetBinding<int>("resources"));
+        }
+
+        [Test]
         public void RoundTrip_NumericRanges_RestoresConcreteRolls()
         {
             GameEvent gameEvent = new GameEvent

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameEventSelectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameEventSelectorTests.cs
@@ -110,11 +110,7 @@ namespace Rebellion.Tests.Game.Events
                 InstanceID = "capital-ship",
                 OwnerInstanceID = "faction",
             };
-            Fleet fleet = new Fleet
-            {
-                InstanceID = "fleet",
-                OwnerInstanceID = "faction",
-            };
+            Fleet fleet = new Fleet { InstanceID = "fleet", OwnerInstanceID = "faction" };
             game.AttachNode(fleet, planet);
             game.AttachNode(ship, fleet);
             ship.IsEnabled = false;

--- a/Assets/Tests/EditMode/GameTests/Game/Events/GameEventSelectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/GameEventSelectorTests.cs
@@ -102,6 +102,34 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
+        public void SelectCapitalShips_IncludeInactive_ReturnsCapitalShip()
+        {
+            GameRoot game = BuildGame(out Planet planet);
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "capital-ship",
+                OwnerInstanceID = "faction",
+            };
+            Fleet fleet = new Fleet
+            {
+                InstanceID = "fleet",
+                OwnerInstanceID = "faction",
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+            ship.IsEnabled = false;
+            SelectCapitalShips selector = new SelectCapitalShips
+            {
+                InstanceID = ship.InstanceID,
+                IncludeInactive = true,
+            };
+
+            ISceneNode selected = selector.Select(game, new FixedRNG(0), null).Single();
+
+            Assert.AreSame(ship, selected);
+        }
+
+        [Test]
         public void SelectOfficers_IncludeInactiveAtCurrentPlanet_ReturnsOfficer()
         {
             GameRoot game = BuildGame(out Planet planet);
@@ -141,6 +169,45 @@ namespace Rebellion.Tests.Game.Events
                 .Single();
 
             Assert.AreSame(canonical, selected);
+        }
+
+        [Test]
+        public void SelectBinding_InactiveRegisteredNode_ReturnsCanonicalNode()
+        {
+            GameRoot game = BuildGame(out Planet origin);
+            Officer officer = EntityFactory.CreateOfficer("officer", "faction");
+            game.AttachNode(officer, origin);
+            officer.IsEnabled = false;
+            GameEventEvaluationContext context = new GameEventEvaluationContext(
+                new GameEvent(),
+                null,
+                null
+            );
+            context.Bind("officer", officer);
+
+            ISceneNode selected = new SelectBinding { Binding = "officer" }
+                .Select(game, new FixedRNG(0), context)
+                .Single();
+
+            Assert.AreSame(officer, selected);
+        }
+
+        [Test]
+        public void SelectPreviousLocation_InactiveUnit_ReturnsPreviousLocation()
+        {
+            GameRoot game = BuildGame(out Planet planet);
+            Officer officer = EntityFactory.CreateOfficer("officer", "faction");
+            game.AttachNode(officer, planet);
+            officer.LastParentInstanceID = planet.InstanceID;
+            officer.IsEnabled = false;
+            SelectPreviousLocation selector = new SelectPreviousLocation
+            {
+                UnitInstanceID = officer.InstanceID,
+            };
+
+            ISceneNode selected = selector.Select(game, new FixedRNG(0), null).Single();
+
+            Assert.AreSame(planet, selected);
         }
 
         private static GameRoot BuildGame(out Planet planet)

--- a/Assets/Tests/EditMode/GameTests/Game/Events/SceneConditionsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/SceneConditionsTests.cs
@@ -191,6 +191,26 @@ namespace Rebellion.Tests.Game.Events
             Assert.IsTrue(isMet);
         }
 
+        [Test]
+        public void HasForceRank_InactiveOfficer_UsesConfiguredMinimum()
+        {
+            GameRoot game = BuildHierarchy(out Planet planet, out _, out _);
+            Officer officer = EntityFactory.CreateOfficer("officer", "faction");
+            officer.ForceValue = game.Config.Jedi.GetMinimumRank(ForceRankLabel.ForceKnight);
+            game.AttachNode(officer, planet);
+            officer.IsEnabled = false;
+            HasForceRankConditional condition = new HasForceRankConditional
+            {
+                OfficerInstanceID = officer.InstanceID,
+                Comparison = ComparisonOperator.GreaterThanOrEqual,
+                Rank = ForceRankLabel.ForceKnight,
+            };
+
+            bool isMet = condition.IsMet(game);
+
+            Assert.IsTrue(isMet);
+        }
+
         private static GameRoot BuildHierarchy(
             out Planet planet,
             out Fleet fleet,

--- a/Assets/Tests/EditMode/GameTests/Game/Events/SceneConditionsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Events/SceneConditionsTests.cs
@@ -173,6 +173,56 @@ namespace Rebellion.Tests.Game.Events
         }
 
         [Test]
+        public void HasBuildingType_InactivePlanetWithEnabledBuilding_ReturnsTrue()
+        {
+            GameRoot game = BuildHierarchy(out Planet planet, out _, out _);
+            planet.EnergyCapacity = 1;
+            Building building = new Building
+            {
+                InstanceID = "building",
+                OwnerInstanceID = "faction",
+                BuildingType = BuildingType.Defense,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(building, planet);
+            planet.IsEnabled = false;
+            HasBuildingTypeConditional condition = new HasBuildingTypeConditional
+            {
+                PlanetInstanceID = planet.InstanceID,
+                Type = BuildingType.Defense,
+            };
+
+            bool isMet = condition.IsMet(game);
+
+            Assert.IsTrue(isMet);
+        }
+
+        [Test]
+        public void HasBuildingType_DisabledBuilding_ReturnsFalse()
+        {
+            GameRoot game = BuildHierarchy(out Planet planet, out _, out _);
+            planet.EnergyCapacity = 1;
+            Building building = new Building
+            {
+                InstanceID = "building",
+                OwnerInstanceID = "faction",
+                BuildingType = BuildingType.Defense,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                IsEnabled = false,
+            };
+            game.AttachNode(building, planet);
+            HasBuildingTypeConditional condition = new HasBuildingTypeConditional
+            {
+                PlanetInstanceID = planet.InstanceID,
+                Type = BuildingType.Defense,
+            };
+
+            bool isMet = condition.IsMet(game);
+
+            Assert.IsFalse(isMet);
+        }
+
+        [Test]
         public void HasForceRank_ConfiguredSemanticRank_UsesConfiguredMinimum()
         {
             GameRoot game = BuildHierarchy(out Planet planet, out _, out _);

--- a/Assets/Tests/EditMode/GameTests/Systems/PlanetaryControlSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/PlanetaryControlSystemTests.cs
@@ -103,6 +103,20 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void TransferPlanet_InactivePlanet_TransfersRetainedBuildingsToNewOwner()
+        {
+            _game.ChangeOwnership(_targetPlanet, "empire");
+            _targetPlanet.EnergyCapacity = 1;
+            Building building = new Building { InstanceID = "b1", OwnerInstanceID = "empire" };
+            _game.AttachNode(building, _targetPlanet);
+            _targetPlanet.IsEnabled = false;
+
+            _ownershipSystem.TransferPlanet(_targetPlanet, _rebels);
+
+            Assert.AreEqual("rebels", building.GetOwnerInstanceID());
+        }
+
+        [Test]
         public void TransferPlanet_HiddenObserverSnapshot_NotRefreshed()
         {
             Faction observer = AddFaction("observer");

--- a/Docs/Modding/Events/Actions.md
+++ b/Docs/Modding/Events/Actions.md
@@ -3,6 +3,10 @@
 Actions change game state. They execute from top to bottom against one shared context, so later
 actions observe earlier state changes.
 
+Direct `InstanceID` and binding targets resolve retained inactive objects. Collection selectors are
+active-only unless `IncludeInactive="true"` is set. Actions that inherently require active
+participation, such as `SendUnits` and `TriggerDuel`, still reject inactive targets.
+
 Requests and results produced by event actions retain the source event's `InstanceID`. They can
 activate other result-triggered events, but they do not generate automatic strategy messages.
 Use `SendMessage` when the event should communicate with a player.

--- a/Docs/Modding/Events/Bindings.md
+++ b/Docs/Modding/Events/Bindings.md
@@ -9,6 +9,10 @@ Binding values are temporary. They are rebuilt whenever the event is evaluated a
 in the save game. A binding's `As` value is its exact name. Every option that consumes the binding
 must use that same name exactly.
 
+An explicit `OfficerInstanceID`, `PlanetInstanceID`, or scene-node binding resolves retained
+inactive objects as well as active objects. Collection selectors remain active-only unless they set
+`IncludeInactive="true"`.
+
 ## Top-level bindings
 
 Each top-level `Bind` resolves exactly one value and exposes it under its `As` name for the complete

--- a/Docs/Modding/Events/Conditionals.md
+++ b/Docs/Modding/Events/Conditionals.md
@@ -3,6 +3,9 @@
 Conditionals inspect game state without changing it. Every top-level conditional must pass before
 an event activates.
 
+Conditionals that name an object by `InstanceID` inspect retained inactive objects as well as active
+objects. Use `IsActive` when activity itself is part of the condition.
+
 ```xml
 <Conditionals>
   <IsOwned PlanetInstanceID="NABOO" FactionInstanceID="FNALL1"/>

--- a/Docs/Modding/Events/Selectors.md
+++ b/Docs/Modding/Events/Selectors.md
@@ -1,7 +1,12 @@
 # Selectors
 
-Selectors find typed collections of scene nodes for bindings, conditionals, and actions. Direct
-selectors return every active matching object when no optional filter is supplied.
+Selectors find typed collections of scene nodes for bindings, conditionals, and actions. They
+return active matching objects by default. Set `IncludeInactive="true"` when a collection scan must
+also include retained objects that have been removed from normal gameplay. Direct instance-ID
+references on bindings, conditionals, and actions resolve retained objects regardless of activity;
+an `InstanceID` filter on a selector still requires `IncludeInactive="true"` to match an inactive
+object. Actions such as `SendUnits` still reject inactive objects when the operation itself requires
+active participation.
 
 ## Planet selectors
 
@@ -12,6 +17,7 @@ Selects active, non-destroyed planets.
 **Optional options**
 
 - `InstanceID` **[Optional]:** The `InstanceID` of the planet to select.
+- `IncludeInactive` **[Optional]:** Include inactive retained planets; defaults to `false`.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must currently own the planet.
 - `SectorType` **[Optional]:** Require `Core` or `OuterRim`.
 
@@ -26,6 +32,7 @@ Selects planet sectors.
 **Optional options**
 
 - `InstanceID` **[Optional]:** The `InstanceID` of the planet sector to select.
+- `IncludeInactive` **[Optional]:** Include inactive retained planet sectors; defaults to `false`.
 - `SectorType` **[Optional]:** `Core` or `OuterRim` filter.
 
 ```xml
@@ -43,7 +50,7 @@ Selects officers.
 - `InstanceID` **[Optional]:** The `InstanceID` of the officer to select.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must own the officer.
 - `IsCaptured` **[Optional]:** Capture-state filter.
-- `IncludeInactive` **[Optional]:** Include inactive officers; defaults to `false`.
+- `IncludeInactive` **[Optional]:** Include inactive retained officers; defaults to `false`.
 - `PlanetInstanceID` **[Optional]:** The `InstanceID` of the planet where the officer must be located.
 - `PlanetBinding` **[Optional]:** Bound location. Takes precedence over `PlanetInstanceID`.
 
@@ -60,6 +67,7 @@ Selects special-forces units.
 **Optional options**
 
 - `InstanceID` **[Optional]:** The `InstanceID` of the special-forces unit to select.
+- `IncludeInactive` **[Optional]:** Include inactive retained special-forces units; defaults to `false`.
 - `PlanetInstanceID` **[Optional]:** The `InstanceID` of the planet where the unit must be located.
 - `PlanetBinding` **[Optional]:** Bound location. Takes precedence over `PlanetInstanceID`.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must own the unit.
@@ -75,6 +83,7 @@ Selects missions.
 **Optional options**
 
 - `InstanceID` **[Optional]:** The `InstanceID` of the mission to select.
+- `IncludeInactive` **[Optional]:** Include inactive retained missions; defaults to `false`.
 - `PlanetInstanceID` **[Optional]:** The `InstanceID` of the planet where the mission must be located.
 - `PlanetBinding` **[Optional]:** Bound location. Takes precedence over `PlanetInstanceID`.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must own the mission.
@@ -92,6 +101,7 @@ Selects fleets.
 **Optional options**
 
 - `InstanceID` **[Optional]:** The `InstanceID` of the fleet to select.
+- `IncludeInactive` **[Optional]:** Include inactive retained fleets; defaults to `false`.
 - `PlanetInstanceID` **[Optional]:** The `InstanceID` of the planet where the fleet must be located.
 - `PlanetBinding` **[Optional]:** Bound location. Takes precedence over `PlanetInstanceID`.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must own the fleet.
@@ -107,6 +117,7 @@ Selects capital ships.
 **Optional options**
 
 - `InstanceID` **[Optional]:** The `InstanceID` of the capital ship to select.
+- `IncludeInactive` **[Optional]:** Include inactive retained capital ships; defaults to `false`.
 - `PlanetInstanceID` **[Optional]:** The `InstanceID` of the planet where the capital ship must be located.
 - `PlanetBinding` **[Optional]:** Bound location. Takes precedence over `PlanetInstanceID`.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must own the capital ship.
@@ -115,6 +126,8 @@ Selects capital ships.
 
 ```xml
 <SelectCapitalShips TypeID="ALCS008" ManufacturingStatus="Complete"/>
+
+<SelectCapitalShips InstanceID="RETAINED_SHIP" IncludeInactive="true"/>
 ```
 
 ### SelectStarfighters
@@ -124,6 +137,7 @@ Selects starfighters. It supports the same filters as `SelectCapitalShips`.
 **Optional options**
 
 - `InstanceID` **[Optional]:** The `InstanceID` of the starfighter to select.
+- `IncludeInactive` **[Optional]:** Include inactive retained starfighters; defaults to `false`.
 - `PlanetInstanceID` **[Optional]:** The `InstanceID` of the planet where the starfighter must be located.
 - `PlanetBinding` **[Optional]:** Bound location. Takes precedence over `PlanetInstanceID`.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must own the starfighter.
@@ -143,6 +157,7 @@ Selects regiments. It supports the same filters as `SelectCapitalShips`.
 **Optional options**
 
 - `InstanceID` **[Optional]:** The `InstanceID` of the regiment to select.
+- `IncludeInactive` **[Optional]:** Include inactive retained regiments; defaults to `false`.
 - `PlanetInstanceID` **[Optional]:** The `InstanceID` of the planet where the regiment must be located.
 - `PlanetBinding` **[Optional]:** Bound location. Takes precedence over `PlanetInstanceID`.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must own the regiment.
@@ -160,6 +175,7 @@ Selects buildings.
 **Optional options**
 
 - `InstanceID` **[Optional]:** The `InstanceID` of the building to select.
+- `IncludeInactive` **[Optional]:** Include inactive retained buildings; defaults to `false`.
 - `PlanetInstanceID` **[Optional]:** The `InstanceID` of the planet where the building must be located.
 - `PlanetBinding` **[Optional]:** Bound location. Takes precedence over `PlanetInstanceID`.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must own the building.
@@ -181,6 +197,7 @@ Selects queued manufacturing items.
 **Optional options**
 
 - `PlanetInstanceID` **[Optional]:** The `InstanceID` of the planet whose manufacturing orders are selected.
+- `IncludeInactive` **[Optional]:** Include orders from inactive retained planets; defaults to `false`.
 - `PlanetBinding` **[Optional]:** Bound location. Takes precedence over `PlanetInstanceID`.
 - `OwnerFactionInstanceID` **[Optional]:** The `InstanceID` of the faction that must own the manufacturing planet.
 - `ManufacturingType` **[Optional]:** `Ship`, `Building`, or `Troop` filter.
@@ -256,8 +273,8 @@ checks candidates in authored order and uses the first one that accepts the unit
 
 ### SelectBinding
 
-Returns the scene node or scene-node collection stored by an explicit event binding. Its runtime
-type must be valid for the consumer.
+Returns the retained scene node or scene-node collection stored by an explicit event binding,
+including inactive nodes. Its runtime type must be valid for the consumer.
 
 **Required options**
 
@@ -291,7 +308,8 @@ Maps each source to its nearest parent of the requested type. It never returns t
 
 ### SelectPreviousLocation
 
-Returns a unit's registered `LastParentInstanceID` when that node still resolves.
+Returns a retained unit's registered `LastParentInstanceID` when that node still resolves. Both the
+unit and remembered location may be inactive.
 
 **Required options**
 


### PR DESCRIPTION
## Summary

- Resolve explicitly referenced retained scene nodes even when they are inactive.
- Add `IncludeInactive` to collection selectors while preserving active-only defaults.
- Keep actions that require active participation, including movement and duels, explicitly guarded.
- Document the activity rules and add regression coverage for officers, planets, capital ships, bindings, and previous locations.
- Paired media schema update is prepared in `rebellion2-media` on the matching branch.

## Validation

- `./build.sh test` — 4,540 passed.
- `./build.sh lint` — passed with zero diagnostics.
- `rebellion2-media/./build.sh lint` — XML formatting and schema validation passed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (`./build.sh test` invokes `UIBuilderMenu.BuildAll`; no UI builder files changed.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Matching schema update prepared.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.