### PR TITLE
Fixing issues where missions were permitted for invalid targets.

### DIFF
--- a/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
@@ -17,6 +17,9 @@ public class StrategyAdvisorAnimationTheme
 
     public string Audio { get; set; }
 
+    [PersistableCollectionItem(Name = "Audio")]
+    public List<string> AudioOptions { get; set; } = new List<string>();
+
     public string AudioPath { get; set; }
 
     public float DelayBeforeSeconds { get; set; }

--- a/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
@@ -219,6 +219,8 @@ public class StrategyAdvisorTheme
 
     public int RepeatCooldownTicks { get; set; }
 
+    public StrategyAdvisorAnimationTheme InvalidOrderRejected { get; set; }
+
     public StrategyAdvisorAnimationTheme InTransitOrderRejected { get; set; }
 
     public StrategyAdvisorAnimationTheme UnitUnderConstructionOrderRejected { get; set; }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Defense/DefenseWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Defense/DefenseWindowController.cs
@@ -832,7 +832,9 @@ public sealed class DefenseWindowController
         if (!targetingController.IsTargeting || session?.Planet == null)
             return false;
 
-        return targetingController.TrySelectTarget(new StrategyMissionTarget(session.Planet, item));
+        return targetingController.TrySelectTarget(
+            new StrategyMissionTarget(session.Planet, item ?? session.Planet.Planet)
+        );
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Facility/FacilityWindowController.cs
@@ -1011,14 +1011,16 @@ public sealed class FacilityWindowController
     /// Attempts to complete strategy targeting from a facility view.
     /// </summary>
     /// <param name="view">The source facility view.</param>
-    /// <param name="item">The optional targeted inventory item.</param>
+    /// <param name="item">The selected item, or null for the represented planet.</param>
     /// <returns>True when an active targeting request accepted the target.</returns>
     private bool TrySelectTarget(FacilityWindowView view, ISceneNode item)
     {
         return targetingController.IsTargeting
             && TryGetSession(view, out FacilityWindowSession session)
-            && session.Planet != null
-            && targetingController.TrySelectTarget(new StrategyMissionTarget(session.Planet, item));
+            && session.Planet?.Planet != null
+            && targetingController.TrySelectTarget(
+                new StrategyMissionTarget(session.Planet, item ?? session.Planet.Planet)
+            );
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowController.cs
@@ -1148,13 +1148,15 @@ public sealed class FleetWindowController
     /// Completes the active targeting request with one fleet-window target.
     /// </summary>
     /// <param name="session">The controller-owned fleet session.</param>
-    /// <param name="item">The optional item within the represented planet.</param>
+    /// <param name="item">The selected item, or null for the represented planet.</param>
     /// <returns>True when an active targeting request completed.</returns>
     private bool TrySelectTarget(FleetWindowSession session, ISceneNode item)
     {
         return targetingController.IsTargeting
             && session?.Planet?.Planet != null
-            && targetingController.TrySelectTarget(new StrategyMissionTarget(session.Planet, item));
+            && targetingController.TrySelectTarget(
+                new StrategyMissionTarget(session.Planet, item ?? session.Planet.Planet)
+            );
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapController.cs
@@ -220,7 +220,7 @@ public sealed class GalaxyMapController
         )
             return false;
 
-        target = new StrategyMissionTarget(planet, null);
+        target = new StrategyMissionTarget(planet, planet.Planet);
         return true;
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -676,6 +676,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <param name="playbacks">The destination playback batch.</param>
     /// <param name="animation">The configured animation.</param>
     /// <param name="usesDroid">Whether the droid image presents the animation.</param>
+    /// <param name="audio">The optional audio name selected for this playback.</param>
     /// <returns>True when the animation is absent, empty, or fully available.</returns>
     private bool TryAddPlayback(
         ICollection<StrategyAdvisorAnimationViewData> playbacks,

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -18,6 +18,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private readonly Func<Faction> getPlayerFaction;
     private readonly Func<string, Texture2D> getTexture;
     private readonly Action<string> playSfx;
+    private readonly Func<int, int> selectRandomIndex;
     private readonly Dictionary<string, StrategyAdvisorNotificationTheme> pendingNotifications =
         new Dictionary<string, StrategyAdvisorNotificationTheme>();
     private readonly Dictionary<string, int> pendingExpirationTicks = new Dictionary<string, int>();
@@ -36,16 +37,19 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <param name="getPlayerFaction">Resolves the current player faction.</param>
     /// <param name="getTexture">Resolves a texture from a configured resource path.</param>
     /// <param name="playSfx">Plays a strategy sound-effect path.</param>
+    /// <param name="selectRandomIndex">Selects a zero-based index below the supplied count.</param>
     public StrategyAdvisorController(
         Func<Faction> getPlayerFaction,
         Func<string, Texture2D> getTexture,
-        Action<string> playSfx
+        Action<string> playSfx,
+        Func<int, int> selectRandomIndex = null
     )
     {
         this.getPlayerFaction =
             getPlayerFaction ?? throw new ArgumentNullException(nameof(getPlayerFaction));
         this.getTexture = getTexture ?? throw new ArgumentNullException(nameof(getTexture));
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
+        this.selectRandomIndex = selectRandomIndex ?? (count => UnityEngine.Random.Range(0, count));
     }
 
     /// <summary>
@@ -303,7 +307,13 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     {
         List<StrategyAdvisorAnimationViewData> playbacks =
             new List<StrategyAdvisorAnimationViewData>();
-        if (!TryAddPlayback(playbacks, animationTheme, false))
+        string audio = animationTheme?.Audio;
+        if (animationTheme?.AudioOptions?.Count > 0)
+            audio = animationTheme.AudioOptions[
+                selectRandomIndex(animationTheme.AudioOptions.Count)
+            ];
+
+        if (!TryAddPlayback(playbacks, animationTheme, false, audio))
             return;
 
         StrategyAdvisorAnimationViewData playback = playbacks.FirstOrDefault();
@@ -670,7 +680,8 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private bool TryAddPlayback(
         ICollection<StrategyAdvisorAnimationViewData> playbacks,
         StrategyAdvisorAnimationTheme animation,
-        bool usesDroid
+        bool usesDroid,
+        string audio = null
     )
     {
         if (animation == null || animation.FrameCount <= 0)
@@ -695,8 +706,8 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
                 frames,
                 usesDroid,
                 !string.IsNullOrWhiteSpace(animation.AudioPath) ? animation.AudioPath
-                    : string.IsNullOrWhiteSpace(animation.Audio) ? null
-                    : theme.GetAudioPath(animation.Audio),
+                    : string.IsNullOrWhiteSpace(audio ?? animation.Audio) ? null
+                    : theme.GetAudioPath(audio ?? animation.Audio),
                 animation.DelayBeforeSeconds
             )
         );

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -280,6 +280,14 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     }
 
     /// <summary>
+    /// Immediately plays the authored response for an invalid order.
+    /// </summary>
+    public void PlayInvalidOrderRejected()
+    {
+        PlayOrderRejected(theme?.InvalidOrderRejected);
+    }
+
+    /// <summary>
     /// Immediately plays the authored response for an order targeting a unit under construction.
     /// </summary>
     public void PlayUnitUnderConstructionOrderRejected()

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
@@ -126,6 +126,14 @@ public sealed class StrategyHudController : IContextMenuReceiver
     }
 
     /// <summary>
+    /// Plays the protocol advisor's authored rejection for an invalid order.
+    /// </summary>
+    public void PlayInvalidOrderRejected()
+    {
+        advisorController.PlayInvalidOrderRejected();
+    }
+
+    /// <summary>
     /// Plays the protocol advisor's authored rejection for a destination under construction.
     /// </summary>
     public void PlayUnitUnderConstructionOrderRejected()

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Missions/MissionCreateWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Missions/MissionCreateWindowController.cs
@@ -113,7 +113,7 @@ public sealed class MissionCreateWindowController
     )
     {
         UIWindow window = view == null ? null : view.GetComponent<UIWindow>();
-        if (view == null || window == null || target == null || target.Item is Fleet)
+        if (view == null || window == null || target?.Item == null || target.Item is Fleet)
             return false;
 
         List<IMissionParticipant> participants = GetMissionSourceParticipants(
@@ -552,7 +552,7 @@ public sealed class MissionCreateWindowController
         {
             MissionTypeID = choice.MissionTypeID,
             Location = missionPlanet,
-            SelectedTarget = session.Target.GetMissionTarget(choice.TargetKind),
+            SelectedTarget = session.Target.Item,
             Discipline = choice.Discipline,
             MainParticipants = session.Agents.ToList(),
             DecoyParticipants = session.Decoys.ToList(),

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Missions/MissionCreateWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Missions/MissionCreateWindowController.cs
@@ -143,7 +143,8 @@ public sealed class MissionCreateWindowController
     /// </summary>
     /// <param name="target">The selected mission target.</param>
     /// <param name="sourceItems">The source selection in visual order.</param>
-    public void Open(StrategyMissionTarget target, IReadOnlyList<ISceneNode> sourceItems)
+    /// <returns>True when the request was valid or toggled an existing window closed.</returns>
+    public bool Open(StrategyMissionTarget target, IReadOnlyList<ISceneNode> sourceItems)
     {
         Vector2Int position = getWindowPosition();
         UIWindow window = windowManager.ToggleExclusiveWindow(
@@ -160,7 +161,7 @@ public sealed class MissionCreateWindowController
             out MissionCreateWindowView view
         );
         if (window == null)
-            return;
+            return true;
 
         if (
             !TryInitializeWindow(
@@ -172,10 +173,11 @@ public sealed class MissionCreateWindowController
         )
         {
             windowManager.DestroyWindow(window);
-            return;
+            return false;
         }
 
         markDirty();
+        return true;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Missions/MissionsWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Missions/MissionsWindowController.cs
@@ -650,9 +650,9 @@ public sealed class MissionsWindowController : IStrategyContextMenuProvider, ICo
         )
             return false;
 
-        return targetingController.TrySelectTarget(
-            new StrategyMissionTarget(session.Planet, session.GetMission(missionIndex))
-        );
+        ISceneNode item =
+            missionIndex < 0 ? session.Planet.Planet : session.GetMission(missionIndex);
+        return targetingController.TrySelectTarget(new StrategyMissionTarget(session.Planet, item));
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowController.cs
@@ -813,7 +813,7 @@ public sealed class PlanetSectorWindowController
         if (hit.Icon == PlanetIcon.Fleet && IsMoveTargetingRequest(request))
             return new StrategyMissionTarget(hit.GalaxyMapPlanet, fleetTarget);
         if (hit.Icon != PlanetIcon.None || hit.PlanetImage)
-            return new StrategyMissionTarget(hit.GalaxyMapPlanet, null);
+            return new StrategyMissionTarget(hit.GalaxyMapPlanet, hit.GalaxyMapPlanet.Planet);
         return null;
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -510,6 +510,7 @@ public sealed class StrategyController
             RebuildSnapshot,
             MarkDirty,
             () => gameManager.HeadquartersSystem,
+            strategyHudController.PlayInvalidOrderRejected,
             strategyHudController.PlayInTransitOrderRejected,
             strategyHudController.PlayUnitUnderConstructionOrderRejected
         );

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Targeting/StrategyMissionTarget.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Targeting/StrategyMissionTarget.cs
@@ -3,7 +3,7 @@ using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 
 /// <summary>
-/// Identifies a strategy planet and optional scene node selected by targeting.
+/// Identifies a strategy planet and the exact scene node selected by targeting.
 /// </summary>
 public sealed class StrategyMissionTarget : ITargetable
 {
@@ -14,10 +14,10 @@ public sealed class StrategyMissionTarget : ITargetable
     public object Target => this;
 
     /// <summary>
-    /// Creates a strategy target for one planet and optional contained item.
+    /// Creates a strategy target for one planet and selected scene node.
     /// </summary>
     /// <param name="planet">The selected galaxy-map planet.</param>
-    /// <param name="item">The optional selected scene node.</param>
+    /// <param name="item">The selected scene node.</param>
     public StrategyMissionTarget(GalaxyMapPlanet planet, ISceneNode item)
     {
         Planet = planet;
@@ -55,7 +55,7 @@ public sealed class StrategyMissionTarget : ITargetable
     {
         return targetKind switch
         {
-            MissionTargetKind.Planet => Planet?.Planet,
+            MissionTargetKind.Planet when Item is Rebellion.Game.Galaxy.Planet => Item,
             MissionTargetKind.Manufacturable when Item is IManufacturable => Item,
             MissionTargetKind.Officer when Item is Officer => Item,
             _ => null,

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandController.cs
@@ -136,13 +136,11 @@ public sealed class StrategyWindowCommandController
         IReadOnlyList<ISceneNode> items
     )
     {
-        if (target?.Item == null)
+        if (target?.Item == null || !missionCreateWindowController.Open(target, items))
         {
             playInvalidOrderRejected();
             return;
         }
-
-        missionCreateWindowController.Open(target, items);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandController.cs
@@ -27,6 +27,7 @@ public sealed class StrategyWindowCommandController
     private readonly Action<UIWindow> clearWindowSelection;
     private readonly Action rebuildSnapshot;
     private readonly Action markDirty;
+    private readonly Action playInvalidOrderRejected;
     private readonly Action playInTransitOrderRejected;
     private readonly Action playUnitUnderConstructionOrderRejected;
 
@@ -45,6 +46,7 @@ public sealed class StrategyWindowCommandController
     /// <param name="rebuildSnapshot">Rebuilds the visible strategy snapshot.</param>
     /// <param name="markDirty">Invalidates the strategy presentation.</param>
     /// <param name="getHeadquartersSystem">Returns the mobile-headquarters system.</param>
+    /// <param name="playInvalidOrderRejected">Plays the advisor's invalid-order rejection.</param>
     /// <param name="playInTransitOrderRejected">Plays the advisor's in-transit rejection.</param>
     /// <param name="playUnitUnderConstructionOrderRejected">Plays the advisor's under-construction rejection.</param>
     public StrategyWindowCommandController(
@@ -60,6 +62,7 @@ public sealed class StrategyWindowCommandController
         Action rebuildSnapshot,
         Action markDirty,
         Func<HeadquartersSystem> getHeadquartersSystem = null,
+        Action playInvalidOrderRejected = null,
         Action playInTransitOrderRejected = null,
         Action playUnitUnderConstructionOrderRejected = null
     )
@@ -87,6 +90,7 @@ public sealed class StrategyWindowCommandController
         this.rebuildSnapshot =
             rebuildSnapshot ?? throw new ArgumentNullException(nameof(rebuildSnapshot));
         this.markDirty = markDirty ?? throw new ArgumentNullException(nameof(markDirty));
+        this.playInvalidOrderRejected = playInvalidOrderRejected ?? (() => { });
         this.playInTransitOrderRejected = playInTransitOrderRejected ?? (() => { });
         this.playUnitUnderConstructionOrderRejected =
             playUnitUnderConstructionOrderRejected ?? (() => { });
@@ -132,6 +136,12 @@ public sealed class StrategyWindowCommandController
         IReadOnlyList<ISceneNode> items
     )
     {
+        if (target?.Item == null)
+        {
+            playInvalidOrderRejected();
+            return;
+        }
+
         missionCreateWindowController.Open(target, items);
     }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowControllerTests.cs
@@ -179,7 +179,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
             Assert.IsInstanceOf<StrategyMissionTarget>(receiver.Target);
             StrategyMissionTarget target = (StrategyMissionTarget)receiver.Target;
             Assert.AreSame(_planet, target.Planet);
-            Assert.IsNull(target.Item);
+            Assert.AreSame(_planet.Planet, target.Item);
             Assert.AreSame(_planet.Planet, target.GetMoveDestination());
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowControllerTests.cs
@@ -218,7 +218,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             Assert.IsInstanceOf<StrategyMissionTarget>(receiver.Target);
             StrategyMissionTarget target = (StrategyMissionTarget)receiver.Target;
             Assert.AreSame(_planet, target.Planet);
-            Assert.IsNull(target.Item);
+            Assert.AreSame(_planet.Planet, target.Item);
             Assert.AreSame(_planet.Planet, target.GetMoveDestination());
         }
 
@@ -254,7 +254,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             Assert.IsInstanceOf<StrategyMissionTarget>(receiver.Target);
             StrategyMissionTarget target = (StrategyMissionTarget)receiver.Target;
             Assert.AreSame(_planet, target.Planet);
-            Assert.IsNull(target.Item);
+            Assert.AreSame(_planet.Planet, target.Item);
             Assert.AreSame(_planet.Planet, target.GetMoveDestination());
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapControllerTests.cs
@@ -147,7 +147,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             Assert.IsTrue(found);
             Assert.IsNotNull(target);
             Assert.AreSame(_sector.Planets[0], target.Planet);
-            Assert.IsNull(target.Item);
+            Assert.AreSame(_sector.Planets[0].Planet, target.Item);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -354,13 +354,13 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
-        public void PlayUnitUnderConstructionOrderRejected_AuthoredResponse_ReplacesPlayback()
+        public void PlayInvalidOrderRejected_AuthoredResponse_ReplacesPlayback()
         {
             GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
             StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
             StrategyAdvisorTheme advisorTheme = CreateTheme();
             advisorTheme.AudioRoot = "Audio";
-            advisorTheme.UnitUnderConstructionOrderRejected = new StrategyAdvisorAnimationTheme
+            advisorTheme.InvalidOrderRejected = new StrategyAdvisorAnimationTheme
             {
                 Animation = "Rejected",
                 FrameCount = 1,
@@ -383,7 +383,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 StrategyAdvisorAnimationViewData playback = null;
                 view.PlaybackStarted += data => playback = data;
 
-                controller.PlayUnitUnderConstructionOrderRejected();
+                controller.PlayInvalidOrderRejected();
 
                 Assert.IsNotNull(playback);
                 Assert.AreSame(rejectedFrame, playback.Frames.Single());

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -364,7 +364,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             {
                 Animation = "Rejected",
                 FrameCount = 1,
-                Audio = "Rejected",
+                AudioOptions = new List<string> { "First", "Second" },
             };
             Texture2D idle = new Texture2D(1, 1);
             Texture2D rejectedFrame = new Texture2D(1, 1);
@@ -377,7 +377,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             try
             {
                 UIComponentTestHelper.InvokeLifecycle(view, "Awake");
-                StrategyAdvisorController controller = CreateController(textures);
+                StrategyAdvisorController controller = CreateController(textures, _ => 1);
                 controller.BindView(view);
                 controller.Render(advisorTheme);
                 StrategyAdvisorAnimationViewData playback = null;
@@ -387,7 +387,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
 
                 Assert.IsNotNull(playback);
                 Assert.AreSame(rejectedFrame, playback.Frames.Single());
-                Assert.AreEqual("Audio/Rejected", playback.AudioPath);
+                Assert.AreEqual("Audio/Second", playback.AudioPath);
             }
             finally
             {
@@ -519,13 +519,15 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         private static StrategyAdvisorController CreateController(
-            IReadOnlyDictionary<string, Texture2D> textures
+            IReadOnlyDictionary<string, Texture2D> textures,
+            Func<int, int> selectRandomIndex = null
         )
         {
             StrategyAdvisorController controller = new StrategyAdvisorController(
                 () => new Faction(),
                 path => textures.TryGetValue(path, out Texture2D texture) ? texture : null,
-                _ => { }
+                _ => { },
+                selectRandomIndex
             );
             controller.Initialize(new TestActions());
             return controller;

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionCreateWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionCreateWindowControllerTests.cs
@@ -58,7 +58,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
                 AllowedMissionTypeIDs = new List<string> { MissionTypeIDs.Reconnaissance },
             };
             _game.AttachNode(_specialForces, origin);
-            _target = new StrategyMissionTarget(targetPlanet, null);
+            _target = new StrategyMissionTarget(targetPlanet, targetPlanet.Planet);
             _rootObject = UIComponentTestHelper.InstantiatePrefab(_strategyViewPrefabPath);
             _windowLayer = _rootObject.GetComponentInChildren<StrategyWindowLayerView>(true);
             _windowManager = _rootObject.GetComponentInChildren<UIWindowManager>(true);

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionCreateWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionCreateWindowProjectorTests.cs
@@ -81,7 +81,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
         public void Build_MissingSessionOrWindow_ThrowsArgumentNullException()
         {
             MissionCreateWindowSession session = CreateSession(
-                new StrategyMissionTarget(_planet, null),
+                new StrategyMissionTarget(_planet, _planet.Planet),
                 Array.Empty<IMissionParticipant>()
             );
 
@@ -94,7 +94,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
         {
             MissionCreateWindowProjector projector = new MissionCreateWindowProjector(() => null);
             MissionCreateWindowSession session = CreateSession(
-                new StrategyMissionTarget(_planet, null),
+                new StrategyMissionTarget(_planet, _planet.Planet),
                 Array.Empty<IMissionParticipant>()
             );
 
@@ -105,7 +105,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
         public void Build_MissionTabWithOpenDropdown_ReturnsMissionWorkflowPresentation()
         {
             MissionCreateWindowSession session = CreateSession(
-                new StrategyMissionTarget(_planet, null),
+                new StrategyMissionTarget(_planet, _planet.Planet),
                 Array.Empty<IMissionParticipant>()
             );
             session.ToggleDropdown();
@@ -167,7 +167,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
         {
             _planet.Planet.PlanetIconPath = null;
             MissionCreateWindowSession session = CreateSession(
-                new StrategyMissionTarget(_planet, null),
+                new StrategyMissionTarget(_planet, _planet.Planet),
                 Array.Empty<IMissionParticipant>()
             );
 
@@ -183,7 +183,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
             Officer selected = CreateOfficer("selected", "Selected", false);
             Officer inTransit = CreateOfficer("transit", "In Transit", true);
             MissionCreateWindowSession session = CreateSession(
-                new StrategyMissionTarget(_planet, null),
+                new StrategyMissionTarget(_planet, _planet.Planet),
                 new IMissionParticipant[] { selected, inTransit }
             );
             session.SelectTab(MissionCreateWindowTab.Personnel);
@@ -228,7 +228,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
             ship.SetParent(fleet);
             officer.SetParent(ship);
             MissionCreateWindowSession session = CreateSession(
-                new StrategyMissionTarget(_planet, null),
+                new StrategyMissionTarget(_planet, _planet.Planet),
                 new IMissionParticipant[] { officer }
             );
             session.SelectTab(MissionCreateWindowTab.Personnel);
@@ -267,27 +267,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
         }
 
         [Test]
-        public void Build_LocationMissionSelectedFromCapitalShip_ReturnsPlanetPreview()
-        {
-            CapitalShip ship = new CapitalShip { DisplayName = "Target Ship" };
-            MissionCreateWindowSession session = CreateSession(
-                new StrategyMissionTarget(_planet, ship),
-                Array.Empty<IMissionParticipant>()
-            );
-
-            MissionCreateWindowRenderData data = _projector.Build(session, _window);
-
-            Assert.AreEqual("Corellia", data.TargetName);
-            Assert.AreSame(_uiContext.GetTexture(_entityImagePath), data.TargetTexture);
-            Assert.IsTrue(data.UsePlanetTargetPreview);
-        }
-
-        [Test]
         public void Build_EmptyChoices_ReturnsEmptyMissionSelection()
         {
             MissionCreateWindowSession session = new MissionCreateWindowSession(
                 _window,
-                new StrategyMissionTarget(_planet, null),
+                new StrategyMissionTarget(_planet, _planet.Planet),
                 Array.Empty<StrategyMissionChoice>(),
                 Array.Empty<IMissionParticipant>()
             );

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionCreateWindowSessionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionCreateWindowSessionTests.cs
@@ -34,7 +34,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
                 new Planet { InstanceID = "planet" },
                 string.Empty
             );
-            _target = new StrategyMissionTarget(planet, null);
+            _target = new StrategyMissionTarget(planet, planet.Planet);
             _choices = new List<StrategyMissionChoice>
             {
                 CreateChoice(MissionTypeIDs.Diplomacy, "Diplomacy"),

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Missions/MissionsWindowControllerTests.cs
@@ -8,6 +8,7 @@ using Rebellion.Game.Galaxy;
 using Rebellion.Game.Missions;
 using Rebellion.Game.Units;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using GalaxyPlanetSector = Rebellion.Game.Galaxy.PlanetSector;
 
 namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
@@ -141,6 +142,23 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
             Assert.AreSame(firstWindow, secondWindow);
             Assert.AreEqual(1, _windowManager.Windows.Count);
             Assert.AreEqual(1, _dirtyCount);
+        }
+
+        [Test]
+        public void SurfaceClicked_ActiveTargeting_SelectsPlanetNode()
+        {
+            MissionsWindowView view = OpenWindow(out UIWindow _);
+            RecordingTargetingReceiver receiver = new RecordingTargetingReceiver();
+            _targetingController.Begin(new TargetingRequest("Select target", null, receiver));
+
+            view.OnPointerClick(
+                new PointerEventData(null) { button = PointerEventData.InputButton.Left }
+            );
+
+            StrategyMissionTarget target = receiver.Target as StrategyMissionTarget;
+            Assert.IsNotNull(target);
+            Assert.AreSame(_planet, target.Planet);
+            Assert.AreSame(_planet.Planet, target.Item);
         }
 
         [Test]
@@ -328,6 +346,18 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Missions
             public void OpenMissionsStatus(StrategyStatusTarget target) { }
 
             public void OpenMissionsInfo(StrategyStatusTarget target) { }
+        }
+
+        private sealed class RecordingTargetingReceiver : ITargetingReceiver
+        {
+            public object Target { get; private set; }
+
+            public void OnTargetSelected(TargetingRequest request, object target)
+            {
+                Target = target;
+            }
+
+            public void OnTargetingCancelled(TargetingRequest request) { }
         }
 
         private sealed class TestMission : Mission

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowControllerTests.cs
@@ -373,7 +373,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
 
             Assert.IsNotNull(target);
             Assert.AreSame(hit.GalaxyMapPlanet, target.Planet);
-            Assert.IsNull(target.Item);
+            Assert.AreSame(hit.GalaxyMapPlanet.Planet, target.Item);
         }
 
         [Test]
@@ -391,7 +391,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
 
             Assert.IsNotNull(target);
             Assert.AreSame(hit.GalaxyMapPlanet, target.Planet);
-            Assert.IsNull(target.Item);
+            Assert.AreSame(hit.GalaxyMapPlanet.Planet, target.Item);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Targeting/StrategyMissionTargetTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Targeting/StrategyMissionTargetTests.cs
@@ -118,12 +118,23 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Targeting
             GalaxyMapPlanet mapPlanet = CreateMapPlanet("planet", "player");
             StrategyMissionTarget locationMission = new StrategyMissionTarget(
                 mapPlanet,
-                new CapitalShip()
+                mapPlanet.Planet
             );
 
             ISceneNode locationTarget = locationMission.GetMissionTarget(MissionTargetKind.Planet);
 
             Assert.AreSame(mapPlanet.Planet, locationTarget);
+        }
+
+        [Test]
+        public void GetMissionTarget_PlanetMissionFromCapitalShip_ReturnsNull()
+        {
+            GalaxyMapPlanet mapPlanet = CreateMapPlanet("planet", "player");
+            StrategyMissionTarget target = new StrategyMissionTarget(mapPlanet, new CapitalShip());
+
+            ISceneNode missionTarget = target.GetMissionTarget(MissionTargetKind.Planet);
+
+            Assert.IsNull(missionTarget);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandControllerTests.cs
@@ -361,6 +361,37 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
         }
 
         [Test]
+        public void ExecuteTargetedCommand_CreateMissionWithoutValidOption_PlaysAdvisorRejection()
+        {
+            Rebellion.Game.Units.Fleet fleet = new Rebellion.Game.Units.Fleet(
+                _opponentFactionId,
+                "target-fleet"
+            );
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "target-ship",
+                OwnerInstanceID = _opponentFactionId,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            _game.AttachNode(fleet, _missionTarget.Planet);
+            _game.AttachNode(ship, fleet);
+
+            _controller.ExecuteTargetedCommand(
+                new StrategyWindowTargetingSource(
+                    _sourceWindow,
+                    StrategyMenuAction.CreateMission,
+                    0,
+                    0,
+                    new ISceneNode[] { _specialForces }
+                ),
+                new StrategyMissionTarget(_missionTarget, ship)
+            );
+
+            Assert.IsEmpty(_windowManager.Windows);
+            Assert.AreEqual(1, _invalidOrderRejectionCount);
+        }
+
+        [Test]
         public void OpenMoveConfirmWindow_ConfirmedMove_MovesUnitAndRefreshesSource()
         {
             _controller.OpenMoveConfirmWindow(

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandControllerTests.cs
@@ -30,6 +30,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
         private GalaxyMapPlanet _destination;
         private GameRoot _game;
         private GameManager _gameManager;
+        private int _invalidOrderRejectionCount;
         private GalaxyMapPlanet _missionTarget;
         private MissionCreateWindowController _missionCreateController;
         private Officer _officer;
@@ -49,6 +50,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
         {
             _clearedWindow = null;
             _dirtyCount = 0;
+            _invalidOrderRejectionCount = 0;
             _rebuildCount = 0;
             _playedSfxCount = 0;
             _transitRejectionCount = 0;
@@ -114,6 +116,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
                 () => _rebuildCount++,
                 () => _dirtyCount++,
                 null,
+                () => _invalidOrderRejectionCount++,
                 () => _transitRejectionCount++,
                 () => _underConstructionRejectionCount++
             );
@@ -331,12 +334,30 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
                     0,
                     new ISceneNode[] { _specialForces }
                 ),
-                new StrategyMissionTarget(_missionTarget, null)
+                new StrategyMissionTarget(_missionTarget, _missionTarget.Planet)
             );
 
             UIWindow window = _windowManager.Windows.Single();
             Assert.IsTrue(window.Modal);
             Assert.IsTrue(_windowManager.TryGetWindowView(window, out MissionCreateWindowView _));
+        }
+
+        [Test]
+        public void ExecuteTargetedCommand_CreateMissionWithoutItem_PlaysAdvisorRejection()
+        {
+            _controller.ExecuteTargetedCommand(
+                new StrategyWindowTargetingSource(
+                    _sourceWindow,
+                    StrategyMenuAction.CreateMission,
+                    0,
+                    0,
+                    new ISceneNode[] { _specialForces }
+                ),
+                new StrategyMissionTarget(_missionTarget, null)
+            );
+
+            Assert.IsEmpty(_windowManager.Windows);
+            Assert.AreEqual(1, _invalidOrderRejectionCount);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

- Preserve the exact selected scene node throughout mission selection and submission so capital ships and other units cannot be reinterpreted as their containing planet.
- Represent explicit planet selections with the planet node across galaxy-map and strategy-window targeting.
- Reject mission targets whose `Item` is null and play the faction advisor's authored invalid-order response.
- Pair the advisor configuration with [rebellion2-media #73](https://github.com/adasgames/rebellion2-media/pull/73).

## Validation

- `./build.sh lint`
- `./build.sh test` — 4,567 passed
- `./build.sh build`
- `rebellion2-media ./build.sh all`

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was not required because no public API or setup changed.
