### PR TITLE
Fixing issue where battle result messages did not open the location of the battle.

### DIFF
--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayProjector.cs
@@ -59,11 +59,7 @@ public sealed class GalacticInformationDisplayProjector
             theme.GetBackgroundColor(),
             ProjectFrame(theme.Frame, selector.Width, selector.Height, context),
             categories,
-            ProjectDisplayOffRow(
-                theme,
-                state.DisplayOffHovered,
-                highlightColor
-            )
+            ProjectDisplayOffRow(theme, state.DisplayOffHovered, highlightColor)
         );
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayProjector.cs
@@ -62,9 +62,7 @@ public sealed class GalacticInformationDisplayProjector
             ProjectDisplayOffRow(
                 theme,
                 state.DisplayOffHovered,
-                state.SelectedFilterMode == GalacticInformationFilterMode.DisplayOff,
-                highlightColor,
-                checkMarkTexture
+                highlightColor
             )
         );
     }
@@ -332,16 +330,12 @@ public sealed class GalacticInformationDisplayProjector
     /// </summary>
     /// <param name="theme">The active galactic-information theme.</param>
     /// <param name="hovered">Whether the display-off row is hovered.</param>
-    /// <param name="selected">Whether the display-off row is currently selected.</param>
     /// <param name="highlightColor">The active faction highlight color.</param>
-    /// <param name="checkMarkTexture">The shared selected-state check-mark texture.</param>
     /// <returns>The immutable display-off row presentation.</returns>
     private static GalacticInformationTextRowRenderData ProjectDisplayOffRow(
         GalacticInformationDisplayTheme theme,
         bool hovered,
-        bool selected,
-        Color highlightColor,
-        Texture2D checkMarkTexture
+        Color highlightColor
     )
     {
         SourceRectLayout row = theme?.DisplayOffRowSourceLayout;
@@ -353,7 +347,7 @@ public sealed class GalacticInformationDisplayProjector
             true,
             bounds,
             new GalacticInformationImageRenderData(
-                selected ? checkMarkTexture : null,
+                null,
                 new RectInt(
                     row.X - theme.MenuIconSourceLayout.Width,
                     row.Y,

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapController.cs
@@ -38,9 +38,9 @@ public sealed class GalaxyMapController
         string,
         GalaxyMapPlanet
     >(StringComparer.Ordinal);
-    private readonly Dictionary<string, PlanetSector> sectorsByInstanceId = new Dictionary<
+    private readonly Dictionary<string, GalaxyMapSector> sectorsByInstanceId = new Dictionary<
         string,
-        PlanetSector
+        GalaxyMapSector
     >(StringComparer.Ordinal);
 
     private IGalaxyMapActions actions;
@@ -277,6 +277,20 @@ public sealed class GalaxyMapController
     }
 
     /// <summary>
+    /// Finds a sector projection in the current galaxy-map snapshot.
+    /// </summary>
+    /// <param name="instanceId">The planet-sector instance identifier.</param>
+    /// <returns>The matching projected sector, or null when it is not visible.</returns>
+    public GalaxyMapSector FindSector(string instanceId)
+    {
+        return
+            !string.IsNullOrEmpty(instanceId)
+            && sectorsByInstanceId.TryGetValue(instanceId, out GalaxyMapSector sector)
+            ? sector
+            : null;
+    }
+
+    /// <summary>
     /// Handles a cluster hover transition emitted by the authored map view.
     /// </summary>
     /// <param name="sectorInstanceId">The hovered planet-sector identifier.</param>
@@ -309,9 +323,9 @@ public sealed class GalaxyMapController
     {
         if (
             !string.IsNullOrEmpty(sectorInstanceId)
-            && sectorsByInstanceId.TryGetValue(sectorInstanceId, out PlanetSector sector)
+            && sectorsByInstanceId.TryGetValue(sectorInstanceId, out GalaxyMapSector sector)
         )
-            actions.OpenPlanetSectorWindow(sector, sourceX, sourceY);
+            actions.OpenPlanetSectorWindow(sector.PlanetSector, sourceX, sourceY);
     }
 
     /// <summary>
@@ -375,7 +389,7 @@ public sealed class GalaxyMapController
         foreach (GalaxyMapSector sector in sectors)
         {
             if (!string.IsNullOrEmpty(sector?.PlanetSector?.InstanceID))
-                sectorsByInstanceId[sector.PlanetSector.InstanceID] = sector.PlanetSector;
+                sectorsByInstanceId[sector.PlanetSector.InstanceID] = sector;
 
             if (sector?.Planets == null)
                 continue;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -2128,7 +2128,12 @@ public sealed class StrategyController
     /// <param name="sourceY">The source window's vertical coordinate.</param>
     void IBattleAlertWindowActions.OpenBattleResultFleet(Planet planet, int sourceX, int sourceY)
     {
-        OpenPlanetWindow(planet, PlanetIcon.Fleet, sourceX, sourceY);
+        GalaxyMapPlanet strategyPlanet = galaxyMapController.FindPlanet(planet?.InstanceID);
+        if (strategyPlanet == null || !OpenPlanetSectorWindow(strategyPlanet.Sector))
+            return;
+
+        OpenPlanetWindowAt(strategyPlanet, PlanetIcon.Fleet, sourceX, sourceY);
+        MarkDirty();
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -2754,9 +2754,7 @@ public sealed class StrategyController
     /// <returns>True when the sector was opened or focused.</returns>
     private bool OpenPlanetSectorWindow(PlanetSector planetSector)
     {
-        GalaxyMapSector sector = Sectors.FirstOrDefault(candidate =>
-            candidate.PlanetSector == planetSector
-        );
+        GalaxyMapSector sector = galaxyMapController.FindSector(planetSector?.InstanceID);
         return OpenPlanetSectorWindow(sector);
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -2323,28 +2323,6 @@ public sealed class StrategyController
     }
 
     /// <summary>
-    /// Opens a category window for an authoritative planet entity.
-    /// </summary>
-    /// <param name="planet">The planet whose feature window should open.</param>
-    /// <param name="icon">The requested feature category.</param>
-    /// <param name="sourceX">The source-space horizontal position.</param>
-    /// <param name="sourceY">The source-space vertical position.</param>
-    private void OpenPlanetWindow(Planet planet, PlanetIcon icon, int sourceX, int sourceY)
-    {
-        if (planet == null || icon == PlanetIcon.None)
-            return;
-
-        GalaxyMapPlanet strategyPlanet = Sectors
-            .SelectMany(sector => sector.Planets)
-            .FirstOrDefault(item => item.Planet?.InstanceID == planet.InstanceID);
-        if (strategyPlanet == null)
-            return;
-
-        OpenPlanetWindowAt(strategyPlanet, icon, sourceX, sourceY);
-        MarkDirty();
-    }
-
-    /// <summary>
     /// Opens the most specific strategy location represented by message identifiers.
     /// </summary>
     /// <param name="targetInstanceId">The preferred target identifier.</param>

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayProjectorTests.cs
@@ -133,6 +133,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             Assert.IsTrue(data.DisplayOffRow.Visible);
             Assert.AreEqual(theme.DisplayOffLabel, data.DisplayOffRow.Label.Text);
             Assert.AreEqual(Color.white, data.DisplayOffRow.Label.Color);
+            Assert.IsNull(data.DisplayOffRow.CheckMark.Texture);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapControllerTests.cs
@@ -166,6 +166,39 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
+        public void FindSector_CurrentSnapshot_ReturnsProjectedSectorByInstanceID()
+        {
+            _controller.Render(
+                new[] { _sector },
+                _playerFactionId,
+                GalacticInformationFilterMode.DisplayOff
+            );
+            GalaxyPlanetSector liveSector = new GalaxyPlanetSector
+            {
+                InstanceID = _sector.PlanetSector.InstanceID,
+            };
+
+            GalaxyMapSector sector = _controller.FindSector(liveSector.InstanceID);
+
+            Assert.AreSame(_sector, sector);
+            Assert.AreNotSame(liveSector, sector.PlanetSector);
+        }
+
+        [Test]
+        public void FindSector_SectorOutsideCurrentSnapshot_ReturnsNull()
+        {
+            _controller.Render(
+                new[] { _sector },
+                _playerFactionId,
+                GalacticInformationFilterMode.DisplayOff
+            );
+
+            GalaxyMapSector sector = _controller.FindSector("hidden-sector");
+
+            Assert.IsNull(sector);
+        }
+
+        [Test]
         public void ClearHover_NoHoveredSector_ReturnsFalse()
         {
             Assert.IsFalse(_controller.ClearHover());


### PR DESCRIPTION
## Summary

- Resolve battle-result planets and sectors from the current projected galaxy-map snapshot before opening their windows.
- Open the containing sector before opening a battle planet’s fleet window.
- Remove the checkmark from the Display Off row.

## Validation

- `dotnet csharpier check Assets/`
- Existing targeted tests cover projected planet and sector lookup and the Display Off presentation.
- Full CI is rerunning after the formatting correction.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. Not applicable; no UI builder or prefab changed.
- [x] Content path or structure changes were also made in `rebellion2-media`. Not applicable; no content path or structure changed.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. Not applicable; no public setup or API changed.