### PR TITLE
Fixing bug causing construction indicators to disappear.

### DIFF
--- a/Assets/Scripts/UI/SceneUI/StrategyView/Defense/DefenseWindowProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Defense/DefenseWindowProjector.cs
@@ -288,8 +288,6 @@ internal sealed class DefenseWindowProjector
             starfighterBadgeTexture: null,
             troopBadgeTexture: null,
             personnelBadgeTexture: null,
-            hideBackgroundWhenSelected: item
-                is IManufacturable { ManufacturingStatus: ManufacturingStatus.Building },
             canDrag: DefenseWindowSession.CanDragItem(item)
         );
     }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowProjector.cs
@@ -275,8 +275,6 @@ internal sealed class FleetWindowProjector
                         capitalShip?.GetChildren<Officer>().Any() == true,
                         badgeIcons => badgeIcons.FleetPersonnelBadgeImagePath
                     ),
-                    hideBackgroundWhenSelected: item
-                        is IManufacturable { ManufacturingStatus: ManufacturingStatus.Building },
                     canDrag: true
                 )
             );

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUnitCardView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUnitCardView.cs
@@ -49,7 +49,6 @@ public sealed class StrategyUnitCardView : MonoBehaviour, IStrategyStatusDoubleC
 
     private bool canDrag;
     private RectInt entityFrameRect;
-    private bool hideBackgroundWhenSelected;
     private bool layoutCaptured;
     private UIPointerGestureRelay pointerGestures;
 
@@ -125,7 +124,6 @@ public sealed class StrategyUnitCardView : MonoBehaviour, IStrategyStatusDoubleC
         VerifyReferences();
         CaptureLayout();
         canDrag = data.CanDrag;
-        hideBackgroundWhenSelected = data.HideBackgroundWhenSelected;
 
         RectInt entityRenderFrameRect = GetEntityRenderFrameRect(data.EntityFrameYOffset);
         SetOptionalImageTexture(backgroundImage, data.BackgroundTexture);
@@ -161,8 +159,6 @@ public sealed class StrategyUnitCardView : MonoBehaviour, IStrategyStatusDoubleC
     {
         VerifyReferences();
         SetOptionalImageTexture(selectionImage, texture);
-        if (backgroundImage != null && hideBackgroundWhenSelected)
-            backgroundImage.gameObject.SetActive(texture == null);
     }
 
     /// <summary>
@@ -422,8 +418,6 @@ public sealed class StrategyUnitCardRenderData
 
     public Texture PersonnelBadgeTexture { get; }
 
-    public bool HideBackgroundWhenSelected { get; }
-
     public bool CanDrag { get; }
 
     /// <summary>
@@ -443,7 +437,6 @@ public sealed class StrategyUnitCardRenderData
     /// <param name="starfighterBadgeTexture">The optional starfighter badge.</param>
     /// <param name="troopBadgeTexture">The optional troop badge.</param>
     /// <param name="personnelBadgeTexture">The optional personnel badge.</param>
-    /// <param name="hideBackgroundWhenSelected">Whether selection replaces the card background.</param>
     /// <param name="canDrag">Whether the card can initiate a move drag.</param>
     public StrategyUnitCardRenderData(
         string name,
@@ -460,7 +453,6 @@ public sealed class StrategyUnitCardRenderData
         Texture starfighterBadgeTexture,
         Texture troopBadgeTexture,
         Texture personnelBadgeTexture,
-        bool hideBackgroundWhenSelected,
         bool canDrag
     )
     {
@@ -478,7 +470,6 @@ public sealed class StrategyUnitCardRenderData
         StarfighterBadgeTexture = starfighterBadgeTexture;
         TroopBadgeTexture = troopBadgeTexture;
         PersonnelBadgeTexture = personnelBadgeTexture;
-        HideBackgroundWhenSelected = hideBackgroundWhenSelected;
         CanDrag = canDrag;
     }
 }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowProjectorTests.cs
@@ -217,7 +217,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
             Assert.IsNull(card.DamagedOverlayTexture);
             Assert.IsNotNull(card.BackgroundTexture);
             Assert.IsNotNull(card.EntityTexture);
-            Assert.IsTrue(card.HideBackgroundWhenSelected);
             Assert.IsFalse(card.CanDrag);
         }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowRenderDataTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowRenderDataTests.cs
@@ -113,7 +113,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
                 null,
                 null,
                 null,
-                false,
                 false
             );
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Defense/DefenseWindowViewTests.cs
@@ -104,26 +104,19 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
         }
 
         [Test]
-        public void RenderItemSelection_UnderConstructionItem_ReplacesConstructionBackground()
+        public void RenderItemSelection_ItemWithBackground_PreservesBackground()
         {
             _view.Render(
                 CreateRenderData(
                     DefenseWindowTab.Starfighters,
-                    new[]
-                    {
-                        CreateItem(
-                            "Fighter Squadron",
-                            backgroundTexture: _backgroundTexture,
-                            hideBackgroundWhenSelected: true
-                        ),
-                    }
+                    new[] { CreateItem("Fighter Squadron", backgroundTexture: _backgroundTexture) }
                 )
             );
             StrategyUnitCardView card = FindItemCards()[0];
 
             _view.RenderItemSelection(new[] { 0 }, _texture);
 
-            Assert.IsFalse(FindCardObject(card, "BackgroundImage").activeSelf);
+            Assert.IsTrue(FindCardObject(card, "BackgroundImage").activeSelf);
             Assert.IsTrue(FindCardObject(card, "SelectionImage").activeSelf);
 
             _view.RenderItemSelection(Array.Empty<int>(), _texture);
@@ -547,8 +540,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
             bool canDrag = false,
             bool showOptionalImages = false,
             bool alternateNameLayout = false,
-            Texture backgroundTexture = null,
-            bool hideBackgroundWhenSelected = false
+            Texture backgroundTexture = null
         )
         {
             Texture optionalTexture = showOptionalImages ? _texture : null;
@@ -568,7 +560,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
                 optionalTexture,
                 optionalTexture,
                 optionalTexture,
-                hideBackgroundWhenSelected,
                 canDrag
             );
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowProjectorTests.cs
@@ -227,7 +227,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             Assert.IsNotNull(card.EntityTexture);
             Assert.IsNull(card.EnrouteOverlayTexture);
             Assert.IsNull(card.DamagedOverlayTexture);
-            Assert.IsTrue(card.HideBackgroundWhenSelected);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowRenderDataTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowRenderDataTests.cs
@@ -225,7 +225,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
                 null,
                 null,
                 null,
-                false,
                 true
             );
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Fleet/FleetWindowViewTests.cs
@@ -729,7 +729,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
                 optionalTexture,
                 optionalTexture,
                 optionalTexture,
-                false,
                 true
             );
         }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUnitCardRenderDataTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUnitCardRenderDataTests.cs
@@ -24,7 +24,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                 null,
                 null,
                 null,
-                true,
                 true
             );
 
@@ -33,7 +32,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
             Assert.IsTrue(card.ShowName);
             Assert.IsTrue(card.UseAlternateNameLayout);
             Assert.AreEqual(4, card.EntityFrameYOffset);
-            Assert.IsTrue(card.HideBackgroundWhenSelected);
             Assert.IsTrue(card.CanDrag);
         }
     }


### PR DESCRIPTION
## Summary

- Preserve faction construction backgrounds while unfinished units are selected.
- Keep selection frames layered above construction state instead of replacing it.
- Remove the obsolete background-suppression option from shared unit-card presentation data.

## Validation

- Unity EditMode tests: 75 passed, 0 failed across the shared unit-card, Fleet window, and Defense window fixtures.
- `dotnet build GameTests.csproj -v:minimal` — passed with 0 warnings and 0 errors.
- `dotnet csharpier check` on all changed files.
- UI builder: not applicable; no generated UI or authored layout changed.
- Media integration: not applicable; no content paths or assets changed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable; this corrects existing presentation behavior.)