### PR TITLE
Fixing bug allowing injured officers to be assigned to missions.

### DIFF
--- a/Assets/Scripts/Game/Missions/MissionFactory.cs
+++ b/Assets/Scripts/Game/Missions/MissionFactory.cs
@@ -201,6 +201,7 @@ namespace Rebellion.Game.Missions
                 if (
                     missionParticipant?.GetOwnerInstanceID() != resolvedContext.OwnerInstanceId
                     || !missionParticipant.IsActive()
+                    || missionParticipant is Officer { InjuryPoints: > 0 }
                     || missionParticipant.IsOnMission()
                     || !missionParticipant.IsMovable()
                     || missionParticipant.GetTransitMovement() != null

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/MissionFactoryTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/MissionFactoryTests.cs
@@ -206,6 +206,51 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
+        public void TryCreateMission_InjuredPrimaryOfficer_ReturnsFalse()
+        {
+            (GameRoot game, Planet planet, Officer officer, MissionFactory factory) = BuildScene();
+            Regiment target = CreateSabotageTarget(game, planet);
+            officer.InjuryPoints = 1;
+
+            bool created = factory.TryCreateMission(
+                CreateContext(
+                    game,
+                    MissionTypeIDs.Sabotage,
+                    "empire",
+                    officer,
+                    planet,
+                    selectedTarget: target
+                ),
+                out _
+            );
+
+            Assert.IsFalse(created);
+        }
+
+        [Test]
+        public void TryCreateMission_InjuredDecoyOfficer_ReturnsFalse()
+        {
+            (GameRoot game, Planet planet, Officer officer, MissionFactory factory) = BuildScene();
+            Regiment target = CreateSabotageTarget(game, planet);
+            Officer decoy = EntityFactory.CreateOfficer("decoy", "empire");
+            decoy.InjuryPoints = 1;
+            game.AttachNode(decoy, planet);
+            MissionContext context = CreateContext(
+                game,
+                MissionTypeIDs.Sabotage,
+                "empire",
+                officer,
+                planet,
+                selectedTarget: target
+            );
+            context.DecoyParticipants.Add(decoy);
+
+            bool created = factory.TryCreateMission(context, out _);
+
+            Assert.IsFalse(created);
+        }
+
+        [Test]
         public void TryCreateMission_DuplicatePrimaryParticipant_ReturnsFalse()
         {
             (GameRoot game, Planet planet, Officer officer, MissionFactory factory) = BuildScene();


### PR DESCRIPTION
## Summary

- Reject new missions when a primary officer is injured.
- Reject new missions when a decoy officer is injured.
- Preserve missions whose participants become injured after departure.

## Validation

- `MissionFactoryTests`: 30 passed, 0 failed.
- `bash build.sh lint`: passed with 0 diagnostics.
- Full EditMode suite: 4,572 passed and 4 space-combat tests failed; those failures do not exercise mission creation or either file changed by this PR.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable.)