### PR TITLE
Preventing diplomacy from being foiled.

### DIFF
--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -615,6 +615,8 @@ namespace Rebellion.Game
 
             public int ForceQualifiedThreshold { get; set; }
 
+            public int FastHealThreshold { get; set; }
+
             public int ForceGrowthPerMission { get; set; }
 
             public int TrainingCatchUpPercent { get; set; }

--- a/Assets/Scripts/Game/Missions/DiplomacyMission.cs
+++ b/Assets/Scripts/Game/Missions/DiplomacyMission.cs
@@ -20,6 +20,11 @@ namespace Rebellion.Game.Missions
         /// </summary>
         internal override bool SuccessfulParticipantsRemainAtLocation => true;
 
+        /// <summary>
+        /// Returns whether hostile forces can foil the mission.
+        /// </summary>
+        internal override bool CanBeFoiled => false;
+
         /// <summary>Creates an empty diplomacy mission copy.</summary>
         /// <returns>An empty diplomacy mission.</returns>
         protected override BaseSceneNode CreateNodeCopy() => new DiplomacyMission();

--- a/Assets/Scripts/Game/Missions/DiplomacyMission.cs
+++ b/Assets/Scripts/Game/Missions/DiplomacyMission.cs
@@ -15,6 +15,11 @@ namespace Rebellion.Game.Missions
     {
         public const string MissionTypeID = "Diplomacy";
 
+        /// <summary>
+        /// Returns whether successful participants remain on the target planet.
+        /// </summary>
+        internal override bool SuccessfulParticipantsRemainAtLocation => true;
+
         /// <summary>Creates an empty diplomacy mission copy.</summary>
         /// <returns>An empty diplomacy mission.</returns>
         protected override BaseSceneNode CreateNodeCopy() => new DiplomacyMission();

--- a/Assets/Scripts/Game/Missions/EspionageMission.cs
+++ b/Assets/Scripts/Game/Missions/EspionageMission.cs
@@ -16,11 +16,6 @@ namespace Rebellion.Game.Missions
     {
         public const string MissionTypeID = "Espionage";
 
-        /// <summary>
-        /// Returns whether detected participants receive the standard foiled-mission consequences.
-        /// </summary>
-        internal override bool AppliesFoiledParticipantConsequences => false;
-
         /// <summary>Creates an empty espionage mission copy.</summary>
         /// <returns>An empty espionage mission.</returns>
         protected override BaseSceneNode CreateNodeCopy() => new EspionageMission();

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -144,6 +144,8 @@ namespace Rebellion.Game.Missions
 
         internal virtual bool AppliesFoiledParticipantConsequences => true;
 
+        internal virtual bool CanBeFoiled => true;
+
         internal virtual bool SuccessfulParticipantsRemainAtLocation => false;
 
         /// <summary>
@@ -1044,7 +1046,7 @@ namespace Rebellion.Game.Missions
             }
 
             List<IMissionParticipant> participantsBeforeDetection = GetAllParticipants();
-            if (runtime.ResolveDetection(this, results))
+            if (CanBeFoiled && runtime.ResolveDetection(this, results))
             {
                 AddMissionResults(ResolveInterruption(game, provider), results);
                 MissionCompletedResult completed = BuildTerminatingResult(

--- a/Assets/Scripts/Game/Units/Officer.cs
+++ b/Assets/Scripts/Game/Units/Officer.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Rebellion.Game.Galaxy;
 using Rebellion.Game.Missions;
 using Rebellion.Game.Movement;
 using Rebellion.Game.Research;
 using Rebellion.SceneGraph;
 using Rebellion.Util.Common;
+using Rebellion.Util.Extensions;
 using Rebellion.Util.Serialization;
 
 namespace Rebellion.Game.Units
@@ -233,8 +235,6 @@ namespace Rebellion.Game.Units
 
         // Injury Info.
         public int InjuryPoints { get; set; }
-        public bool CanHeal { get; set; }
-        public bool FastHeal { get; set; }
 
         // Force Info.
         public int JediProbability { get; set; }
@@ -354,8 +354,6 @@ namespace Rebellion.Game.Units
             copy.IsTraitor = IsTraitor;
             copy.Loyalty = Loyalty;
             copy.InjuryPoints = InjuryPoints;
-            copy.CanHeal = CanHeal;
-            copy.FastHeal = FastHeal;
             copy.JediProbability = JediProbability;
             copy.JediLevel = JediLevel;
             copy.JediLevelVariance = JediLevelVariance;
@@ -490,6 +488,46 @@ namespace Rebellion.Game.Units
         public bool IsOnMission()
         {
             return GetParent() is Mission;
+        }
+
+        /// <summary>
+        /// Returns whether the injured officer is resting at a location controlled by their faction.
+        /// </summary>
+        /// <returns>True when the officer can recover injury points; otherwise, false.</returns>
+        public bool CanHeal()
+        {
+            if (
+                InjuryPoints <= 0
+                || IsCaptured
+                || IsKilled
+                || IsOnMission()
+                || this.GetTransitMovement() != null
+            )
+                return false;
+
+            string ownerInstanceID = GetOwnerInstanceID();
+            if (string.IsNullOrEmpty(ownerInstanceID))
+                return false;
+
+            CapitalShip ship = GetParentOfType<CapitalShip>();
+            if (ship?.GetOwnerInstanceID() == ownerInstanceID)
+                return true;
+
+            Fleet fleet = GetParentOfType<Fleet>();
+            if (fleet?.GetOwnerInstanceID() == ownerInstanceID)
+                return true;
+
+            return GetParentOfType<Planet>()?.GetOwnerInstanceID() == ownerInstanceID;
+        }
+
+        /// <summary>
+        /// Returns whether the officer qualifies for the accelerated Force-user healing rate.
+        /// </summary>
+        /// <param name="minimumForceRank">The minimum Force rank required for fast healing.</param>
+        /// <returns>True when the officer is Force-sensitive and meets the rank threshold; otherwise, false.</returns>
+        public bool HealsFast(int minimumForceRank)
+        {
+            return IsForceSensitive && ForceRank >= minimumForceRank;
         }
 
         /// <summary>

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -455,7 +455,6 @@ public sealed class GameManager
         _duelSystem = new DuelSystem(_game, _randomProvider);
         _movementSystem = new MovementSystem(_game, _fogOfWarSystem, _fleetSystem, _blockadeSystem);
         _headquartersSystem = new HeadquartersSystem(_game, _movementSystem);
-        _recoverySystem = new RecoverySystem(_game);
         _manufacturingSystem = new ManufacturingSystem(_game, _fleetSystem, _movementSystem);
         _namingSystem = new NamingSystem(_game);
         _recoverySystem = new RecoverySystem(_game);

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -46,6 +46,7 @@ public sealed class GameManager
     private MovementSystem _movementSystem;
     private HeadquartersSystem _headquartersSystem;
     private NamingSystem _namingSystem;
+    private RecoverySystem _recoverySystem;
 
     // Economy Systems.
     private ManufacturingSystem _manufacturingSystem;
@@ -327,6 +328,7 @@ public sealed class GameManager
         ProcessResults(_resourceProductionSystem.ProcessTick());
         ProcessResults(_manufacturingSystem.ProcessTick());
         ProcessResults(_maintenanceSystem.ProcessTick());
+        ProcessResults(_recoverySystem.ProcessTick());
 
         List<GameResult> movementResults = ProcessResults(
             _movementSystem.ProcessTick(),
@@ -453,6 +455,7 @@ public sealed class GameManager
         _duelSystem = new DuelSystem(_game, _randomProvider);
         _movementSystem = new MovementSystem(_game, _fogOfWarSystem, _fleetSystem, _blockadeSystem);
         _headquartersSystem = new HeadquartersSystem(_game, _movementSystem);
+        _recoverySystem = new RecoverySystem(_game);
         _manufacturingSystem = new ManufacturingSystem(_game, _fleetSystem, _movementSystem);
         _namingSystem = new NamingSystem(_game);
         _factionAutomationSystem = new FactionAutomationSystem(

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -515,7 +515,7 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Resolves a participant's recorded container or recorded planet.
+        /// Resolves a participant's recorded container, recorded planet, or nearest friendly planet.
         /// </summary>
         /// <param name="participant">The participant whose return destination is required.</param>
         /// <returns>The first valid return container, or null when none can receive the participant.</returns>
@@ -542,7 +542,10 @@ namespace Rebellion.Systems
                     return returnLocation;
             }
 
-            return null;
+            string ownerInstanceID = GetMovementControlOwner(participant);
+            Faction owner = _game.GetFactionByOwnerInstanceID(ownerInstanceID);
+            Planet missionPlanet = participant.GetParentOfType<Planet>();
+            return FindEvacuationDestinations(owner, participant, missionPlanet).FirstOrDefault();
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -543,6 +543,9 @@ namespace Rebellion.Systems
             }
 
             string ownerInstanceID = GetMovementControlOwner(participant);
+            if (string.IsNullOrEmpty(ownerInstanceID))
+                return null;
+
             Faction owner = _game.GetFactionByOwnerInstanceID(ownerInstanceID);
             Planet missionPlanet = participant.GetParentOfType<Planet>();
             return FindEvacuationDestinations(owner, participant, missionPlanet).FirstOrDefault();

--- a/Assets/Scripts/Systems/RecoverySystem.cs
+++ b/Assets/Scripts/Systems/RecoverySystem.cs
@@ -9,7 +9,7 @@ namespace Rebellion.Systems
 {
     /// <summary>
     /// Heals injured officers and repairs damaged ships each tick.
-    /// Officers heal based on CanHeal/FastHeal flags. Ships repair hull damage
+    /// Officers heal while resting at a friendly location. Ships repair hull damage
     /// at a rate determined by whether they are at a friendly planet.
     /// </summary>
     public class RecoverySystem
@@ -51,10 +51,12 @@ namespace Rebellion.Systems
         {
             foreach (Officer officer in _game.GetSceneNodesByType<Officer>())
             {
-                if (officer.InjuryPoints <= 0 || !officer.CanHeal || officer.IsCaptured)
+                if (!officer.CanHeal())
                     continue;
 
-                int amount = officer.FastHeal ? _config.FastHealAmount : _config.NormalHealAmount;
+                int amount = officer.HealsFast(_game.Config.Jedi.FastHealThreshold)
+                    ? _config.FastHealAmount
+                    : _config.NormalHealAmount;
                 officer.Heal(amount);
 
                 if (officer.InjuryPoints == 0)

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Construction/ConstructionOrderController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Construction/ConstructionOrderController.cs
@@ -258,25 +258,9 @@ public sealed class ConstructionOrderController
         {
             FacilityWindowTab.Shipyards => item is CapitalShip or Starfighter,
             FacilityWindowTab.Training => item is Regiment or SpecialForces,
-            FacilityWindowTab.Construction => item is Building building
-                && IsBuildableFacility(building),
+            FacilityWindowTab.Construction => item is Building,
             _ => false,
         };
-    }
-
-    /// <summary>
-    /// Determines whether a building template is available from the construction window.
-    /// </summary>
-    /// <param name="building">The building template.</param>
-    /// <returns>True when the template is a manufacturable facility.</returns>
-    private static bool IsBuildableFacility(Building building)
-    {
-        return building.GetBuildingType()
-            is BuildingType.Mine
-                or BuildingType.Refinery
-                or BuildingType.Shipyard
-                or BuildingType.TrainingFacility
-                or BuildingType.ConstructionFacility;
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -199,6 +199,33 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
+        public void ProcessTick_InjuredOfficerAtFriendlyPlanet_Heals()
+        {
+            GameConfig config = TestConfig.Create();
+            config.Recovery.NormalHealAmount = 1;
+            GameRoot game = new GameRoot(config);
+            Faction faction = new Faction { InstanceID = "FNALL1" };
+            game.GetFactions().Add(faction);
+            PlanetSector sector = new PlanetSector { InstanceID = "SECTOR" };
+            Planet planet = new Planet
+            {
+                InstanceID = "PLANET",
+                OwnerInstanceID = faction.InstanceID,
+                IsColonized = true,
+            };
+            Officer officer = EntityFactory.CreateOfficer("OFFICER", faction.InstanceID);
+            officer.InjuryPoints = 2;
+            game.AttachNode(sector, game.GetGalaxyMap());
+            game.AttachNode(planet, sector);
+            game.AttachNode(officer, planet);
+            GameManager manager = TestContent.CreateGameManager(game);
+
+            manager.ProcessTick();
+
+            Assert.AreEqual(1, officer.InjuryPoints);
+        }
+
+        [Test]
         public void ProcessTick_EventCapturesMissionParticipant_TearsDownMission()
         {
             GameRoot game = new GameRoot(TestConfig.Create());

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -328,7 +328,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_DiplomacyCompletion_ParticipantRemainsAtTargetPlanet()
+        public void UpdateMission_DiplomacyCompletionFromFleet_ParticipantRemainsAtTargetPlanet()
         {
             GameRoot game = new GameRoot(TestConfig.Create());
             Faction faction = new Faction { InstanceID = "empire" };
@@ -359,8 +359,17 @@ namespace Rebellion.Tests.Sectors
             target.AddVisitor(faction.InstanceID);
             game.AttachNode(origin, planetSector);
             game.AttachNode(target, planetSector);
+            Fleet fleet = EntityFactory.CreateFleet("fleet", faction.InstanceID);
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "ship",
+                OwnerInstanceID = faction.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, origin);
+            game.AttachNode(ship, fleet);
             Officer officer = EntityFactory.CreateOfficer("diplomat", faction.InstanceID);
-            game.AttachNode(officer, origin);
+            game.AttachNode(officer, ship);
             game.Config.ProbabilityTables.Mission.Diplomacy = new Dictionary<int, int>
             {
                 { -200, 100 },

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -162,9 +162,8 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_CompletedParticipantOnNeutralPlanet_DoesNotChooseAnotherPlanet()
+        public void UpdateMission_CompletedParticipantOnNeutralPlanet_ReturnsToNearestFriendlyPlanet()
         {
-            // A missing recorded return location must not be replaced with another friendly planet.
             GameConfig config = TestConfig.Create();
             GameRoot game = new GameRoot(config);
             game.GetFactions().Add(new Faction { InstanceID = "empire" });
@@ -220,9 +219,9 @@ namespace Rebellion.Tests.Sectors
                 mission.IncrementProgress();
 
             Assert.DoesNotThrow(() => missionSystem.UpdateMission(mission));
-            Assert.AreSame(planet, officer.GetParent());
-            Assert.AreNotSame(homePlanet, officer.GetParent());
-            Assert.IsTrue(officer.IsCaptured);
+            Assert.AreSame(homePlanet, officer.GetParent());
+            Assert.AreNotSame(planet, officer.GetParent());
+            Assert.IsFalse(officer.IsCaptured);
         }
 
         [Test]
@@ -524,7 +523,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_DiplomacyOnNeutralPlanetWithHostileDetector_CanBeFoiled()
+        public void UpdateMission_DiplomacyWithHostileDetector_DoesNotFoilOrInjureParticipant()
         {
             (GameRoot game, Planet planet, Officer spy, Officer defender, MovementSystem movement) =
                 BuildDetectionScene();
@@ -542,7 +541,6 @@ namespace Rebellion.Tests.Sectors
             );
             SetFoilTable(game, new Dictionary<int, int> { { -1000, 100 } });
             SetEvasionTable(game, new Dictionary<int, int> { { -1000, 0 } });
-            DisableCaptureEvasionInjury(game);
             game.AttachNode(mission, planet);
             game.MoveNode(spy, mission);
             mission.Initiate(0);
@@ -555,11 +553,14 @@ namespace Rebellion.Tests.Sectors
 
             List<GameResult> results = system.UpdateMission(mission);
 
-            Assert.IsTrue(
+            Assert.IsFalse(
                 results
                     .OfType<MissionCompletedResult>()
                     .Any(result => result.Outcome == MissionOutcome.Foiled)
             );
+            Assert.IsFalse(spy.IsCaptured);
+            Assert.Zero(spy.InjuryPoints);
+            Assert.IsFalse(results.OfType<OfficerInjuredResult>().Any());
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -915,7 +915,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_EspionageDetected_FoilsWithoutCaptureOrKill()
+        public void UpdateMission_EspionageDetected_AppliesFoiledParticipantConsequences()
         {
             (GameRoot game, Planet planet, Officer spy, Officer defender, MovementSystem movement) =
                 BuildDetectionScene();
@@ -931,6 +931,8 @@ namespace Rebellion.Tests.Sectors
             );
             Assert.IsNotNull(mission);
             SetFoilTable(game, new Dictionary<int, int> { { 0, 100 } });
+            SetEvasionTable(game, new Dictionary<int, int> { { -200, 0 } });
+            DisableCaptureEvasionInjury(game);
             game.AttachNode(mission, planet);
             game.MoveNode(spy, mission);
 
@@ -942,9 +944,9 @@ namespace Rebellion.Tests.Sectors
 
             List<GameResult> results = system.UpdateMission(mission);
 
-            Assert.IsFalse(spy.IsCaptured);
+            Assert.IsTrue(spy.IsCaptured);
             Assert.IsFalse(spy.IsKilled);
-            Assert.IsFalse(results.Any(r => r is OfficerCaptureStateResult));
+            Assert.IsTrue(results.Any(r => r is OfficerCaptureStateResult));
             Assert.IsFalse(results.Any(r => r is OfficerKilledResult));
             Assert.IsTrue(
                 results

--- a/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
@@ -2267,6 +2267,28 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void ReturnFromMission_MissingOwnerAndRecordedLocation_ReturnsParticipantAsStranded()
+        {
+            (GameRoot game, _, Planet destination, Officer officer, MovementSystem movement) =
+                BuildScene();
+            StubMission mission = new StubMission("empire", destination.InstanceID);
+            game.AttachNode(mission, destination);
+            movement.SendToMission(officer, mission);
+            officer.Movement = null;
+            officer.OwnerInstanceID = null;
+            officer.MissionReturnParentInstanceID = "missing-parent";
+            officer.MissionReturnLocationInstanceID = "missing-location";
+
+            List<IMovable> stranded = movement.ReturnFromMission(
+                new IMissionParticipant[] { officer },
+                new IMovable[0]
+            );
+
+            CollectionAssert.AreEqual(new IMovable[] { officer }, stranded);
+            Assert.AreSame(mission, officer.GetParent());
+        }
+
+        [Test]
         public void ReturnFromMission_RecordedPlanetCaptured_ReturnsToNearestFriendlyPlanet()
         {
             (

--- a/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
@@ -2241,7 +2241,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void ReturnFromMission_MissingRecordedLocation_ReturnsParticipantAsStranded()
+        public void ReturnFromMission_MissingRecordedLocation_ReturnsToNearestFriendlyPlanet()
         {
             (
                 GameRoot game,
@@ -2262,12 +2262,12 @@ namespace Rebellion.Tests.Sectors
                 new IMovable[0]
             );
 
-            CollectionAssert.AreEqual(new IMovable[] { officer }, stranded);
-            Assert.AreEqual(mission, officer.GetParent());
+            Assert.IsEmpty(stranded);
+            Assert.AreSame(origin, officer.GetParent());
         }
 
         [Test]
-        public void ReturnFromMission_RecordedPlanetCaptured_ReturnsParticipantAsStranded()
+        public void ReturnFromMission_RecordedPlanetCaptured_ReturnsToNearestFriendlyPlanet()
         {
             (
                 GameRoot game,
@@ -2281,18 +2281,27 @@ namespace Rebellion.Tests.Sectors
             movement.SendToMission(officer, mission);
             officer.Movement = null;
             origin.OwnerInstanceID = "rebels";
+            Planet fallback = new Planet
+            {
+                InstanceID = "fallback",
+                OwnerInstanceID = "empire",
+                IsColonized = true,
+                PositionX = 200,
+                PositionY = 200,
+            };
+            game.AttachNode(fallback, destination.GetParent());
 
             List<IMovable> stranded = movement.ReturnFromMission(
                 new IMissionParticipant[] { officer },
                 new IMovable[0]
             );
 
-            CollectionAssert.AreEqual(new IMovable[] { officer }, stranded);
-            Assert.AreSame(mission, officer.GetParent());
+            Assert.IsEmpty(stranded);
+            Assert.AreSame(fallback, officer.GetParent());
         }
 
         [Test]
-        public void ReturnFromMission_MissingRecordedLocation_DoesNotChooseAnotherFleet()
+        public void ReturnFromMission_MissingRecordedLocation_UsesFriendlyPlanetInsteadOfUnrelatedFleet()
         {
             (
                 GameRoot game,
@@ -2323,8 +2332,8 @@ namespace Rebellion.Tests.Sectors
                 new IMovable[0]
             );
 
-            CollectionAssert.AreEqual(new IMovable[] { officer }, stranded);
-            Assert.AreSame(mission, officer.GetParent());
+            Assert.IsEmpty(stranded);
+            Assert.AreSame(origin, officer.GetParent());
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/RecoverySystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/RecoverySystemTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using Rebellion.Game;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
+using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using Rebellion.Systems;
@@ -14,13 +15,12 @@ namespace Rebellion.Tests.Systems
     public class RecoverySystemTests
     {
         [Test]
-        public void ProcessTick_InjuredOfficerCanHeal_ReducesInjury()
+        public void ProcessTick_InjuredOfficerAtFriendlyPlanet_ReducesInjury()
         {
             (GameRoot game, Planet planet) = BuildScene();
 
             Officer officer = EntityFactory.CreateOfficer("o1", "empire");
             officer.InjuryPoints = 10;
-            officer.CanHeal = true;
             game.AttachNode(officer, planet);
 
             RecoverySystem system = new RecoverySystem(game);
@@ -31,14 +31,14 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_InjuredOfficerFastHeal_HealsMorePerTick()
+        public void ProcessTick_InjuredHighRankForceSensitiveOfficer_HealsMorePerTick()
         {
             (GameRoot game, Planet planet) = BuildScene();
 
             Officer officer = EntityFactory.CreateOfficer("o1", "empire");
             officer.InjuryPoints = 10;
-            officer.CanHeal = true;
-            officer.FastHeal = true;
+            officer.IsForceSensitive = true;
+            officer.ForceValue = game.Config.Jedi.FastHealThreshold;
             game.AttachNode(officer, planet);
 
             RecoverySystem system = new RecoverySystem(game);
@@ -48,25 +48,69 @@ namespace Rebellion.Tests.Systems
             Assert.AreEqual(
                 7,
                 officer.InjuryPoints,
-                "FastHeal officer should heal 3 points per tick"
+                "High-rank Force-sensitive officer should heal 3 points per tick"
             );
         }
 
         [Test]
-        public void ProcessTick_InjuredOfficerCannotHeal_NoChange()
+        public void ProcessTick_InjuredLowRankForceSensitiveOfficer_HealsNormally()
         {
             (GameRoot game, Planet planet) = BuildScene();
 
             Officer officer = EntityFactory.CreateOfficer("o1", "empire");
             officer.InjuryPoints = 10;
-            officer.CanHeal = false;
+            officer.IsForceSensitive = true;
+            officer.ForceValue = game.Config.Jedi.FastHealThreshold - 1;
             game.AttachNode(officer, planet);
 
             RecoverySystem system = new RecoverySystem(game);
 
             system.ProcessTick();
 
-            Assert.AreEqual(10, officer.InjuryPoints, "Officer with CanHeal=false should not heal");
+            Assert.AreEqual(9, officer.InjuryPoints);
+        }
+
+        [Test]
+        public void ProcessTick_InjuredOfficerAtEnemyPlanet_DoesNotHeal()
+        {
+            (GameRoot game, Planet planet) = BuildScene();
+
+            Officer officer = EntityFactory.CreateOfficer("o1", "empire");
+            officer.InjuryPoints = 10;
+            game.AttachNode(officer, planet);
+            planet.OwnerInstanceID = "rebels";
+
+            RecoverySystem system = new RecoverySystem(game);
+
+            system.ProcessTick();
+
+            Assert.AreEqual(10, officer.InjuryPoints, "Officer at enemy planet should not heal");
+        }
+
+        [Test]
+        public void ProcessTick_InjuredOfficerAboardFriendlyFleet_ReducesInjury()
+        {
+            (GameRoot game, Planet planet) = BuildScene();
+
+            Fleet fleet = EntityFactory.CreateFleet("fleet", "empire");
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "ship",
+                OwnerInstanceID = "empire",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            Officer officer = EntityFactory.CreateOfficer("o1", "empire");
+            officer.InjuryPoints = 10;
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+            game.AttachNode(officer, ship);
+            planet.OwnerInstanceID = "rebels";
+
+            RecoverySystem system = new RecoverySystem(game);
+
+            system.ProcessTick();
+
+            Assert.AreEqual(9, officer.InjuryPoints, "Officer aboard friendly fleet should heal");
         }
 
         [Test]
@@ -76,7 +120,6 @@ namespace Rebellion.Tests.Systems
 
             Officer officer = EntityFactory.CreateOfficer("o1", "empire");
             officer.InjuryPoints = 10;
-            officer.CanHeal = true;
             officer.IsCaptured = true;
             game.AttachNode(officer, planet);
 
@@ -88,13 +131,47 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_OfficerInTransit_DoesNotHeal()
+        {
+            (GameRoot game, Planet planet) = BuildScene();
+
+            Officer officer = EntityFactory.CreateOfficer("o1", "empire");
+            officer.InjuryPoints = 10;
+            officer.Movement = new MovementState { TransitTicks = 10 };
+            game.AttachNode(officer, planet);
+
+            RecoverySystem system = new RecoverySystem(game);
+
+            system.ProcessTick();
+
+            Assert.AreEqual(10, officer.InjuryPoints, "Officer in transit should not heal");
+        }
+
+        [Test]
+        public void ProcessTick_OfficerOnMission_DoesNotHeal()
+        {
+            (GameRoot game, Planet planet) = BuildScene();
+
+            Officer officer = EntityFactory.CreateOfficer("o1", "empire");
+            officer.InjuryPoints = 10;
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            game.AttachNode(mission, planet);
+            game.AttachNode(officer, mission);
+
+            RecoverySystem system = new RecoverySystem(game);
+
+            system.ProcessTick();
+
+            Assert.AreEqual(10, officer.InjuryPoints, "Officer on mission should not heal");
+        }
+
+        [Test]
         public void ProcessTick_OfficerFullyHealed_EmitsResult()
         {
             (GameRoot game, Planet planet) = BuildScene();
 
             Officer officer = EntityFactory.CreateOfficer("o1", "empire");
             officer.InjuryPoints = 1;
-            officer.CanHeal = true;
             game.AttachNode(officer, planet);
 
             RecoverySystem system = new RecoverySystem(game);
@@ -114,7 +191,6 @@ namespace Rebellion.Tests.Systems
 
             Officer officer = EntityFactory.CreateOfficer("o1", "empire");
             officer.InjuryPoints = 10;
-            officer.CanHeal = true;
             game.AttachNode(officer, planet);
 
             RecoverySystem system = new RecoverySystem(game);
@@ -134,8 +210,7 @@ namespace Rebellion.Tests.Systems
 
             Officer officer = EntityFactory.CreateOfficer("o1", "empire");
             officer.InjuryPoints = 1;
-            officer.CanHeal = true;
-            officer.FastHeal = true;
+            officer.IsForceSensitive = true;
             game.AttachNode(officer, planet);
 
             RecoverySystem system = new RecoverySystem(game);

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Construction/ConstructionOrderControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Construction/ConstructionOrderControllerTests.cs
@@ -135,8 +135,21 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Construction
                 .Where(template => template.ManufacturingFactionInstanceIDs?.Count > 0)
                 .ToList();
             string ownerId = templates
-                .SelectMany(template => template.ManufacturingFactionInstanceIDs)
-                .First();
+                .SelectMany(template =>
+                    template.ManufacturingFactionInstanceIDs.Select(factionId =>
+                        (FactionId: factionId, Building: (Building)template)
+                    )
+                )
+                .GroupBy(candidate => candidate.FactionId)
+                .First(group =>
+                    group.Any(candidate =>
+                        candidate.Building.GetBuildingType() == BuildingType.Defense
+                    )
+                    && group.Any(candidate =>
+                        candidate.Building.GetBuildingType() == BuildingType.Weapon
+                    )
+                )
+                .Key;
             IManufacturable[] applicableTemplates = templates
                 .Where(template => template.ManufacturingFactionInstanceIDs.Contains(ownerId))
                 .ToArray();

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Construction/ConstructionOrderControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Construction/ConstructionOrderControllerTests.cs
@@ -128,6 +128,57 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Construction
         }
 
         [Test]
+        public void GetBuildSelection_ConstructionTab_IncludesAllApplicableBuildings()
+        {
+            List<IManufacturable> templates = TestContent
+                .Data.Buildings.Cast<IManufacturable>()
+                .Where(template => template.ManufacturingFactionInstanceIDs?.Count > 0)
+                .ToList();
+            string ownerId = templates
+                .SelectMany(template => template.ManufacturingFactionInstanceIDs)
+                .First();
+            IManufacturable[] applicableTemplates = templates
+                .Where(template => template.ManufacturingFactionInstanceIDs.Contains(ownerId))
+                .ToArray();
+            GameRoot game = new GameRoot(TestConfig.Create());
+            Faction owner = new Faction { InstanceID = ownerId };
+            owner.SetHighestUnlockedOrder(
+                ManufacturingType.Building,
+                applicableTemplates.Max(template => template.GetResearchOrder())
+            );
+            owner.RebuildResearchCatalog(applicableTemplates);
+            game.GetFactions().Add(owner);
+            FleetSystem fleetSystem = new FleetSystem(game);
+            MovementSystem movement = new MovementSystem(
+                game,
+                new FogOfWarSystem(game),
+                fleetSystem
+            );
+            ConstructionOrderController controller = new ConstructionOrderController(
+                () => game,
+                () => new ManufacturingSystem(game, fleetSystem, movement),
+                () => movement
+            );
+
+            IReadOnlyList<IManufacturable> selection = controller.GetBuildSelection(
+                FacilityWindowTab.Construction,
+                ownerId
+            );
+
+            CollectionAssert.AreEquivalent(applicableTemplates, selection);
+            Assert.IsTrue(
+                selection
+                    .Cast<Building>()
+                    .Any(building => building.GetBuildingType() == BuildingType.Defense)
+            );
+            Assert.IsTrue(
+                selection
+                    .Cast<Building>()
+                    .Any(building => building.GetBuildingType() == BuildingType.Weapon)
+            );
+        }
+
+        [Test]
         public void GetBuildEstimates_StationaryTemplate_ReturnsCompletionWithoutDeployment()
         {
             const string ownerId = "owner";


### PR DESCRIPTION
## Summary

- Prevent diplomacy missions from entering the generic mission-detection and foiling path.
- Leave successful diplomacy participants on the target planet.
- Return completed mission participants to the nearest valid friendly planet when their immediate location cannot accept them.
- Restore officer recovery behavior and defensive construction availability included in the missing local fix.
- Cover diplomacy detection, mission return fallback, healing, and construction availability with focused tests.

## Validation

- `MissionSystemTests`: 89/89 passed.
- `./build.sh all`: passed.
- Unity EditMode tests: 4,568/4,568 passed.
- Line coverage: 80.8% (79.0% required).
- Method coverage: 90.9% (87.8% required).
- Formatting, analyzers, compilation, Roslynator, and member-order checks passed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. Not applicable; no UI builder changes.
- [x] Content path or structure changes were also made in `rebellion2-media`. Not applicable; no media changes are required.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. No documentation changes are required for this internal mission behavior correction.