### PR TITLE
Fixing bug where unfinished units could show up in battle & bombardment results.

### DIFF
--- a/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjector.cs
@@ -556,7 +556,7 @@ internal sealed class BattleAlertWindowProjector
         {
             if (child is Fleet || child is Starfighter fighter && IsActiveStarfighter(fighter))
                 continue;
-            if (!IsConstructed(child))
+            if (child is IManufacturable { ManufacturingStatus: not ManufacturingStatus.Complete })
                 continue;
 
             rows.Add(
@@ -598,7 +598,7 @@ internal sealed class BattleAlertWindowProjector
 
         foreach (ISceneNode child in node.GetChildren())
         {
-            if (!IsConstructed(child))
+            if (child is IManufacturable { ManufacturingStatus: not ManufacturingStatus.Complete })
                 continue;
 
             rows.Add(
@@ -609,17 +609,6 @@ internal sealed class BattleAlertWindowProjector
             );
             AddDescendantRows(rows, child, uiContext);
         }
-    }
-
-    /// <summary>
-    /// Returns whether a scene node is available outside the manufacturing pipeline.
-    /// </summary>
-    /// <param name="node">The scene node to inspect.</param>
-    /// <returns>True when the node is not manufacturable or has completed manufacturing.</returns>
-    private static bool IsConstructed(ISceneNode node)
-    {
-        return node is not IManufacturable manufacturable
-            || manufacturable.ManufacturingStatus == ManufacturingStatus.Complete;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjector.cs
@@ -556,6 +556,8 @@ internal sealed class BattleAlertWindowProjector
         {
             if (child is Fleet || child is Starfighter fighter && IsActiveStarfighter(fighter))
                 continue;
+            if (!IsConstructed(child))
+                continue;
 
             rows.Add(
                 new BattleAlertRowRenderData(
@@ -596,6 +598,9 @@ internal sealed class BattleAlertWindowProjector
 
         foreach (ISceneNode child in node.GetChildren())
         {
+            if (!IsConstructed(child))
+                continue;
+
             rows.Add(
                 new BattleAlertRowRenderData(
                     child.GetDisplayName(),
@@ -604,6 +609,17 @@ internal sealed class BattleAlertWindowProjector
             );
             AddDescendantRows(rows, child, uiContext);
         }
+    }
+
+    /// <summary>
+    /// Returns whether a scene node is available outside the manufacturing pipeline.
+    /// </summary>
+    /// <param name="node">The scene node to inspect.</param>
+    /// <returns>True when the node is not manufacturable or has completed manufacturing.</returns>
+    private static bool IsConstructed(ISceneNode node)
+    {
+        return node is not IManufacturable manufacturable
+            || manufacturable.ManufacturingStatus == ManufacturingStatus.Complete;
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjectorTests.cs
@@ -134,6 +134,50 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Combat
         }
 
         [Test]
+        public void Project_PendingSecondForces_ExcludesUnitsUnderConstruction()
+        {
+            (
+                GameRoot Game,
+                UIContext Context,
+                Planet Planet,
+                GameFleet PlayerFleet,
+                GameFleet OpponentFleet
+            ) scene = CreateScene();
+            CapitalShip unfinishedShip = CreateCapitalShip(
+                "unfinished-ship",
+                _opponentFactionId,
+                "Unfinished Ship"
+            );
+            unfinishedShip.ManufacturingStatus = ManufacturingStatus.Building;
+            scene.Game.AttachNode(unfinishedShip, scene.OpponentFleet);
+            PendingCombatResult pending = new PendingCombatResult
+            {
+                Planet = scene.Planet,
+                AttackerFleet = scene.PlayerFleet,
+                DefenderFleet = scene.OpponentFleet,
+            };
+            BattleAlertWindowProjector projector = new BattleAlertWindowProjector();
+
+            BattleAlertWindowRenderData data = projector.Project(
+                BattleAlertWindowMode.Pending,
+                BattleAlertPanel.SecondForces,
+                BattleResultPanel.Summary,
+                BattleResultCategory.CapitalShips,
+                pending,
+                null,
+                _playerFactionId,
+                0,
+                0,
+                scene.Context
+            );
+
+            CollectionAssert.AreEqual(
+                new[] { "Opponent Fleet", "Opponent Ship" },
+                data.Pending.Rows.Select(row => row.Text)
+            );
+        }
+
+        [Test]
         public void Project_PendingSecondForces_IncludesActivePlanetStarfighters()
         {
             (
@@ -722,6 +766,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Combat
                 DisplayName = displayName,
                 DisplayImagePath = definition.DisplayImagePath,
                 SmallDisplayImagePath = definition.SmallDisplayImagePath,
+                ManufacturingStatus = ManufacturingStatus.Complete,
             };
         }
 


### PR DESCRIPTION
## Summary

- Exclude units still being built or delivered from pending battle force lists.
- Preserve every completed unit in the engaged fleet, including unarmed transports.
- Cover the unfinished-unit case in the battle preview projector tests.

## Validation

- `./build.sh format`
- Focused Unity EditMode suite: 15 passed
- Standalone macOS player build: passed
- `./build.sh lint` reaches pre-existing unused-import errors in unrelated prefab builders.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [ ] UI builder changes were verified by rebuilding the affected UI. (Not applicable; no builder changed.)
- [ ] Content path or structure changes were also made in `rebellion2-media`. (Not applicable; no content changed.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable; this corrects internal preview filtering.)