### PR TITLE
Preserving unlinked classes used through reflection.

### DIFF
--- a/Assets/Scripts/Util/Serialization/PersistableObjectAttribute.cs
+++ b/Assets/Scripts/Util/Serialization/PersistableObjectAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine.Scripting;
 
 namespace Rebellion.Util.Serialization
 {
@@ -14,7 +15,7 @@ namespace Rebellion.Util.Serialization
         Inherited = true,
         AllowMultiple = false
     )]
-    public class PersistableObjectAttribute : Attribute
+    public class PersistableObjectAttribute : PreserveAttribute
     {
         public string Name { get; set; }
 


### PR DESCRIPTION
## Summary

- Make `PersistableObjectAttribute` inherit Unity’s `PreserveAttribute`.
- Prevent UnityLinker from stripping concrete serializer types that are discovered only through reflection.
- Keep preservation coupled to the existing serializer marker instead of maintaining a separate `link.xml` registry.

## Validation

- Full EditMode suite: 4,554 passed, 0 failed.
- Standalone macOS player build: passed.
- Inspected the packaged `GameAssembly.dll` and confirmed `OfficerRatingBindingSource`, `OfficerForceBindingSource`, `PlanetStatBindingSource`, and `SelectionCountBindingSource` are retained.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.

UI, media, and documentation are unaffected by this linker-preservation change.