### PR TITLE
Wiring unit unit recovery into game.

### DIFF
--- a/Assets/Scripts/Game/Messages/MessageFactory.cs
+++ b/Assets/Scripts/Game/Messages/MessageFactory.cs
@@ -412,7 +412,9 @@ namespace Rebellion.Game.Messages
                         },
                         { "system", planet?.GetDisplayName() ?? string.Empty },
                     },
-                    overlayImagePath: GetMessageImagePath(officer),
+                    overlayImagePath: resultType == MessageResultType.OfficerRecovered
+                        ? null
+                        : GetMessageImagePath(officer),
                     officerVoicePath: GetOfficerMessageVoicePath(resultType, officer, game)
                 ),
                 planet,

--- a/Assets/Scripts/Game/Messages/MessageFactory.cs
+++ b/Assets/Scripts/Game/Messages/MessageFactory.cs
@@ -412,9 +412,7 @@ namespace Rebellion.Game.Messages
                         },
                         { "system", planet?.GetDisplayName() ?? string.Empty },
                     },
-                    overlayImagePath: resultType == MessageResultType.OfficerRecovered
-                        ? null
-                        : GetMessageImagePath(officer),
+                    overlayImagePath: GetMessageImagePath(officer),
                     officerVoicePath: GetOfficerMessageVoicePath(resultType, officer, game)
                 ),
                 planet,

--- a/Assets/Scripts/Game/Messages/MessageFactory.cs
+++ b/Assets/Scripts/Game/Messages/MessageFactory.cs
@@ -3295,7 +3295,8 @@ namespace Rebellion.Game.Messages
                 {
                     { "item", unit.GetDisplayName() ?? string.Empty },
                     { "attachment", unit.GetParent()?.GetDisplayName() ?? string.Empty },
-                }
+                },
+                imageOverride: unit.EncyclopediaImagePath
             );
             if (message != null)
             {

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -46,6 +46,7 @@ public sealed class GameManager
     private MovementSystem _movementSystem;
     private HeadquartersSystem _headquartersSystem;
     private NamingSystem _namingSystem;
+    private RecoverySystem _recoverySystem;
 
     // Economy Systems.
     private ManufacturingSystem _manufacturingSystem;
@@ -327,6 +328,7 @@ public sealed class GameManager
         ProcessResults(_resourceProductionSystem.ProcessTick());
         ProcessResults(_manufacturingSystem.ProcessTick());
         ProcessResults(_maintenanceSystem.ProcessTick());
+        ProcessResults(_recoverySystem.ProcessTick());
 
         List<GameResult> movementResults = ProcessResults(
             _movementSystem.ProcessTick(),
@@ -455,6 +457,7 @@ public sealed class GameManager
         _headquartersSystem = new HeadquartersSystem(_game, _movementSystem);
         _manufacturingSystem = new ManufacturingSystem(_game, _fleetSystem, _movementSystem);
         _namingSystem = new NamingSystem(_game);
+        _recoverySystem = new RecoverySystem(_game);
         _factionAutomationSystem = new FactionAutomationSystem(
             _game,
             _gameData,

--- a/Assets/Scripts/Systems/RecoverySystem.cs
+++ b/Assets/Scripts/Systems/RecoverySystem.cs
@@ -8,9 +8,7 @@ using Rebellion.SceneGraph;
 namespace Rebellion.Systems
 {
     /// <summary>
-    /// Heals injured officers and repairs damaged ships each tick.
-    /// Officers heal based on CanHeal/FastHeal flags. Ships repair hull damage
-    /// at a rate determined by whether they are at a friendly planet.
+    /// Heals injured officers, repairs capital ships, and replenishes fighter squadrons each tick.
     /// </summary>
     public class RecoverySystem
     {

--- a/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
@@ -2470,7 +2470,7 @@ namespace Rebellion.Tests.Game.Messages
         }
 
         [Test]
-        public void CreateMessages_OfficerRecovered_OmitsOfficerImage()
+        public void CreateMessages_OfficerRecovered_UsesBackgroundWithoutSubjectImage()
         {
             (GameRoot game, Faction alliance, Planet origin, _) = BuildMessageScene();
             Officer officer = new Officer
@@ -2495,8 +2495,7 @@ namespace Rebellion.Tests.Game.Messages
                             MessageType.Mission,
                             "recovered:{officer}:{system}",
                             "body:{officer}:{system}",
-                            DefaultImage("fallback-card"),
-                            showSubjectImage: true
+                            DefaultImage("fallback-card")
                         ),
                     },
                     new OfficerInjuredResult { Officer = officer, Severity = 0 }

--- a/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
@@ -2470,7 +2470,7 @@ namespace Rebellion.Tests.Game.Messages
         }
 
         [Test]
-        public void CreateMessages_OfficerRecovered_UsesRecoveredDefinition()
+        public void CreateMessages_OfficerRecovered_OmitsOfficerImage()
         {
             (GameRoot game, Faction alliance, Planet origin, _) = BuildMessageScene();
             Officer officer = new Officer
@@ -2506,7 +2506,7 @@ namespace Rebellion.Tests.Game.Messages
 
             Assert.AreEqual("recovered:Agent:Coruscant", message.Title);
             Assert.AreEqual("fallback-card", message.DisplayImagePath);
-            Assert.AreEqual("agent-card", message.OverlayImagePath);
+            Assert.IsNull(message.OverlayImagePath);
             Assert.AreEqual("recovered-voice", message.OfficerVoicePath);
         }
 

--- a/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Messages/MessageFactoryTests.cs
@@ -889,7 +889,7 @@ namespace Rebellion.Tests.Game.Messages
         }
 
         [Test]
-        public void CreateMessages_CapitalShipRepaired_UsesDefinitionImageInsteadOfUnitCard()
+        public void CreateMessages_CapitalShipRepaired_UsesUnitEncyclopediaImage()
         {
             (GameRoot game, Faction alliance, Planet origin, _) = BuildMessageScene();
             Fleet fleet = new Fleet
@@ -905,6 +905,7 @@ namespace Rebellion.Tests.Game.Messages
                 MaxHullStrength = 100,
                 CurrentHullStrength = 100,
                 DisplayImagePath = "unit-card",
+                EncyclopediaImagePath = "unit-message-image",
             };
             game.AttachNode(fleet, origin);
             game.AttachNode(ship, fleet);
@@ -938,7 +939,7 @@ namespace Rebellion.Tests.Game.Messages
                 alliance
             );
 
-            Assert.AreEqual("repair-background", message.DisplayImagePath);
+            Assert.AreEqual("unit-message-image", message.DisplayImagePath);
             Assert.IsNull(message.OverlayImagePath);
         }
 
@@ -964,6 +965,7 @@ namespace Rebellion.Tests.Game.Messages
                 MaxSquadronSize = 12,
                 CurrentSquadronSize = 12,
                 DisplayImagePath = "fighter-card",
+                EncyclopediaImagePath = "fighter-message-image",
             };
             game.AttachNode(fleet, origin);
             game.AttachNode(carrier, fleet);
@@ -996,7 +998,7 @@ namespace Rebellion.Tests.Game.Messages
             Assert.AreEqual("full", message.Title);
             Assert.AreEqual("body:X-Wing Squadron:Carrier", message.Body);
             Assert.AreEqual("starfighter_repaired", message.BackgroundImageKey);
-            Assert.IsNull(message.DisplayImagePath);
+            Assert.AreEqual("fighter-message-image", message.DisplayImagePath);
             Assert.IsNull(message.OverlayImagePath);
         }
 
@@ -2470,7 +2472,7 @@ namespace Rebellion.Tests.Game.Messages
         }
 
         [Test]
-        public void CreateMessages_OfficerRecovered_UsesBackgroundWithoutSubjectImage()
+        public void CreateMessages_OfficerRecovered_UsesBackgroundAndSubjectImage()
         {
             (GameRoot game, Faction alliance, Planet origin, _) = BuildMessageScene();
             Officer officer = new Officer
@@ -2495,7 +2497,8 @@ namespace Rebellion.Tests.Game.Messages
                             MessageType.Mission,
                             "recovered:{officer}:{system}",
                             "body:{officer}:{system}",
-                            DefaultImage("fallback-card")
+                            DefaultImage("fallback-card"),
+                            showSubjectImage: true
                         ),
                     },
                     new OfficerInjuredResult { Officer = officer, Severity = 0 }
@@ -2505,7 +2508,7 @@ namespace Rebellion.Tests.Game.Messages
 
             Assert.AreEqual("recovered:Agent:Coruscant", message.Title);
             Assert.AreEqual("fallback-card", message.DisplayImagePath);
-            Assert.IsNull(message.OverlayImagePath);
+            Assert.AreEqual("agent-card", message.OverlayImagePath);
             Assert.AreEqual("recovered-voice", message.OfficerVoicePath);
         }
 

--- a/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
+++ b/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
@@ -297,9 +297,12 @@ public static class TestConfig
 public static class TestGameData
 {
     /// <summary>
-    /// Creates an empty catalog around the supplied runtime configuration.
+    /// Creates a synthetic catalog around the supplied configuration and message definitions.
     /// </summary>
-    public static GameDataCatalog Create(GameConfig config = null)
+    public static GameDataCatalog Create(
+        GameConfig config = null,
+        MessageDefinition[] messageDefinitions = null
+    )
     {
         return new GameDataCatalog(
             config ?? new GameConfig(),
@@ -313,7 +316,7 @@ public static class TestGameData
             Array.Empty<SpecialForces>(),
             Array.Empty<Officer>(),
             Array.Empty<GameEvent>(),
-            Array.Empty<MessageDefinition>(),
+            messageDefinitions ?? Array.Empty<MessageDefinition>(),
             new EncyclopediaEntries(),
             new FactionThemes()
         );

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -199,6 +199,31 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
+        public void ProcessTick_FullyRecoveredUnits_DeliversRecoveryMessages()
+        {
+            (GameManager manager, Officer officer, CapitalShip ship, Starfighter fighter) =
+                CreateRecoveryGame();
+            List<MessageResultType> deliveredResultTypes = new List<MessageResultType>();
+            manager.MessageDelivered += result =>
+                deliveredResultTypes.Add(result.Message.ResultType);
+
+            manager.ProcessTick();
+
+            Assert.AreEqual(0, officer.InjuryPoints);
+            Assert.AreEqual(ship.MaxHullStrength, ship.CurrentHullStrength);
+            Assert.AreEqual(fighter.MaxSquadronSize, fighter.CurrentSquadronSize);
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    MessageResultType.OfficerRecovered,
+                    MessageResultType.CapitalShipRepaired,
+                    MessageResultType.StarfighterRepaired,
+                },
+                deliveredResultTypes
+            );
+        }
+
+        [Test]
         public void ProcessTick_EventCapturesMissionParticipant_TearsDownMission()
         {
             GameRoot game = new GameRoot(TestConfig.Create());
@@ -1307,6 +1332,91 @@ namespace Rebellion.Tests.Managers
                 IsColonized = true,
                 EnergyCapacity = 10,
                 PositionX = positionX,
+            };
+        }
+
+        private static (
+            GameManager manager,
+            Officer officer,
+            CapitalShip ship,
+            Starfighter fighter
+        ) CreateRecoveryGame()
+        {
+            GameConfig config = new GameConfig();
+            config.Recovery.NormalHealAmount = 1;
+            config.Recovery.FastRepairAmount = 1;
+            config.Recovery.FastReplacementAmount = 1;
+            config.Smuggling.LossPercentByMinimumSupport[0] = 0;
+            GameRoot game = new GameRoot(config);
+            Faction faction = new Faction
+            {
+                InstanceID = "FACTION",
+                DisplayName = "Faction",
+                PlayerID = "PLAYER",
+            };
+            game.GetFactions().Add(faction);
+            PlanetSector sector = new PlanetSector { InstanceID = "SECTOR" };
+            Planet planet = new Planet
+            {
+                InstanceID = "PLANET",
+                DisplayName = "Planet",
+                OwnerInstanceID = faction.InstanceID,
+                IsColonized = true,
+            };
+            game.AttachNode(sector, game.GetGalaxyMap());
+            game.AttachNode(planet, sector);
+
+            Officer officer = EntityFactory.CreateOfficer("OFFICER", faction.InstanceID);
+            officer.DisplayName = "Officer";
+            officer.InjuryPoints = 1;
+            officer.CanHeal = true;
+            Fleet fleet = EntityFactory.CreateFleet("FLEET", faction.InstanceID);
+            fleet.DisplayName = "Fleet";
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "SHIP",
+                DisplayName = "Ship",
+                OwnerInstanceID = faction.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                MaxHullStrength = 100,
+                CurrentHullStrength = 99,
+                StarfighterCapacity = 1,
+            };
+            Starfighter fighter = new Starfighter
+            {
+                InstanceID = "FIGHTER",
+                DisplayName = "Fighter",
+                OwnerInstanceID = faction.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                MaxSquadronSize = 12,
+                CurrentSquadronSize = 11,
+            };
+            game.AttachNode(officer, planet);
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+            game.AttachNode(fighter, ship);
+
+            MessageDefinition[] definitions =
+            {
+                CreateMessageDefinition(MessageResultType.OfficerRecovered, MessageType.Mission),
+                CreateMessageDefinition(MessageResultType.CapitalShipRepaired, MessageType.Fleet),
+                CreateMessageDefinition(MessageResultType.StarfighterRepaired, MessageType.Fleet),
+            };
+            GameManager manager = new GameManager(game, TestGameData.Create(config, definitions));
+            return (manager, officer, ship, fighter);
+        }
+
+        private static MessageDefinition CreateMessageDefinition(
+            MessageResultType resultType,
+            MessageType messageType
+        )
+        {
+            return new MessageDefinition
+            {
+                ResultType = resultType,
+                MessageType = messageType,
+                Subject = resultType.ToString(),
+                Body = resultType.ToString(),
             };
         }
 


### PR DESCRIPTION
## Summary

- Wires officer healing, capital-ship repair, and starfighter replenishment into the normal game tick.
- Routes completed recoveries through existing result and message processing.
- Shows the generic recovery background with the healed officer's face and leaves officer recovery voices unconfigured in shipped content.
- Shows each repaired capital ship or replenished fighter squadron with its large unit-specific artwork.
- Adds manager-level and message-factory coverage for recovery completion and presentation.

## Validation

- `bash build.sh all`
- Full EditMode suite: 4,563 passed, 0 failed.
- Windows standalone build: `bash build.sh build`
- Matching media validation: `bash build.sh all`

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`. (Recovery presentation configuration is included in the matching media PR.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (No documentation changes are required.)
