### PR TITLE
Showing fatal load errors

### DIFF
--- a/Assets/Scripts/App/AppBootstrap.cs
+++ b/Assets/Scripts/App/AppBootstrap.cs
@@ -92,10 +92,11 @@ public sealed class AppBootstrap : MonoBehaviour
         {
             InitializeRuntimeCore();
         }
-        catch
+        catch (System.Exception exception)
         {
             ReleaseRuntimeServices();
             Instance = null;
+            FatalErrorScreen.Show(exception, "Application initialization");
             throw;
         }
     }

--- a/Assets/Scripts/App/FatalErrorReport.cs
+++ b/Assets/Scripts/App/FatalErrorReport.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Text;
+using Rebellion.Game;
+using UnityEngine;
+
+/// <summary>
+/// Contains a player-visible fatal startup error and its persisted diagnostic report.
+/// </summary>
+internal sealed class FatalErrorReport
+{
+    internal string ErrorID { get; }
+
+    internal string Stage { get; }
+
+    internal string Message { get; }
+
+    internal string Contents { get; }
+
+    internal string DirectoryPath { get; }
+
+    internal string FilePath { get; }
+
+    internal string WriteFailure { get; }
+
+    /// <summary>
+    /// Creates a diagnostic report and writes it beneath the application's persistent data path.
+    /// </summary>
+    /// <param name="exception">The fatal exception.</param>
+    /// <param name="stage">The application stage that could not complete.</param>
+    /// <param name="directoryPath">The report directory, or null to use the application log directory.</param>
+    /// <param name="timestamp">The report timestamp, or null to use the current local time.</param>
+    /// <param name="identifier">The unique identifier suffix, or null to generate one.</param>
+    /// <returns>The diagnostic report, including any failure encountered while writing it.</returns>
+    internal static FatalErrorReport Create(
+        Exception exception,
+        string stage,
+        string directoryPath = null,
+        DateTimeOffset? timestamp = null,
+        string identifier = null
+    )
+    {
+        if (exception == null)
+            throw new ArgumentNullException(nameof(exception));
+
+        DateTimeOffset occurredAt = timestamp ?? DateTimeOffset.Now;
+        string suffix = string.IsNullOrWhiteSpace(identifier)
+            ? Guid.NewGuid().ToString("N").Substring(0, 6).ToUpperInvariant()
+            : identifier.Trim().ToUpperInvariant();
+        string errorID = $"LOAD-{occurredAt:yyyyMMdd-HHmmss}-{suffix}";
+        string resolvedStage = string.IsNullOrWhiteSpace(stage) ? "Application startup" : stage;
+        string resolvedDirectory =
+            directoryPath ?? Path.Combine(Application.persistentDataPath, "Logs");
+        string contents = BuildContents(exception, resolvedStage, errorID, occurredAt);
+        string filePath = Path.Combine(resolvedDirectory, $"error-{errorID}.txt");
+        string writeFailure = null;
+
+        try
+        {
+            Directory.CreateDirectory(resolvedDirectory);
+            File.WriteAllText(filePath, contents);
+        }
+        catch (Exception writeException)
+        {
+            filePath = null;
+            writeFailure = writeException.Message;
+        }
+
+        return new FatalErrorReport(
+            errorID,
+            resolvedStage,
+            exception.Message,
+            contents,
+            resolvedDirectory,
+            filePath,
+            writeFailure
+        );
+    }
+
+    /// <summary>
+    /// Stores one complete fatal-error report.
+    /// </summary>
+    private FatalErrorReport(
+        string errorID,
+        string stage,
+        string message,
+        string contents,
+        string directoryPath,
+        string filePath,
+        string writeFailure
+    )
+    {
+        ErrorID = errorID;
+        Stage = stage;
+        Message = message;
+        Contents = contents;
+        DirectoryPath = directoryPath;
+        FilePath = filePath;
+        WriteFailure = writeFailure;
+    }
+
+    /// <summary>
+    /// Formats application, launch, and exception details for diagnostics.
+    /// </summary>
+    /// <param name="exception">The fatal exception.</param>
+    /// <param name="stage">The application stage that failed.</param>
+    /// <param name="errorID">The player-visible error identifier.</param>
+    /// <param name="occurredAt">The local failure timestamp.</param>
+    /// <returns>The complete plain-text report.</returns>
+    private static string BuildContents(
+        Exception exception,
+        string stage,
+        string errorID,
+        DateTimeOffset occurredAt
+    )
+    {
+        StringBuilder report = new StringBuilder();
+        report.AppendLine($"Error ID: {errorID}");
+        report.AppendLine($"Occurred: {occurredAt:O}");
+        report.AppendLine($"Stage: {stage}");
+        report.AppendLine($"Product: {Application.productName}");
+        report.AppendLine($"Version: {Application.version}");
+        report.AppendLine($"Unity: {Application.unityVersion}");
+        report.AppendLine($"Platform: {Application.platform}");
+        AppendLaunchContext(report);
+        report.AppendLine();
+        report.AppendLine("Exception:");
+        report.AppendLine(exception.ToString());
+        return report.ToString();
+    }
+
+    /// <summary>
+    /// Appends available content and save identifiers without requiring initialized runtime services.
+    /// </summary>
+    /// <param name="report">The report receiving launch metadata.</param>
+    private static void AppendLaunchContext(StringBuilder report)
+    {
+        try
+        {
+            GameSummary summary = GameLaunchContext.Summary;
+            report.AppendLine($"Content pack: {summary?.PackID ?? "Unavailable"}");
+            report.AppendLine($"Content version: {summary?.PackVersion ?? "Unavailable"}");
+            report.AppendLine($"Scenario: {summary?.ScenarioID ?? "Unavailable"}");
+            report.AppendLine($"Player faction: {summary?.PlayerFactionID ?? "Unavailable"}");
+            report.AppendLine(
+                $"Launch type: {(GameLaunchContext.IsLoadGame ? "Load game" : "New game")}"
+            );
+            report.AppendLine($"Save file: {GameLaunchContext.SaveFileName ?? "None"}");
+        }
+        catch (Exception metadataException)
+        {
+            report.AppendLine($"Launch metadata unavailable: {metadataException.Message}");
+        }
+    }
+}

--- a/Assets/Scripts/App/FatalErrorReport.cs.meta
+++ b/Assets/Scripts/App/FatalErrorReport.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8ee66dd98a8e344fd87d42367801b8c3

--- a/Assets/Scripts/App/FatalErrorScreen.cs
+++ b/Assets/Scripts/App/FatalErrorScreen.cs
@@ -1,0 +1,157 @@
+using System;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Presents a content-independent fallback when the application cannot finish loading.
+/// </summary>
+internal sealed class FatalErrorScreen : MonoBehaviour
+{
+    private const int _windowWidth = 760;
+    private const int _windowHeight = 430;
+
+    private static FatalErrorScreen instance;
+
+    private FatalErrorReport report;
+    private bool canReturnToMainMenu;
+    private Vector2 reportScrollPosition;
+
+    /// <summary>
+    /// Records a fatal loading exception and takes over presentation with the fallback screen.
+    /// </summary>
+    /// <param name="exception">The exception that prevented loading.</param>
+    /// <param name="stage">The application stage that failed.</param>
+    /// <param name="allowMainMenuReturn">Whether the initialized application can safely return to its menu.</param>
+    internal static void Show(Exception exception, string stage, bool allowMainMenuReturn = false)
+    {
+        if (exception == null)
+            throw new ArgumentNullException(nameof(exception));
+
+        if (instance != null)
+            return;
+
+        Debug.LogException(exception);
+        GameObject root = new GameObject("FatalErrorScreen");
+        DontDestroyOnLoad(root);
+        instance = root.AddComponent<FatalErrorScreen>();
+        instance.report = FatalErrorReport.Create(exception, stage);
+        instance.canReturnToMainMenu = allowMainMenuReturn;
+        Time.timeScale = 0f;
+        AudioManager.Instance?.StopSfx();
+        AudioManager.Instance?.StopMusic();
+    }
+
+    /// <summary>
+    /// Clears the singleton reference when the fallback screen is destroyed.
+    /// </summary>
+    private void OnDestroy()
+    {
+        if (instance == this)
+            instance = null;
+    }
+
+    /// <summary>
+    /// Draws the fallback without relying on content packs, prefabs, or authored fonts.
+    /// </summary>
+    private void OnGUI()
+    {
+        if (report == null)
+            return;
+
+        GUI.depth = int.MinValue;
+        Color previousColor = GUI.color;
+        GUI.color = Color.black;
+        GUI.DrawTexture(new Rect(0f, 0f, Screen.width, Screen.height), Texture2D.whiteTexture);
+        GUI.color = previousColor;
+
+        float width = Mathf.Min(_windowWidth, Screen.width - 40f);
+        float height = Mathf.Min(_windowHeight, Screen.height - 40f);
+        Rect area = new Rect(
+            (Screen.width - width) * 0.5f,
+            (Screen.height - height) * 0.5f,
+            width,
+            height
+        );
+        GUILayout.BeginArea(area);
+        DrawHeading();
+        DrawReportLocation();
+        DrawExceptionSummary();
+        GUILayout.FlexibleSpace();
+        DrawCommands();
+        GUILayout.EndArea();
+    }
+
+    /// <summary>
+    /// Draws the player-facing failure heading and error identifier.
+    /// </summary>
+    private void DrawHeading()
+    {
+        GUIStyle heading = new GUIStyle(GUI.skin.label)
+        {
+            fontSize = 26,
+            fontStyle = FontStyle.Bold,
+            wordWrap = true,
+        };
+        GUIStyle subheading = new GUIStyle(GUI.skin.label) { fontSize = 15, wordWrap = true };
+        GUILayout.Label("Rebellion 2 could not finish loading.", heading);
+        GUILayout.Space(8f);
+        GUILayout.Label($"{report.Stage} failed. Error ID: {report.ErrorID}", subheading);
+        GUILayout.Space(12f);
+    }
+
+    /// <summary>
+    /// Draws the diagnostic report destination or its write failure.
+    /// </summary>
+    private void DrawReportLocation()
+    {
+        GUIStyle body = new GUIStyle(GUI.skin.label) { fontSize = 14, wordWrap = true };
+        string location =
+            report.FilePath != null
+                ? $"A diagnostic report was written to:\n{report.FilePath}"
+                : $"The diagnostic report could not be written: {report.WriteFailure}";
+        GUILayout.Label(location, body);
+        GUILayout.Space(12f);
+    }
+
+    /// <summary>
+    /// Draws the exception summary in a scrollable selectable field.
+    /// </summary>
+    private void DrawExceptionSummary()
+    {
+        GUIStyle detail = new GUIStyle(GUI.skin.textArea) { fontSize = 13, wordWrap = true };
+        reportScrollPosition = GUILayout.BeginScrollView(
+            reportScrollPosition,
+            GUILayout.Height(145f)
+        );
+        GUILayout.TextArea(report.Message, detail, GUILayout.ExpandHeight(true));
+        GUILayout.EndScrollView();
+    }
+
+    /// <summary>
+    /// Draws recovery and diagnostic commands available from the fatal state.
+    /// </summary>
+    private void DrawCommands()
+    {
+        GUILayout.BeginHorizontal();
+        if (GUILayout.Button("Copy Report", GUILayout.Height(36f)))
+            GUIUtility.systemCopyBuffer = report.Contents;
+        if (report.FilePath != null && GUILayout.Button("Open Log Folder", GUILayout.Height(36f)))
+            Application.OpenURL(new Uri(report.DirectoryPath).AbsoluteUri);
+        if (canReturnToMainMenu && GUILayout.Button("Return to Main Menu", GUILayout.Height(36f)))
+            ReturnToMainMenu();
+        if (GUILayout.Button("Quit", GUILayout.Height(36f)))
+            Application.Quit();
+        GUILayout.EndHorizontal();
+    }
+
+    /// <summary>
+    /// Ends any partial game session and loads the already initialized main menu.
+    /// </summary>
+    private void ReturnToMainMenu()
+    {
+        AppBootstrap.Instance?.GetRuntime()?.EndGame();
+        Time.timeScale = 1f;
+        Destroy(gameObject);
+        SceneManager.LoadScene("MainMenu", LoadSceneMode.Single);
+    }
+}

--- a/Assets/Scripts/App/FatalErrorScreen.cs.meta
+++ b/Assets/Scripts/App/FatalErrorScreen.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c549aef5863b49ab8e5de2f5398dea7

--- a/Assets/Scripts/UI/SceneUI/Boot/BootController.cs
+++ b/Assets/Scripts/UI/SceneUI/Boot/BootController.cs
@@ -32,7 +32,7 @@ public sealed class BootController : MonoBehaviour
         }
         catch (Exception exception)
         {
-            Debug.LogException(exception);
+            FatalErrorScreen.Show(exception, "Boot content loading");
         }
     }
 

--- a/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
+++ b/Assets/Scripts/UI/SceneUI/MainMenu/MainMenuController.cs
@@ -102,7 +102,7 @@ public sealed class MainMenuController : MonoBehaviour
         }
         catch (System.Exception exception)
         {
-            Debug.LogException(exception);
+            FatalErrorScreen.Show(exception, "Main menu loading");
         }
     }
 

--- a/Assets/Scripts/UI/SceneUI/SceneLoader.cs
+++ b/Assets/Scripts/UI/SceneUI/SceneLoader.cs
@@ -51,11 +51,13 @@ public sealed class SceneLoader : MonoBehaviour
         {
             _loadCoroutine = null;
             GameStartupTrace.Complete($"Content initialization for '{sceneName}' failed.");
-            Debug.LogException(
+            FatalErrorScreen.Show(
                 initialization.Exception?.GetBaseException()
                     ?? new InvalidOperationException(
                         "Local content initialization failed without an exception."
-                    )
+                    ),
+                $"{sceneName} content loading",
+                allowMainMenuReturn: sceneName == "StrategyView"
             );
             yield break;
         }
@@ -66,7 +68,11 @@ public sealed class SceneLoader : MonoBehaviour
         {
             _loadCoroutine = null;
             GameStartupTrace.Complete($"Unity could not start loading '{sceneName}'.");
-            Debug.LogException(new InvalidOperationException($"Scene was not found: {sceneName}"));
+            FatalErrorScreen.Show(
+                new InvalidOperationException($"Scene was not found: {sceneName}"),
+                $"{sceneName} scene loading",
+                allowMainMenuReturn: sceneName == "StrategyView"
+            );
             yield break;
         }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/GameFlowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/GameFlowController.cs
@@ -86,7 +86,7 @@ public sealed class GameFlowController : MonoBehaviour
         catch (Exception exception)
         {
             GameStartupTrace.Complete("Game flow startup failed.");
-            Debug.LogException(exception);
+            FatalErrorScreen.Show(exception, "Game loading", allowMainMenuReturn: true);
         }
     }
 

--- a/Assets/Tests/EditMode/GameTests/App/FatalErrorReportTests.cs
+++ b/Assets/Tests/EditMode/GameTests/App/FatalErrorReportTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace Rebellion.Tests.App
+{
+    [TestFixture]
+    public sealed class FatalErrorReportTests
+    {
+        private string reportDirectory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            reportDirectory = Path.Combine(
+                Path.GetTempPath(),
+                $"rebellion2-fatal-error-{Guid.NewGuid():N}"
+            );
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(reportDirectory))
+                Directory.Delete(reportDirectory, recursive: true);
+            else if (File.Exists(reportDirectory))
+                File.Delete(reportDirectory);
+        }
+
+        [Test]
+        public void Create_LoadFailure_WritesDiagnosticReport()
+        {
+            InvalidOperationException inner = new InvalidOperationException("missing texture");
+            Exception exception = new Exception("content failed", inner);
+            DateTimeOffset timestamp = new DateTimeOffset(
+                2026,
+                9,
+                1,
+                8,
+                30,
+                0,
+                TimeSpan.FromHours(-4)
+            );
+
+            FatalErrorReport report = FatalErrorReport.Create(
+                exception,
+                "Strategy content loading",
+                reportDirectory,
+                timestamp,
+                "abc123"
+            );
+
+            Assert.AreEqual("LOAD-20260901-083000-ABC123", report.ErrorID);
+            Assert.AreEqual("Strategy content loading", report.Stage);
+            Assert.AreEqual("content failed", report.Message);
+            Assert.AreEqual(reportDirectory, report.DirectoryPath);
+            Assert.IsTrue(File.Exists(report.FilePath));
+            Assert.IsNull(report.WriteFailure);
+            StringAssert.Contains("Stage: Strategy content loading", report.Contents);
+            StringAssert.Contains(
+                "System.InvalidOperationException: missing texture",
+                report.Contents
+            );
+            Assert.AreEqual(report.Contents, File.ReadAllText(report.FilePath));
+        }
+
+        [Test]
+        public void Create_UnwritableDirectory_ReturnsReportWithWriteFailure()
+        {
+            File.WriteAllText(reportDirectory, "not a directory");
+
+            FatalErrorReport report = FatalErrorReport.Create(
+                new InvalidOperationException("failed"),
+                "Application initialization",
+                reportDirectory,
+                DateTimeOffset.Now,
+                "write"
+            );
+
+            Assert.IsNull(report.FilePath);
+            Assert.IsNotEmpty(report.WriteFailure);
+            StringAssert.Contains("InvalidOperationException: failed", report.Contents);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/GameTests/App/FatalErrorReportTests.cs.meta
+++ b/Assets/Tests/EditMode/GameTests/App/FatalErrorReportTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e0126a56deae450ba9c455d3579306d


### PR DESCRIPTION
## Summary

- Replace black-screen startup failures with a content-independent fatal error screen.
- Write a diagnostic report containing the error ID, launch context, environment, and complete exception details.
- Let players copy the report, open its folder, quit, or return safely to the main menu when game loading fails.
- Route boot, main-menu, scene-loading, application-initialization, and game-flow startup exceptions through the same fallback.

## Validation

- `dotnet csharpier check Assets/`
- `./build.sh test` — 4,564 passed
- `LOG_LEVEL=none ./build.sh build` — macOS standalone player built successfully

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (No UI builder changes.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (No content changes required.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (No setup or public API documentation changed.)