### PR TITLE
Removing the Unity splash screen.

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1


### PR DESCRIPTION
## Summary

- Disable Unity's built-in splash screen for standalone builds.

## Validation

- Confirmed `m_ShowUnitySplashScreen` is disabled in `ProjectSettings/ProjectSettings.asset`.
- No automated tests run; this is a serialized Unity project-setting change.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable.)