### PR TITLE
Fixing cutscene audio playback

### DIFF
--- a/Assets/Scripts/UI/SceneUI/Cutscenes/CutsceneManager.cs
+++ b/Assets/Scripts/UI/SceneUI/Cutscenes/CutsceneManager.cs
@@ -8,8 +8,8 @@ using UnityEngine.Video;
 /// Responsibilities:
 /// - Instantiates and controls a <see cref="CutscenePlayer"/>
 /// - Ensures only one cutscene plays at a time
-/// - Pauses gameplay time during playback
-/// - Restores time and invokes a completion callback when finished
+/// - Pauses gameplay time and application audio during playback
+/// - Restores application state and invokes a completion callback when finished
 /// </summary>
 public sealed class CutsceneManager : MonoBehaviour
 {
@@ -21,7 +21,9 @@ public sealed class CutsceneManager : MonoBehaviour
     private AudioManager audioManager;
 
     private CutscenePlayer activePlayer;
+    private bool ownsAudioPause;
     private bool ownsTimePause;
+    private bool previousAudioPause;
     private float previousTimeScale = _runningTimeScale;
 
     /// <summary>
@@ -54,11 +56,12 @@ public sealed class CutsceneManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Cancels active playback and restores scaled application time on destruction.
+    /// Cancels active playback and restores application state on destruction.
     /// </summary>
     private void OnDestroy()
     {
         DestroyActivePlayer();
+        RestoreApplicationAudio();
         RestoreTimeScale();
     }
 
@@ -128,6 +131,7 @@ public sealed class CutsceneManager : MonoBehaviour
 
         activePlayer = player;
         player.SetVolume(GetVideoVolume());
+        PauseApplicationAudio();
         PauseTimeScale();
         try
         {
@@ -136,6 +140,7 @@ public sealed class CutsceneManager : MonoBehaviour
         catch
         {
             DestroyActivePlayer();
+            RestoreApplicationAudio();
             RestoreTimeScale();
             throw;
         }
@@ -163,6 +168,7 @@ public sealed class CutsceneManager : MonoBehaviour
 
         activePlayer = player;
         player.SetVolume(GetVideoVolume());
+        PauseApplicationAudio();
         PauseTimeScale();
         try
         {
@@ -171,6 +177,7 @@ public sealed class CutsceneManager : MonoBehaviour
         catch
         {
             DestroyActivePlayer();
+            RestoreApplicationAudio();
             RestoreTimeScale();
             throw;
         }
@@ -186,7 +193,7 @@ public sealed class CutsceneManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Restores application time, destroys the active player, and completes the request.
+    /// Restores application state, destroys the active player, and completes the request.
     /// </summary>
     /// <param name="player">The player that completed playback.</param>
     /// <param name="onFinished">The callback supplied with the playback request.</param>
@@ -195,10 +202,35 @@ public sealed class CutsceneManager : MonoBehaviour
         if (activePlayer != player)
             return;
 
-        RestoreTimeScale();
         DestroyActivePlayer();
+        RestoreApplicationAudio();
+        RestoreTimeScale();
 
         onFinished?.Invoke();
+    }
+
+    /// <summary>
+    /// Pauses application audio while allowing the cutscene player to remain audible.
+    /// </summary>
+    private void PauseApplicationAudio()
+    {
+        if (!ownsAudioPause)
+            previousAudioPause = AudioListener.pause;
+
+        AudioListener.pause = true;
+        ownsAudioPause = true;
+    }
+
+    /// <summary>
+    /// Restores the audio-listener state that preceded cutscene playback.
+    /// </summary>
+    private void RestoreApplicationAudio()
+    {
+        if (!ownsAudioPause)
+            return;
+
+        AudioListener.pause = previousAudioPause;
+        ownsAudioPause = false;
     }
 
     /// <summary>
@@ -247,6 +279,7 @@ public sealed class CutsceneManager : MonoBehaviour
     private void CancelPlayback()
     {
         DestroyActivePlayer();
+        RestoreApplicationAudio();
         RestoreTimeScale();
     }
 }

--- a/Assets/Scripts/UI/SceneUI/Cutscenes/CutsceneManager.cs
+++ b/Assets/Scripts/UI/SceneUI/Cutscenes/CutsceneManager.cs
@@ -21,7 +21,7 @@ public sealed class CutsceneManager : MonoBehaviour
     private AudioManager audioManager;
 
     private CutscenePlayer activePlayer;
-    private bool ownsAudioPause;
+    private bool _audioPauseApplied;
     private bool ownsTimePause;
     private bool previousAudioPause;
     private float previousTimeScale = _runningTimeScale;
@@ -214,11 +214,11 @@ public sealed class CutsceneManager : MonoBehaviour
     /// </summary>
     private void PauseApplicationAudio()
     {
-        if (!ownsAudioPause)
+        if (!_audioPauseApplied)
             previousAudioPause = AudioListener.pause;
 
         AudioListener.pause = true;
-        ownsAudioPause = true;
+        _audioPauseApplied = true;
     }
 
     /// <summary>
@@ -226,11 +226,11 @@ public sealed class CutsceneManager : MonoBehaviour
     /// </summary>
     private void RestoreApplicationAudio()
     {
-        if (!ownsAudioPause)
+        if (!_audioPauseApplied)
             return;
 
         AudioListener.pause = previousAudioPause;
-        ownsAudioPause = false;
+        _audioPauseApplied = false;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/Cutscenes/CutscenePlayer.cs
+++ b/Assets/Scripts/UI/SceneUI/Cutscenes/CutscenePlayer.cs
@@ -43,6 +43,7 @@ public sealed class CutscenePlayer : MonoBehaviour
         videoPlayer.isLooping = false;
         videoPlayer.errorReceived += HandlePlaybackError;
         audioSource.playOnAwake = false;
+        audioSource.ignoreListenerPause = true;
         authoredScreenColor = screen.color;
         BlankScreen();
     }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/Cutscenes/CutsceneManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/Cutscenes/CutsceneManagerTests.cs
@@ -19,10 +19,13 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
         private GameObject _managerObject;
         private GameObject _playerPrefab;
         private AudioManager _audioManager;
+        private bool _previousAudioPause;
 
         [SetUp]
         public void SetUp()
         {
+            _previousAudioPause = AudioListener.pause;
+            AudioListener.pause = false;
             _playerPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(_prefabPath);
             _managerObject = new GameObject("CutsceneManager");
             _manager = _managerObject.AddComponent<CutsceneManager>();
@@ -49,6 +52,7 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
             }
 
             Time.timeScale = 1f;
+            AudioListener.pause = _previousAudioPause;
         }
 
         [Test]
@@ -62,7 +66,7 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
         }
 
         [Test]
-        public void Play_NullClip_InvokesCompletionWithoutChangingTimeScale()
+        public void Play_NullClip_InvokesCompletionWithoutChangingApplicationState()
         {
             int completedCount = 0;
             Time.timeScale = 0.75f;
@@ -71,16 +75,18 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
 
             Assert.AreEqual(1, completedCount);
             Assert.AreEqual(0.75f, Time.timeScale);
+            Assert.IsFalse(AudioListener.pause);
         }
 
         [Test]
-        public void Play_ValidClip_PausesTimeAndCreatesPlayer()
+        public void Play_ValidClip_PausesApplicationAndCreatesPlayer()
         {
             _manager.Play(_clip, null);
             CutscenePlayer player = GetField<CutscenePlayer>("activePlayer");
 
             Assert.IsNotNull(player);
             Assert.AreEqual(0f, Time.timeScale);
+            Assert.IsTrue(AudioListener.pause);
             Assert.AreSame(_clip, player.GetComponent<VideoPlayer>().clip);
         }
 
@@ -117,7 +123,21 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
         }
 
         [Test]
-        public void OnDestroy_ActivePlayback_RestoresPreviousTimeScale()
+        public void Play_ReplacementClip_PreservesInitialAudioPauseForRestoration()
+        {
+            AudioListener.pause = true;
+            _manager.Play(_clip, null);
+            _manager.Play(_clip, null);
+
+            UIComponentTestHelper.InvokeLifecycle(_manager, "OnDestroy");
+            UnityEngine.Object.DestroyImmediate(_manager.gameObject);
+            _manager = null;
+
+            Assert.IsTrue(AudioListener.pause);
+        }
+
+        [Test]
+        public void OnDestroy_ActivePlayback_RestoresPreviousApplicationState()
         {
             Time.timeScale = 0.75f;
             _manager.Play(_clip, null);
@@ -127,6 +147,7 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
             _manager = null;
 
             Assert.AreEqual(0.75f, Time.timeScale);
+            Assert.IsFalse(AudioListener.pause);
         }
 
         private T GetField<T>(string fieldName)

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/Cutscenes/CutscenePlayerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/Cutscenes/CutscenePlayerTests.cs
@@ -59,6 +59,7 @@ namespace Rebellion.Tests.UI.SceneUI.Cutscenes
             Assert.IsFalse(_videoPlayer.isLooping);
             Assert.IsFalse(_videoPlayer.sendFrameReadyEvents);
             Assert.IsFalse(_audioSource.playOnAwake);
+            Assert.IsTrue(_audioSource.ignoreListenerPause);
             Assert.AreEqual(Color.black, _screen.color);
             Assert.IsTrue(_screen.raycastTarget);
             Assert.AreEqual(VideoRenderMode.APIOnly, _videoPlayer.renderMode);


### PR DESCRIPTION
## Summary

- Pauses application music, ambience, and sound effects while a cutscene plays.
- Keeps the cutscene audio audible while the application listener is paused.
- Restores the previous audio and time state after completion, cancellation, replacement, or failure.

## Validation

- `dotnet build GameAssembly.csproj --no-restore --verbosity:minimal`
- Unity EditMode tests: `Rebellion.Tests.UI.SceneUI.Cutscenes` (15 passed)
- UI builder: not applicable; no generated UI changed.
- Media integration: not applicable; no content paths or assets changed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable; this corrects runtime behavior.)