### PR TITLE
Restoring fleet based mission detections.

### DIFF
--- a/Assets/Scripts/Game/Missions/DiplomacyMission.cs
+++ b/Assets/Scripts/Game/Missions/DiplomacyMission.cs
@@ -20,11 +20,6 @@ namespace Rebellion.Game.Missions
         /// </summary>
         internal override bool SuccessfulParticipantsRemainAtLocation => true;
 
-        /// <summary>
-        /// Returns whether hostile forces can foil the mission.
-        /// </summary>
-        internal override bool CanBeFoiled => false;
-
         /// <summary>Creates an empty diplomacy mission copy.</summary>
         /// <returns>An empty diplomacy mission.</returns>
         protected override BaseSceneNode CreateNodeCopy() => new DiplomacyMission();

--- a/Assets/Scripts/Game/Missions/JediTrainingMission.cs
+++ b/Assets/Scripts/Game/Missions/JediTrainingMission.cs
@@ -18,6 +18,11 @@ namespace Rebellion.Game.Missions
         public const string MissionTypeID = "JediTraining";
 
         /// <summary>
+        /// Returns whether hostile forces can foil the mission.
+        /// </summary>
+        internal override bool CanBeFoiled => false;
+
+        /// <summary>
         /// Instance ID of the officer selected as the trainer.
         /// </summary>
         public string TrainerInstanceID { get; set; }
@@ -198,19 +203,6 @@ namespace Rebellion.Game.Missions
                 ? null
                 : MissionCompletionReason.Failure;
         }
-
-        /// <summary>
-        /// Jedi training targets own planets and is never foiled.
-        /// </summary>
-        /// <param name="detectorRating">The detector rating, unused because training cannot be foiled.</param>
-        /// <param name="defender">The defender, unused because training cannot be foiled.</param>
-        /// <param name="game">The current game state, unused because training cannot be foiled.</param>
-        /// <returns>Always 0.</returns>
-        protected override double GetFoilProbability(
-            int detectorRating,
-            Officer defender,
-            GameRoot game
-        ) => 0;
 
         /// <summary>
         /// Calculates the probability that at least one student makes Force training progress.

--- a/Assets/Scripts/Game/Missions/JediTrainingMission.cs
+++ b/Assets/Scripts/Game/Missions/JediTrainingMission.cs
@@ -18,11 +18,6 @@ namespace Rebellion.Game.Missions
         public const string MissionTypeID = "JediTraining";
 
         /// <summary>
-        /// Returns whether hostile forces can foil the mission.
-        /// </summary>
-        internal override bool CanBeFoiled => false;
-
-        /// <summary>
         /// Instance ID of the officer selected as the trainer.
         /// </summary>
         public string TrainerInstanceID { get; set; }

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -115,8 +115,6 @@ namespace Rebellion.Game.Missions
 
         internal virtual bool AppliesFoiledParticipantConsequences => true;
 
-        internal virtual bool CanBeFoiled => true;
-
         internal virtual bool SuccessfulParticipantsRemainAtLocation => false;
 
         /// <summary>
@@ -776,7 +774,8 @@ namespace Rebellion.Game.Missions
             )
                 return false;
 
-            return candidate is Regiment or Starfighter or CapitalShip;
+            return (candidate is Regiment or Starfighter or CapitalShip)
+                && FindDetectorCommander(candidate) != null;
         }
 
         /// <summary>
@@ -877,7 +876,7 @@ namespace Rebellion.Game.Missions
             }
 
             List<IMissionParticipant> participantsBeforeDetection = GetAllParticipants();
-            if (CanBeFoiled && runtime.ResolveDetection(this, results))
+            if (runtime.ResolveDetection(this, results))
             {
                 AddMissionResults(ResolveInterruption(game, provider), results);
                 MissionCompletedResult completed = BuildTerminatingResult(

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -482,33 +482,6 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns the probability that enemy forces detect the mission.
-        /// </summary>
-        /// <param name="detectorRating">The selected enemy detector's detection rating.</param>
-        /// <param name="defender">The commander paired with the selected detector, if present.</param>
-        /// <param name="game">The current game state.</param>
-        /// <returns>The foil probability.</returns>
-        protected virtual double GetFoilProbability(
-            int detectorRating,
-            Officer defender,
-            GameRoot game
-        )
-        {
-            int defenderEspionage = defender?.GetEffectiveRating(OfficerRating.Espionage) ?? 0;
-            GameConfig.MissionProbabilityTablesConfig missionTables = GetMissionTables(game);
-            int scaledDefender =
-                defenderEspionage * missionTables.FoilDefenderScalingPercent / _ratingPercentScale;
-            int specialForcesPenalty = GetMainParticipants().OfType<SpecialForces>().Count();
-            int score =
-                GetAveragedRating(OfficerRating.Espionage)
-                - scaledDefender
-                - detectorRating
-                - specialForcesPenalty
-                - missionTables.FoilFlatScoreAdjustment;
-            return LookupProbability(missionTables.Foil, score);
-        }
-
-        /// <summary>
         /// Returns the success probability for this mission's configured table.
         /// </summary>
         /// <param name="game">The current game state.</param>
@@ -564,20 +537,6 @@ namespace Rebellion.Game.Missions
                 return defaultValue;
 
             return new ProbabilityTable(entries).Lookup(score);
-        }
-
-        /// <summary>
-        /// Returns the average effective rating for the mission's main participants.
-        /// </summary>
-        /// <param name="rating">The rating to average.</param>
-        /// <returns>The averaged effective rating, or 0 when no main participants exist.</returns>
-        private int GetAveragedRating(OfficerRating rating)
-        {
-            if (GetMainParticipants().Count == 0)
-                return 0;
-
-            return GetMainParticipants().Sum(participant => participant.GetEffectiveRating(rating))
-                / GetMainParticipants().Count;
         }
 
         /// <summary>
@@ -867,34 +826,6 @@ namespace Rebellion.Game.Missions
                 && officer.CurrentRank == requiredRank
                 && IsEligibleDetectorCommander(officer)
             );
-        }
-
-        /// <summary>
-        /// Rolls one detector's mission foil check.
-        /// </summary>
-        /// <param name="provider">RNG provider for the foil roll.</param>
-        /// <param name="game">The current game state.</param>
-        /// <param name="detector">The detector making this attempt.</param>
-        /// <returns>True if the mission is detected this tick.</returns>
-        internal bool RollFoilCheck(
-            IRandomNumberProvider provider,
-            GameRoot game,
-            ISceneNode detector
-        )
-        {
-            if (detector == null)
-                return false;
-
-            double foilProbability = GetFoilProbability(
-                GetDetectorRating(detector),
-                FindDetectorCommander(detector),
-                game
-            );
-
-            if (foilProbability <= 0)
-                return false;
-
-            return IsSuccessfulProbabilityRoll(provider.NextDouble() * 100, foilProbability);
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -62,35 +62,6 @@ namespace Rebellion.Game.Missions
     }
 
     /// <summary>
-    /// Describes one hostile unit that can detect a mission or confront a detected participant.
-    /// </summary>
-    internal sealed class MissionDetector
-    {
-        internal ISceneNode Unit { get; }
-
-        internal Officer Commander { get; }
-
-        internal int Rating { get; }
-
-        internal bool IsFleetBased { get; }
-
-        /// <summary>
-        /// Creates a detector with its original detection context.
-        /// </summary>
-        /// <param name="unit">The detecting regiment, starfighter, or capital ship.</param>
-        /// <param name="commander">The matching local commander, when one is present.</param>
-        /// <param name="rating">The unit's authored detection rating.</param>
-        /// <param name="isFleetBased">Whether the detector belongs to a fleet.</param>
-        internal MissionDetector(ISceneNode unit, Officer commander, int rating, bool isFleetBased)
-        {
-            Unit = unit;
-            Commander = commander;
-            Rating = rating;
-            IsFleetBased = isFleetBased;
-        }
-    }
-
-    /// <summary>
     /// Base scene node for missions and their assigned participants.
     /// </summary>
     public abstract class Mission : ContainerNode
@@ -491,20 +462,22 @@ namespace Rebellion.Game.Missions
         /// <returns>The decoy success probability.</returns>
         private double GetDecoyProbability(
             IMissionParticipant decoy,
-            MissionDetector detector,
+            ISceneNode detector,
             GameRoot game
         )
         {
             int decoyEspionage = decoy.GetEffectiveRating(OfficerRating.Espionage);
             GameConfig.MissionProbabilityTablesConfig missionTables = GetMissionTables(game);
+            Officer commander = FindDetectorCommander(detector);
             int scaledDefender =
-                (detector.Commander?.GetEffectiveRating(OfficerRating.Espionage) ?? 0)
+                (commander?.GetEffectiveRating(OfficerRating.Espionage) ?? 0)
                 * missionTables.DecoyDefenderScalingPercent
                 / _ratingPercentScale;
-            int score = decoyEspionage - detector.Rating - scaledDefender;
-            Dictionary<int, int> table = detector.IsFleetBased
-                ? missionTables.FleetDecoy
-                : missionTables.PlanetaryDecoy;
+            int score = decoyEspionage - GetDetectorRating(detector) - scaledDefender;
+            Dictionary<int, int> table =
+                detector.GetParentOfType<Fleet>() != null
+                    ? missionTables.FleetDecoy
+                    : missionTables.PlanetaryDecoy;
             return LookupProbability(table, score);
         }
 
@@ -814,7 +787,7 @@ namespace Rebellion.Game.Missions
             IMissionParticipant decoy,
             IRandomNumberProvider provider,
             GameRoot game,
-            MissionDetector detector
+            ISceneNode detector
         )
         {
             if (decoy == null || detector == null)
@@ -827,90 +800,11 @@ namespace Rebellion.Game.Missions
         }
 
         /// <summary>
-        /// Returns hostile detector units in the original foil traversal order.
-        /// </summary>
-        /// <returns>The ordered detector collection.</returns>
-        internal List<MissionDetector> GetDetectors()
-        {
-            if (GetParent() is not Planet planet)
-                return new List<MissionDetector>();
-
-            List<MissionDetector> detectors = new List<MissionDetector>();
-            foreach (Starfighter starfighter in planet.GetChildren<Starfighter>())
-            {
-                if (IsEligibleDetector(starfighter))
-                    detectors.Add(CreateDetector(planet, starfighter));
-            }
-
-            foreach (Regiment regiment in planet.GetChildren<Regiment>())
-            {
-                if (IsEligibleDetector(regiment))
-                    detectors.Add(CreateDetector(planet, regiment));
-            }
-
-            foreach (Fleet fleet in planet.GetChildren<Fleet>())
-            {
-                foreach (CapitalShip capitalShip in fleet.GetChildren<CapitalShip>())
-                {
-                    if (IsEligibleDetector(capitalShip))
-                        detectors.Add(CreateDetector(planet, capitalShip));
-
-                    foreach (Starfighter starfighter in capitalShip.GetChildren<Starfighter>())
-                    {
-                        if (IsEligibleDetector(starfighter))
-                            detectors.Add(CreateDetector(planet, starfighter));
-                    }
-
-                    foreach (Regiment regiment in capitalShip.GetChildren<Regiment>())
-                    {
-                        if (IsEligibleDetector(regiment))
-                            detectors.Add(CreateDetector(planet, regiment));
-                    }
-                }
-            }
-
-            return detectors;
-        }
-
-        /// <summary>
-        /// Creates a detector and resolves its matching local commander.
-        /// </summary>
-        /// <param name="planet">The mission planet.</param>
-        /// <param name="unit">The detecting unit.</param>
-        /// <returns>The resolved detector.</returns>
-        private static MissionDetector CreateDetector(Planet planet, ISceneNode unit)
-        {
-            return new MissionDetector(
-                unit,
-                FindDetectorCommander(planet, unit),
-                GetDetectorRating(unit),
-                unit.GetParentOfType<Fleet>() != null
-            );
-        }
-
-        /// <summary>
-        /// Selects one detector uniformly for a post-foil participant encounter.
-        /// </summary>
-        /// <param name="detectors">The remaining active detectors.</param>
-        /// <param name="provider">RNG provider used for selection.</param>
-        /// <returns>The selected detector, or null when none remain.</returns>
-        internal static MissionDetector SelectDetector(
-            IReadOnlyList<MissionDetector> detectors,
-            IRandomNumberProvider provider
-        )
-        {
-            if (detectors == null || detectors.Count == 0)
-                return null;
-
-            return detectors[provider.NextInt(0, detectors.Count)];
-        }
-
-        /// <summary>
         /// Returns whether a scene object may attempt to detect this mission.
         /// </summary>
         /// <param name="candidate">The potential hostile detector.</param>
         /// <returns>True for a completed, stationary hostile unit with a detection rating.</returns>
-        private bool IsEligibleDetector(ISceneNode candidate)
+        internal bool IsEligibleDetector(ISceneNode candidate)
         {
             string candidateOwnerId = candidate?.GetOwnerInstanceID();
             if (
@@ -943,11 +837,13 @@ namespace Rebellion.Game.Missions
         /// <summary>
         /// Finds the commander type paired with the selected detector in its local container.
         /// </summary>
-        /// <param name="planet">The mission planet.</param>
         /// <param name="detector">The selected hostile detector.</param>
         /// <returns>The matching commander, or null when none is assigned.</returns>
-        private static Officer FindDetectorCommander(Planet planet, ISceneNode detector)
+        internal Officer FindDetectorCommander(ISceneNode detector)
         {
+            if (GetParent() is not Planet planet)
+                return null;
+
             OfficerRank requiredRank = detector switch
             {
                 Starfighter => OfficerRank.Commander,
@@ -983,13 +879,17 @@ namespace Rebellion.Game.Missions
         internal bool RollFoilCheck(
             IRandomNumberProvider provider,
             GameRoot game,
-            MissionDetector detector
+            ISceneNode detector
         )
         {
             if (detector == null)
                 return false;
 
-            double foilProbability = GetFoilProbability(detector.Rating, detector.Commander, game);
+            double foilProbability = GetFoilProbability(
+                GetDetectorRating(detector),
+                FindDetectorCommander(detector),
+                game
+            );
 
             if (foilProbability <= 0)
                 return false;
@@ -1009,7 +909,7 @@ namespace Rebellion.Game.Missions
             IRandomNumberProvider provider,
             GameRoot game,
             IMissionParticipant decoy,
-            MissionDetector detector
+            ISceneNode detector
         )
         {
             return CheckDecoySuccessful(decoy, provider, game, detector);

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -774,8 +774,7 @@ namespace Rebellion.Game.Missions
             )
                 return false;
 
-            return (candidate is Regiment or Starfighter or CapitalShip)
-                && FindDetectorCommander(candidate) != null;
+            return candidate is Regiment or Starfighter or CapitalShip;
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -34,7 +34,7 @@ namespace Rebellion.Game.Missions
     internal interface IMissionExecutionRuntime
     {
         /// <summary>
-        /// Resolves this tick's detection attempt.
+        /// Resolves the mission's initial detection attempt.
         /// </summary>
         /// <param name="mission">The mission executing its lifecycle.</param>
         /// <param name="results">The result collection receiving detection consequences.</param>
@@ -112,6 +112,7 @@ namespace Rebellion.Game.Missions
         // Mission progress.
         public int MaxProgress { get; set; }
         public int CurrentProgress { get; set; }
+        public bool DetectionResolved { get; set; }
 
         internal virtual bool AppliesFoiledParticipantConsequences => true;
 
@@ -182,6 +183,7 @@ namespace Rebellion.Game.Missions
             copy.HasInitiated = HasInitiated;
             copy.MaxProgress = MaxProgress;
             copy.CurrentProgress = CurrentProgress;
+            copy.DetectionResolved = DetectionResolved;
         }
 
         /// <summary>
@@ -281,6 +283,7 @@ namespace Rebellion.Game.Missions
         {
             CurrentProgress = 0;
             MaxProgress = maxProgress;
+            DetectionResolved = false;
             CaptureMainParticipantIDs();
             HasInitiated = true;
         }
@@ -770,6 +773,8 @@ namespace Rebellion.Game.Missions
                 || candidate
                     is not IManufacturable { ManufacturingStatus: ManufacturingStatus.Complete }
                 || candidate is IMovable movable && movable.GetTransitMovement() != null
+                || candidate.GetParentOfType<CapitalShip>()
+                    is IManufacturable { ManufacturingStatus: not ManufacturingStatus.Complete }
                 || candidate.GetParentOfType<Fleet>()?.GetTransitMovement() != null
             )
                 return false;
@@ -875,7 +880,13 @@ namespace Rebellion.Game.Missions
             }
 
             List<IMissionParticipant> participantsBeforeDetection = GetAllParticipants();
-            if (runtime.ResolveDetection(this, results))
+            bool wasDetected = false;
+            if (!DetectionResolved)
+            {
+                DetectionResolved = true;
+                wasDetected = runtime.ResolveDetection(this, results);
+            }
+            if (wasDetected)
             {
                 AddMissionResults(ResolveInterruption(game, provider), results);
                 MissionCompletedResult completed = BuildTerminatingResult(

--- a/Assets/Scripts/Game/Missions/ResearchMission.cs
+++ b/Assets/Scripts/Game/Missions/ResearchMission.cs
@@ -19,11 +19,6 @@ namespace Rebellion.Game.Missions
         public const string MissionTypeID = "Research";
 
         /// <summary>
-        /// Returns whether hostile forces can foil the mission.
-        /// </summary>
-        internal override bool CanBeFoiled => false;
-
-        /// <summary>
         /// Research discipline advanced by this mission.
         /// </summary>
         public ResearchDiscipline Discipline { get; set; }

--- a/Assets/Scripts/Game/Missions/ResearchMission.cs
+++ b/Assets/Scripts/Game/Missions/ResearchMission.cs
@@ -19,6 +19,11 @@ namespace Rebellion.Game.Missions
         public const string MissionTypeID = "Research";
 
         /// <summary>
+        /// Returns whether hostile forces can foil the mission.
+        /// </summary>
+        internal override bool CanBeFoiled => false;
+
+        /// <summary>
         /// Research discipline advanced by this mission.
         /// </summary>
         public ResearchDiscipline Discipline { get; set; }
@@ -170,19 +175,6 @@ namespace Rebellion.Game.Missions
                 _ => false,
             };
         }
-
-        /// <summary>
-        /// Research missions target own planets and are never foiled.
-        /// </summary>
-        /// <param name="detectorRating">The detector rating (unused).</param>
-        /// <param name="defender">The defender (unused).</param>
-        /// <param name="game">The current game state, unused because research cannot be foiled.</param>
-        /// <returns>Always 0.</returns>
-        protected override double GetFoilProbability(
-            int detectorRating,
-            Officer defender,
-            GameRoot game
-        ) => 0;
 
         /// <summary>
         /// Calculates the probability that at least one researcher produces research progress.

--- a/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
+++ b/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
@@ -13,11 +13,6 @@ namespace Rebellion.Game.Missions
     {
         public const string MissionTypeID = "SubdueUprising";
 
-        /// <summary>
-        /// Returns whether hostile forces can foil the mission.
-        /// </summary>
-        internal override bool CanBeFoiled => false;
-
         /// <summary>Creates an empty subdue-uprising mission copy.</summary>
         /// <returns>An empty subdue-uprising mission.</returns>
         protected override BaseSceneNode CreateNodeCopy() => new SubdueUprisingMission();

--- a/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
+++ b/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
@@ -14,6 +14,11 @@ namespace Rebellion.Game.Missions
     {
         public const string MissionTypeID = "SubdueUprising";
 
+        /// <summary>
+        /// Returns whether hostile forces can foil the mission.
+        /// </summary>
+        internal override bool CanBeFoiled => false;
+
         /// <summary>Creates an empty subdue-uprising mission copy.</summary>
         /// <returns>An empty subdue-uprising mission.</returns>
         protected override BaseSceneNode CreateNodeCopy() => new SubdueUprisingMission();
@@ -88,19 +93,6 @@ namespace Rebellion.Game.Missions
                 ? null
                 : MissionCompletionReason.Failure;
         }
-
-        /// <summary>
-        /// Subdue Uprising missions are never foiled — they target own planets.
-        /// </summary>
-        /// <param name="detectorRating">The detector rating, unused because subdue uprising cannot be foiled.</param>
-        /// <param name="defender">The defender, unused because subdue uprising cannot be foiled.</param>
-        /// <param name="game">The current game state, unused because subdue uprising cannot be foiled.</param>
-        /// <returns>Always 0.</returns>
-        protected override double GetFoilProbability(
-            int detectorRating,
-            Officer defender,
-            GameRoot game
-        ) => 0;
 
         /// <summary>
         /// Returns a participant's raw score for subduing the target uprising.

--- a/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
+++ b/Assets/Scripts/Game/Missions/SubdueUprisingMission.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Results;
-using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
 
 namespace Rebellion.Game.Missions

--- a/Assets/Scripts/Game/Units/Building.cs
+++ b/Assets/Scripts/Game/Units/Building.cs
@@ -51,6 +51,7 @@ namespace Rebellion.Game.Units
         public int ShieldStrength { get; set; }
         public int WeaponPower { get; set; }
         public DefenseWeaponEffect DefenseWeaponEffect { get; set; }
+        public bool IsDetectionBlocker { get; set; }
         public List<string> ProtectedUnitTypeIDs { get; set; } = new List<string>();
         public int ProductionModifier { get; set; }
         public List<string> Upgrades { get; set; } = new List<string>();
@@ -101,6 +102,7 @@ namespace Rebellion.Game.Units
             copy.ShieldStrength = ShieldStrength;
             copy.WeaponPower = WeaponPower;
             copy.DefenseWeaponEffect = DefenseWeaponEffect;
+            copy.IsDetectionBlocker = IsDetectionBlocker;
             copy.ProtectedUnitTypeIDs =
                 ProtectedUnitTypeIDs == null
                     ? new List<string>()

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -701,13 +701,13 @@ namespace Rebellion.Systems
             if (mission.GetParent() is not Planet planet)
                 return false;
 
-            List<MissionDetector> activeDetectors = mission.GetDetectors();
+            List<ISceneNode> activeDetectors = GetDetectors(mission, planet);
             if (activeDetectors.Count == 0)
                 return false;
 
             ResolveDecoys(mission, activeDetectors, planet, results);
 
-            MissionDetector foilingDetector = activeDetectors.FirstOrDefault(detector =>
+            ISceneNode foilingDetector = activeDetectors.FirstOrDefault(detector =>
                 mission.RollFoilCheck(_provider, _game, detector)
             );
             if (foilingDetector == null)
@@ -717,7 +717,7 @@ namespace Rebellion.Systems
                 return true;
 
             foreach (IMissionParticipant participant in mission.GetMainParticipants().ToList())
-                ResolveFoiledParticipant(participant, activeDetectors, planet, results);
+                ResolveFoiledParticipant(mission, participant, activeDetectors, planet, results);
 
             return true;
         }
@@ -732,12 +732,12 @@ namespace Rebellion.Systems
         /// <param name="results">The result collection receiving confrontation outcomes.</param>
         private void ResolveDecoys(
             Mission mission,
-            List<MissionDetector> activeDetectors,
+            List<ISceneNode> activeDetectors,
             Planet planet,
             List<GameResult> results
         )
         {
-            foreach (MissionDetector detector in activeDetectors.ToList())
+            foreach (ISceneNode detector in activeDetectors.ToList())
             {
                 List<IMissionParticipant> decoys = mission
                     .GetDecoyParticipants()
@@ -753,20 +753,22 @@ namespace Rebellion.Systems
                     continue;
                 }
 
-                ResolveEvasion(decoy, detector, planet, results);
+                ResolveEvasion(mission, decoy, detector, planet, results);
             }
         }
 
         /// <summary>
         /// Applies the post-foil confrontation to one mission participant.
         /// </summary>
+        /// <param name="mission">The mission whose participant was detected.</param>
         /// <param name="participant">The exposed participant.</param>
         /// <param name="detectors">The detectors that were not diverted.</param>
         /// <param name="planet">The mission planet.</param>
         /// <param name="results">Collection to append generated results to.</param>
         private void ResolveFoiledParticipant(
+            Mission mission,
             IMissionParticipant participant,
-            IReadOnlyList<MissionDetector> detectors,
+            IReadOnlyList<ISceneNode> detectors,
             Planet planet,
             List<GameResult> results
         )
@@ -774,26 +776,30 @@ namespace Rebellion.Systems
             if (!IsFreeParticipant(participant))
                 return;
 
-            MissionDetector detector = Mission.SelectDetector(detectors, _provider);
+            ISceneNode detector =
+                detectors.Count == 0 ? null : detectors[_provider.NextInt(0, detectors.Count)];
             if (detector != null)
-                ResolveEvasion(participant, detector, planet, results);
+                ResolveEvasion(mission, participant, detector, planet, results);
         }
 
         /// <summary>
         /// Resolves whether a participant evades the detector that confronted them.
         /// </summary>
+        /// <param name="mission">The mission whose participant was detected.</param>
         /// <param name="participant">The participant attempting to evade.</param>
         /// <param name="detector">The detector confronting the participant.</param>
         /// <param name="planet">The planet where the confrontation occurs.</param>
         /// <param name="results">The result collection receiving capture or destruction outcomes.</param>
         private void ResolveEvasion(
+            Mission mission,
             IMissionParticipant participant,
-            MissionDetector detector,
+            ISceneNode detector,
             Planet planet,
             List<GameResult> results
         )
         {
-            int defenderCombat = detector.Commander?.GetEffectiveRating(OfficerRating.Combat) ?? 0;
+            Officer commander = mission.FindDetectorCommander(detector);
+            int defenderCombat = commander?.GetEffectiveRating(OfficerRating.Combat) ?? 0;
             int score = participant.GetEffectiveRating(OfficerRating.Combat) - defenderCombat;
             bool evaded = _provider.NextDouble() * 100 < GetEvasionProbability(score);
             if (evaded)
@@ -811,7 +817,7 @@ namespace Rebellion.Systems
             if (
                 Mission.ApplyCaptureEvasionInjury(
                     officer,
-                    detector.Unit,
+                    detector,
                     planet,
                     _game,
                     _provider,
@@ -824,6 +830,67 @@ namespace Rebellion.Systems
             }
 
             CaptureOfficer(officer, planet, results);
+        }
+
+        /// <summary>
+        /// Returns hostile detector units in the original traversal order.
+        /// </summary>
+        /// <param name="mission">The mission being checked for detection.</param>
+        /// <param name="planet">The planet where the mission is operating.</param>
+        /// <returns>The ordered detector units.</returns>
+        private static List<ISceneNode> GetDetectors(Mission mission, Planet planet)
+        {
+            List<ISceneNode> detectors = new List<ISceneNode>();
+            AddEligibleDetectors(mission, planet.GetChildren<Starfighter>(), detectors);
+            AddEligibleDetectors(mission, planet.GetChildren<Regiment>(), detectors);
+
+            bool blocksFleetDetection = planet
+                .GetChildren<Building>()
+                .Any(building =>
+                    building.IsDetectionBlocker
+                    && building.OwnerInstanceID == mission.OwnerInstanceID
+                    && building.ManufacturingStatus == ManufacturingStatus.Complete
+                    && building.Movement == null
+                );
+            if (blocksFleetDetection)
+                return detectors;
+
+            foreach (Fleet fleet in planet.GetChildren<Fleet>())
+            {
+                foreach (CapitalShip capitalShip in fleet.GetChildren<CapitalShip>())
+                {
+                    if (mission.IsEligibleDetector(capitalShip))
+                        detectors.Add(capitalShip);
+
+                    AddEligibleDetectors(
+                        mission,
+                        capitalShip.GetChildren<Starfighter>(),
+                        detectors
+                    );
+                    AddEligibleDetectors(mission, capitalShip.GetChildren<Regiment>(), detectors);
+                }
+            }
+
+            return detectors;
+        }
+
+        /// <summary>
+        /// Appends eligible detector units without changing their scene order.
+        /// </summary>
+        /// <param name="mission">The mission being checked for detection.</param>
+        /// <param name="candidates">The candidate detector units.</param>
+        /// <param name="detectors">The collection receiving eligible detectors.</param>
+        private static void AddEligibleDetectors(
+            Mission mission,
+            IEnumerable<ISceneNode> candidates,
+            ICollection<ISceneNode> detectors
+        )
+        {
+            foreach (ISceneNode candidate in candidates)
+            {
+                if (mission.IsEligibleDetector(candidate))
+                    detectors.Add(candidate);
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -708,7 +708,7 @@ namespace Rebellion.Systems
             ResolveDecoys(mission, activeDetectors, planet, results);
 
             ISceneNode foilingDetector = activeDetectors.FirstOrDefault(detector =>
-                mission.RollFoilCheck(_provider, _game, detector)
+                IsMissionDetected(mission, detector)
             );
             if (foilingDetector == null)
                 return false;
@@ -720,6 +720,41 @@ namespace Rebellion.Systems
                 ResolveFoiledParticipant(mission, participant, activeDetectors, planet, results);
 
             return true;
+        }
+
+        /// <summary>
+        /// Rolls one hostile unit's detection attempt against a mission.
+        /// </summary>
+        /// <param name="mission">The mission attempting to remain undetected.</param>
+        /// <param name="detector">The hostile unit making the detection attempt.</param>
+        /// <returns>True when the detector foils the mission.</returns>
+        private bool IsMissionDetected(Mission mission, ISceneNode detector)
+        {
+            if (mission == null || detector == null)
+                return false;
+
+            GameConfig.MissionProbabilityTablesConfig missionTables = GetMissionTables();
+            Officer commander = mission.FindDetectorCommander(detector);
+            int commanderEspionage = commander?.GetEffectiveRating(OfficerRating.Espionage) ?? 0;
+            int scaledCommanderEspionage =
+                commanderEspionage * missionTables.FoilDefenderScalingPercent / 100;
+            IReadOnlyList<IMissionParticipant> participants = mission.GetMainParticipants();
+            int averageEspionage =
+                participants.Count == 0
+                    ? 0
+                    : participants.Sum(participant =>
+                        participant.GetEffectiveRating(OfficerRating.Espionage)
+                    ) / participants.Count;
+            int detectorRating = GetDetectorRating(detector);
+            int specialForcesPenalty = participants.OfType<SpecialForces>().Count();
+            int score =
+                averageEspionage
+                - scaledCommanderEspionage
+                - detectorRating
+                - specialForcesPenalty
+                - missionTables.FoilFlatScoreAdjustment;
+            int detectionProbability = LookupProbability(missionTables.Foil, score);
+            return detectionProbability > 0 && _provider.NextDouble() * 100 < detectionProbability;
         }
 
         /// <summary>
@@ -892,6 +927,20 @@ namespace Rebellion.Systems
                     detectors.Add(candidate);
             }
         }
+
+        /// <summary>
+        /// Returns the authored detection rating for a detector unit.
+        /// </summary>
+        /// <param name="detector">The detector unit.</param>
+        /// <returns>The detector's authored rating.</returns>
+        private static int GetDetectorRating(ISceneNode detector) =>
+            detector switch
+            {
+                Regiment regiment => regiment.DetectionRating,
+                Starfighter starfighter => starfighter.DetectionRating,
+                CapitalShip capitalShip => capitalShip.DetectionRating,
+                _ => 0,
+            };
 
         /// <summary>
         /// Removes a special-forces unit and records its destruction.

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -447,7 +447,7 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Resolves this tick's mission detection through the mission system's external services.
+        /// Resolves the mission's initial detection through the mission system's external services.
         /// </summary>
         /// <param name="mission">The mission executing its lifecycle.</param>
         /// <param name="results">The result collection receiving detection consequences.</param>

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -733,28 +733,64 @@ namespace Rebellion.Systems
             if (mission == null || detector == null)
                 return false;
 
+            int score = CalculateDetectionScore(mission, detector);
+            int probability = LookupProbability(GetMissionTables().Foil, score);
+            return RollProbability(probability);
+        }
+
+        /// <summary>
+        /// Calculates one detector's score against a mission team.
+        /// </summary>
+        /// <param name="mission">The mission attempting to remain undetected.</param>
+        /// <param name="detector">The hostile unit making the detection attempt.</param>
+        /// <returns>The score used to look up the detection probability.</returns>
+        private int CalculateDetectionScore(Mission mission, ISceneNode detector)
+        {
             GameConfig.MissionProbabilityTablesConfig missionTables = GetMissionTables();
-            Officer commander = mission.FindDetectorCommander(detector);
-            int commanderEspionage = commander?.GetEffectiveRating(OfficerRating.Espionage) ?? 0;
-            int scaledCommanderEspionage =
-                commanderEspionage * missionTables.FoilDefenderScalingPercent / 100;
             IReadOnlyList<IMissionParticipant> participants = mission.GetMainParticipants();
-            int averageEspionage =
-                participants.Count == 0
-                    ? 0
-                    : participants.Sum(participant =>
-                        participant.GetEffectiveRating(OfficerRating.Espionage)
-                    ) / participants.Count;
-            int detectorRating = GetDetectorRating(detector);
-            int specialForcesPenalty = participants.OfType<SpecialForces>().Count();
-            int score =
-                averageEspionage
-                - scaledCommanderEspionage
-                - detectorRating
-                - specialForcesPenalty
+            Officer commander = mission.FindDetectorCommander(detector);
+            return GetAverageEspionage(participants)
+                - GetScaledCommanderEspionage(commander, missionTables.FoilDefenderScalingPercent)
+                - GetDetectorRating(detector)
+                - participants.OfType<SpecialForces>().Count()
                 - missionTables.FoilFlatScoreAdjustment;
-            int detectionProbability = LookupProbability(missionTables.Foil, score);
-            return detectionProbability > 0 && _provider.NextDouble() * 100 < detectionProbability;
+        }
+
+        /// <summary>
+        /// Returns the mission team's average effective Espionage rating.
+        /// </summary>
+        /// <param name="participants">The mission's main participants.</param>
+        /// <returns>The average rating, or zero when the mission has no participants.</returns>
+        private static int GetAverageEspionage(IReadOnlyList<IMissionParticipant> participants)
+        {
+            return participants.Count == 0
+                ? 0
+                : participants.Sum(participant =>
+                    participant.GetEffectiveRating(OfficerRating.Espionage)
+                ) / participants.Count;
+        }
+
+        /// <summary>
+        /// Returns the configured portion of a detector commander's Espionage rating.
+        /// </summary>
+        /// <param name="commander">The detector commander, if one is assigned.</param>
+        /// <param name="scalingPercent">The percentage of the rating applied to detection.</param>
+        /// <returns>The scaled commander contribution.</returns>
+        private static int GetScaledCommanderEspionage(Officer commander, int scalingPercent)
+        {
+            return (commander?.GetEffectiveRating(OfficerRating.Espionage) ?? 0)
+                * scalingPercent
+                / 100;
+        }
+
+        /// <summary>
+        /// Rolls against a percentage probability.
+        /// </summary>
+        /// <param name="probability">The percentage chance of success.</param>
+        /// <returns>True when the random roll succeeds.</returns>
+        private bool RollProbability(int probability)
+        {
+            return probability > 0 && _provider.NextDouble() * 100 < probability;
         }
 
         /// <summary>

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/EspionageMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/EspionageMissionTests.cs
@@ -695,6 +695,7 @@ namespace Rebellion.Tests.Game.Missions
                 HasInitiated = true,
                 MaxProgress = 10,
                 CurrentProgress = 5,
+                DetectionResolved = true,
             };
 
             string xml = SerializationHelper.Serialize(mission);
@@ -707,6 +708,7 @@ namespace Rebellion.Tests.Game.Missions
             Assert.IsTrue(deserialized.HasInitiated);
             Assert.AreEqual(10, deserialized.MaxProgress);
             Assert.AreEqual(5, deserialized.CurrentProgress);
+            Assert.IsTrue(deserialized.DetectionResolved);
         }
 
         private static Mission CreateMission(

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/ReconnaissanceMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/ReconnaissanceMissionTests.cs
@@ -78,6 +78,9 @@ namespace Rebellion.Tests.Game.Missions
             detector.DetectionRating = 100;
             detector.ManufacturingStatus = ManufacturingStatus.Complete;
             game.AttachNode(detector, enemyPlanet);
+            Officer commander = EntityFactory.CreateOfficer("commander", "rebels");
+            commander.CurrentRank = OfficerRank.General;
+            game.AttachNode(commander, enemyPlanet);
 
             game.Config.ProbabilityTables.Mission.Foil = new Dictionary<int, int>
             {

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/ReconnaissanceMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/ReconnaissanceMissionTests.cs
@@ -78,9 +78,6 @@ namespace Rebellion.Tests.Game.Missions
             detector.DetectionRating = 100;
             detector.ManufacturingStatus = ManufacturingStatus.Complete;
             game.AttachNode(detector, enemyPlanet);
-            Officer commander = EntityFactory.CreateOfficer("commander", "rebels");
-            commander.CurrentRank = OfficerRank.General;
-            game.AttachNode(commander, enemyPlanet);
 
             game.Config.ProbabilityTables.Mission.Foil = new Dictionary<int, int>
             {

--- a/Assets/Tests/EditMode/GameTests/Game/Units/BuildingTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Units/BuildingTests.cs
@@ -339,6 +339,7 @@ namespace Rebellion.Tests.Game.Units
                 ProductionInputReserved = true,
                 ResourceMaintenanceAllocation = 12,
                 ResourceStartupCyclePending = false,
+                IsDetectionBlocker = true,
                 Upgrades = { "advanced-building" },
                 Movement = null,
             };
@@ -357,6 +358,7 @@ namespace Rebellion.Tests.Game.Units
             Assert.AreEqual(building.WeaponStrength, deserializedBuilding.WeaponStrength);
             Assert.AreEqual(building.ShieldStrength, deserializedBuilding.ShieldStrength);
             Assert.AreEqual(building.DefenseWeaponEffect, deserializedBuilding.DefenseWeaponEffect);
+            Assert.AreEqual(building.IsDetectionBlocker, deserializedBuilding.IsDetectionBlocker);
             CollectionAssert.AreEqual(
                 building.ProtectedUnitTypeIDs,
                 deserializedBuilding.ProtectedUnitTypeIDs

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -988,6 +988,46 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void UpdateMission_InTransitFleetDetector_DoesNotFoilMission()
+        {
+            (GameRoot game, Planet planet, Officer spy, Officer _, MovementSystem movement) =
+                BuildDetectionScene();
+            game.DeleteNode(planet.GetChildren<Regiment>().Single());
+            Fleet fleet = new Fleet
+            {
+                InstanceID = "fleet",
+                OwnerInstanceID = "rebels",
+                Movement = new MovementState { TransitTicks = 10 },
+            };
+            CapitalShip capitalShip = new CapitalShip
+            {
+                InstanceID = "ship",
+                OwnerInstanceID = "rebels",
+                DetectionRating = 100,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(capitalShip, fleet);
+
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            mission.SetExecutionTick(5);
+            SetFoilTable(game, new Dictionary<int, int> { { -1000, 100 } });
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+
+            List<GameResult> results = system.UpdateMission(mission);
+
+            Assert.IsFalse(results.OfType<MissionCompletedResult>().Any());
+            Assert.AreEqual(1, mission.CurrentProgress);
+        }
+
+        [Test]
         public void UpdateMission_FriendlyBuildingBlocksFleetDetection()
         {
             (GameRoot game, Planet planet, Officer spy, Officer _, MovementSystem movement) =

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -523,7 +523,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_DiplomacyWithHostileDetector_DoesNotFoilOrInjureParticipant()
+        public void UpdateMission_DiplomacyWithHostileDetector_CanBeFoiled()
         {
             (GameRoot game, Planet planet, Officer spy, Officer defender, MovementSystem movement) =
                 BuildDetectionScene();
@@ -553,13 +553,53 @@ namespace Rebellion.Tests.Sectors
 
             List<GameResult> results = system.UpdateMission(mission);
 
+            Assert.IsTrue(
+                results
+                    .OfType<MissionCompletedResult>()
+                    .Any(result => result.Outcome == MissionOutcome.Foiled)
+            );
+        }
+
+        [Test]
+        public void UpdateMission_DiplomacyWithoutHostileDetector_DoesNotInjureParticipant()
+        {
+            (GameRoot game, Planet planet, Officer diplomat, Officer _, MovementSystem movement) =
+                BuildDetectionScene();
+            planet.OwnerInstanceID = null;
+            planet.PopularSupport["empire"] = 50;
+            planet.AddVisitor("empire");
+            foreach (Regiment regiment in planet.GetChildren<Regiment>().ToList())
+                game.DeleteNode(regiment);
+
+            Mission mission = MissionTestFactory.TryCreate(
+                MissionTypeIDs.Diplomacy,
+                game,
+                "empire",
+                planet,
+                new List<IMissionParticipant> { diplomat },
+                new List<IMissionParticipant>()
+            );
+            SetFoilTable(game, new Dictionary<int, int> { { -1000, 100 } });
+            SetEvasionTable(game, new Dictionary<int, int> { { -1000, 0 } });
+            game.AttachNode(mission, planet);
+            game.MoveNode(diplomat, mission);
+            mission.Initiate(0);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+
+            List<GameResult> results = system.UpdateMission(mission);
+
             Assert.IsFalse(
                 results
                     .OfType<MissionCompletedResult>()
                     .Any(result => result.Outcome == MissionOutcome.Foiled)
             );
-            Assert.IsFalse(spy.IsCaptured);
-            Assert.Zero(spy.InjuryPoints);
+            Assert.IsFalse(diplomat.IsCaptured);
+            Assert.Zero(diplomat.InjuryPoints);
             Assert.IsFalse(results.OfType<OfficerInjuredResult>().Any());
         }
 
@@ -1182,7 +1222,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_DetectorWithoutCommander_CanFoil()
+        public void UpdateMission_DetectorWithoutCommander_CannotFoil()
         {
             (GameRoot game, Planet planet, Officer spy, Officer defender, MovementSystem movement) =
                 BuildDetectionScene();
@@ -1206,13 +1246,13 @@ namespace Rebellion.Tests.Sectors
             List<GameResult> results = system.UpdateMission(mission);
 
             Assert.IsFalse(spy.IsKilled);
-            Assert.IsTrue(spy.IsCaptured);
-            Assert.IsTrue(
+            Assert.IsFalse(spy.IsCaptured);
+            Assert.IsFalse(
                 results
                     .OfType<MissionCompletedResult>()
                     .Any(result => result.Outcome == MissionOutcome.Foiled)
             );
-            Assert.AreEqual(0, mission.CurrentProgress);
+            Assert.AreEqual(1, mission.CurrentProgress);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -834,6 +834,75 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void UpdateMission_DetectionAlreadyResolved_DoesNotRollAgain()
+        {
+            (GameRoot game, Planet planet, Officer spy, Officer _, MovementSystem movement) =
+                BuildDetectionScene();
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            mission.SetExecutionTick(5);
+            SetFoilTable(game, new Dictionary<int, int> { { -1000, 0 } });
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+
+            system.UpdateMission(mission);
+            SetFoilTable(game, new Dictionary<int, int> { { -1000, 100 } });
+            List<GameResult> results = system.UpdateMission(mission);
+
+            Assert.IsFalse(results.OfType<MissionCompletedResult>().Any());
+            Assert.IsFalse(spy.IsCaptured);
+            Assert.AreEqual(2, mission.CurrentProgress);
+        }
+
+        [Test]
+        public void UpdateMission_CompletedUnitOnIncompleteCapitalShip_DoesNotDetectMission()
+        {
+            (GameRoot game, Planet planet, Officer spy, Officer _, MovementSystem movement) =
+                BuildDetectionScene();
+            game.DeleteNode(planet.GetChildren<Regiment>().Single());
+            Fleet fleet = new Fleet { InstanceID = "fleet", OwnerInstanceID = "rebels" };
+            CapitalShip capitalShip = new CapitalShip
+            {
+                InstanceID = "ship",
+                OwnerInstanceID = "rebels",
+                StarfighterCapacity = 1,
+                ManufacturingStatus = ManufacturingStatus.Building,
+            };
+            Starfighter starfighter = new Starfighter
+            {
+                InstanceID = "fighter",
+                OwnerInstanceID = "rebels",
+                DetectionRating = 100,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(capitalShip, fleet);
+            game.AttachNode(starfighter, capitalShip);
+
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            mission.SetExecutionTick(5);
+            SetFoilTable(game, new Dictionary<int, int> { { -1000, 100 } });
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+
+            List<GameResult> results = system.UpdateMission(mission);
+
+            Assert.IsFalse(results.OfType<MissionCompletedResult>().Any());
+            Assert.AreEqual(1, mission.CurrentProgress);
+        }
+
+        [Test]
         public void UpdateMission_FleetDetector_UsesFleetDecoyTable()
         {
             (GameRoot game, Planet planet, Officer spy, Officer _, MovementSystem movement) =
@@ -881,6 +950,44 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void UpdateMission_UnblockedFleetDetector_FoilsMission()
+        {
+            (GameRoot game, Planet planet, Officer spy, Officer _, MovementSystem movement) =
+                BuildDetectionScene();
+            game.DeleteNode(planet.GetChildren<Regiment>().Single());
+            Fleet fleet = new Fleet { InstanceID = "fleet", OwnerInstanceID = "rebels" };
+            CapitalShip capitalShip = new CapitalShip
+            {
+                InstanceID = "ship",
+                OwnerInstanceID = "rebels",
+                DetectionRating = 100,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(capitalShip, fleet);
+
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            mission.SetExecutionTick(5);
+            SetFoilTable(game, new Dictionary<int, int> { { -1000, 100 } });
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+
+            List<GameResult> results = system.UpdateMission(mission);
+
+            Assert.IsTrue(
+                results
+                    .OfType<MissionCompletedResult>()
+                    .Any(result => result.Outcome == MissionOutcome.Foiled)
+            );
+        }
+
+        [Test]
         public void UpdateMission_FriendlyBuildingBlocksFleetDetection()
         {
             (GameRoot game, Planet planet, Officer spy, Officer _, MovementSystem movement) =
@@ -923,6 +1030,43 @@ namespace Rebellion.Tests.Sectors
 
             Assert.IsFalse(results.OfType<MissionCompletedResult>().Any());
             Assert.AreEqual(1, mission.CurrentProgress);
+        }
+
+        [Test]
+        public void UpdateMission_FriendlyBuildingDoesNotBlockPlanetaryDetection()
+        {
+            (GameRoot game, Planet planet, Officer spy, Officer _, MovementSystem movement) =
+                BuildDetectionScene();
+            planet.OwnerInstanceID = "empire";
+            planet.EnergyCapacity = 1;
+            Building building = new Building
+            {
+                InstanceID = "detection-blocker",
+                OwnerInstanceID = "empire",
+                IsDetectionBlocker = true,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(building, planet);
+
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            mission.SetExecutionTick(5);
+            SetFoilTable(game, new Dictionary<int, int> { { -1000, 100 } });
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+
+            List<GameResult> results = system.UpdateMission(mission);
+
+            Assert.IsTrue(
+                results
+                    .OfType<MissionCompletedResult>()
+                    .Any(result => result.Outcome == MissionOutcome.Foiled)
+            );
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -1222,7 +1222,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_DetectorWithoutCommander_CannotFoil()
+        public void UpdateMission_DetectorWithoutCommander_CanFoil()
         {
             (GameRoot game, Planet planet, Officer spy, Officer defender, MovementSystem movement) =
                 BuildDetectionScene();
@@ -1246,13 +1246,13 @@ namespace Rebellion.Tests.Sectors
             List<GameResult> results = system.UpdateMission(mission);
 
             Assert.IsFalse(spy.IsKilled);
-            Assert.IsFalse(spy.IsCaptured);
-            Assert.IsFalse(
+            Assert.IsTrue(spy.IsCaptured);
+            Assert.IsTrue(
                 results
                     .OfType<MissionCompletedResult>()
                     .Any(result => result.Outcome == MissionOutcome.Foiled)
             );
-            Assert.AreEqual(1, mission.CurrentProgress);
+            Assert.AreEqual(0, mission.CurrentProgress);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -680,9 +680,9 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void RollFoilCheck_DetectorRatingAndRank_SelectMatchingCommander()
+        public void UpdateMission_DetectorRatingAndRank_SelectMatchingCommander()
         {
-            (GameRoot game, Planet planet, Officer spy, Officer general, MovementSystem _) =
+            (GameRoot game, Planet planet, Officer spy, Officer general, MovementSystem movement) =
                 BuildDetectionScene();
             general.SetBaseRating(OfficerRating.Espionage, 40);
             Officer admiral = EntityFactory.CreateOfficer("admiral", "rebels");
@@ -699,10 +699,20 @@ namespace Rebellion.Tests.Sectors
             game.MoveNode(spy, mission);
 
             Regiment selectedDetector = planet.GetChildren<Regiment>().Single();
-            bool foiled = mission.RollFoilCheck(new FixedRNG(0.0), game, selectedDetector);
-
-            Assert.IsTrue(foiled);
             Assert.AreSame(general, mission.FindDetectorCommander(selectedDetector));
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.0),
+                movement
+            );
+
+            List<GameResult> results = system.UpdateMission(mission);
+
+            Assert.IsTrue(
+                results
+                    .OfType<MissionCompletedResult>()
+                    .Any(result => result.Outcome == MissionOutcome.Foiled)
+            );
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -698,12 +698,11 @@ namespace Rebellion.Tests.Sectors
             game.AttachNode(mission, planet);
             game.MoveNode(spy, mission);
 
-            MissionDetector selectedDetector = mission.GetDetectors().Single();
+            Regiment selectedDetector = planet.GetChildren<Regiment>().Single();
             bool foiled = mission.RollFoilCheck(new FixedRNG(0.0), game, selectedDetector);
 
             Assert.IsTrue(foiled);
-            Assert.AreEqual(17, selectedDetector.Rating);
-            Assert.AreSame(general, selectedDetector.Commander);
+            Assert.AreSame(general, mission.FindDetectorCommander(selectedDetector));
         }
 
         [Test]
@@ -818,6 +817,51 @@ namespace Rebellion.Tests.Sectors
             game.MoveNode(spy, mission);
             mission.AddDecoyParticipant(decoy);
             game.AttachNode(decoy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+
+            List<GameResult> results = system.UpdateMission(mission);
+
+            Assert.IsFalse(results.OfType<MissionCompletedResult>().Any());
+            Assert.AreEqual(1, mission.CurrentProgress);
+        }
+
+        [Test]
+        public void UpdateMission_FriendlyBuildingBlocksFleetDetection()
+        {
+            (GameRoot game, Planet planet, Officer spy, Officer _, MovementSystem movement) =
+                BuildDetectionScene();
+            game.DeleteNode(planet.GetChildren<Regiment>().Single());
+            Fleet fleet = new Fleet { InstanceID = "fleet", OwnerInstanceID = "rebels" };
+            CapitalShip capitalShip = new CapitalShip
+            {
+                InstanceID = "ship",
+                OwnerInstanceID = "rebels",
+                DetectionRating = 100,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            planet.OwnerInstanceID = "empire";
+            planet.EnergyCapacity = 1;
+            Building building = new Building
+            {
+                InstanceID = "detection-blocker",
+                OwnerInstanceID = "empire",
+                IsDetectionBlocker = true,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(capitalShip, fleet);
+            game.AttachNode(building, planet);
+
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            mission.SetExecutionTick(5);
+            SetFoilTable(game, new Dictionary<int, int> { { -1000, 100 } });
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
 
             MissionSystem system = TestSystems.CreateMissionSystem(
                 game,


### PR DESCRIPTION
## Summary

- Restore hostile fleet units as mission detection candidates.
- Let friendly buildings marked `IsDetectionBlocker` suppress fleet-based detection.
- Preserve planetary detector checks and resolve detector commanders from scene ownership.

## Validation

- `dotnet csharpier check` on all changed C# files.
- `dotnet build GameAssembly.csproj` (passes with existing warnings).
- `UpdateMission_FriendlyBuildingBlocksFleetDetection` focused EditMode test.
- `SerializeAndDeserialize_PopulatedBuilding_RetainsProperties` focused EditMode test.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable; no UI builder changes.)
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable; no documentation surface changed.)