### PR TITLE
Fixing issue where damaged ships could not perform bombardments; units captured by own faction.

### DIFF
--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -763,15 +763,13 @@ namespace Rebellion.Game.Missions
         /// Returns whether a scene object may attempt to detect this mission.
         /// </summary>
         /// <param name="candidate">The potential hostile detector.</param>
-        /// <param name="game">The active game state, used to confirm the owner is a belligerent faction.</param>
         /// <returns>True for a completed, stationary hostile unit with a detection rating.</returns>
-        internal bool IsEligibleDetector(ISceneNode candidate, GameRoot game)
+        internal bool IsEligibleDetector(ISceneNode candidate)
         {
             string candidateOwnerId = candidate?.GetOwnerInstanceID();
             if (
                 string.IsNullOrEmpty(candidateOwnerId)
                 || candidateOwnerId == OwnerInstanceID
-                || !game.GetFactions().Any(faction => faction.InstanceID == candidateOwnerId)
                 || candidate
                     is not IManufacturable { ManufacturingStatus: ManufacturingStatus.Complete }
                 || candidate is IMovable movable && movable.GetTransitMovement() != null

--- a/Assets/Scripts/Game/Missions/Mission.cs
+++ b/Assets/Scripts/Game/Missions/Mission.cs
@@ -763,13 +763,15 @@ namespace Rebellion.Game.Missions
         /// Returns whether a scene object may attempt to detect this mission.
         /// </summary>
         /// <param name="candidate">The potential hostile detector.</param>
+        /// <param name="game">The active game state, used to confirm the owner is a belligerent faction.</param>
         /// <returns>True for a completed, stationary hostile unit with a detection rating.</returns>
-        internal bool IsEligibleDetector(ISceneNode candidate)
+        internal bool IsEligibleDetector(ISceneNode candidate, GameRoot game)
         {
             string candidateOwnerId = candidate?.GetOwnerInstanceID();
             if (
                 string.IsNullOrEmpty(candidateOwnerId)
                 || candidateOwnerId == OwnerInstanceID
+                || !game.GetFactions().Any(faction => faction.InstanceID == candidateOwnerId)
                 || candidate
                     is not IManufacturable { ManufacturingStatus: ManufacturingStatus.Complete }
                 || candidate is IMovable movable && movable.GetTransitMovement() != null

--- a/Assets/Scripts/Systems/BombardmentSystem.cs
+++ b/Assets/Scripts/Systems/BombardmentSystem.cs
@@ -1270,7 +1270,13 @@ namespace Rebellion.Systems
         /// <returns>The condition-adjusted value.</returns>
         private static int ScaleByCondition(int value, int current, int maximum)
         {
-            return maximum > 0 ? value * Math.Max(0, current) / maximum : value;
+            // Original REBEXE scales by hull as value - floor(value * damage / maximum), flooring
+            // the loss rather than the result, so a 1-strength ship keeps its point until destroyed.
+            if (maximum <= 0)
+                return value;
+
+            int damage = maximum - Math.Min(maximum, Math.Max(0, current));
+            return value - value * damage / maximum;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/BombardmentSystem.cs
+++ b/Assets/Scripts/Systems/BombardmentSystem.cs
@@ -1270,8 +1270,6 @@ namespace Rebellion.Systems
         /// <returns>The condition-adjusted value.</returns>
         private static int ScaleByCondition(int value, int current, int maximum)
         {
-            // Original REBEXE scales by hull as value - floor(value * damage / maximum), flooring
-            // the loss rather than the result, so a 1-strength ship keeps its point until destroyed.
             if (maximum <= 0)
                 return value;
 

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -914,7 +914,7 @@ namespace Rebellion.Systems
         /// <param name="mission">The mission being checked for detection.</param>
         /// <param name="planet">The planet where the mission is operating.</param>
         /// <returns>The ordered detector units.</returns>
-        private List<ISceneNode> GetDetectors(Mission mission, Planet planet)
+        private static List<ISceneNode> GetDetectors(Mission mission, Planet planet)
         {
             List<ISceneNode> detectors = new List<ISceneNode>();
             AddEligibleDetectors(mission, planet.GetChildren<Starfighter>(), detectors);
@@ -935,7 +935,7 @@ namespace Rebellion.Systems
             {
                 foreach (CapitalShip capitalShip in fleet.GetChildren<CapitalShip>())
                 {
-                    if (mission.IsEligibleDetector(capitalShip, _game))
+                    if (mission.IsEligibleDetector(capitalShip))
                         detectors.Add(capitalShip);
 
                     AddEligibleDetectors(
@@ -956,7 +956,7 @@ namespace Rebellion.Systems
         /// <param name="mission">The mission being checked for detection.</param>
         /// <param name="candidates">The candidate detector units.</param>
         /// <param name="detectors">The collection receiving eligible detectors.</param>
-        private void AddEligibleDetectors(
+        private static void AddEligibleDetectors(
             Mission mission,
             IEnumerable<ISceneNode> candidates,
             ICollection<ISceneNode> detectors
@@ -964,7 +964,7 @@ namespace Rebellion.Systems
         {
             foreach (ISceneNode candidate in candidates)
             {
-                if (mission.IsEligibleDetector(candidate, _game))
+                if (mission.IsEligibleDetector(candidate))
                     detectors.Add(candidate);
             }
         }

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -619,7 +619,12 @@ namespace Rebellion.Systems
                 if (unit is Officer officer)
                 {
                     if (!officer.IsCaptured)
-                        CaptureOfficer(officer, missionPlanet, results);
+                        CaptureOfficer(
+                            officer,
+                            missionPlanet?.GetOwnerInstanceID(),
+                            missionPlanet,
+                            results
+                        );
 
                     if (missionPlanet != null)
                         _movementManager.RequestMove(officer, missionPlanet);
@@ -900,7 +905,7 @@ namespace Rebellion.Systems
                 return;
             }
 
-            CaptureOfficer(officer, planet, results);
+            CaptureOfficer(officer, detector.GetOwnerInstanceID(), planet, results);
         }
 
         /// <summary>
@@ -1005,12 +1010,18 @@ namespace Rebellion.Systems
         /// Marks an officer captured at a planet and records the capture state change.
         /// </summary>
         /// <param name="officer">The officer being captured.</param>
+        /// <param name="captorInstanceId">The faction taking the officer captive.</param>
         /// <param name="planet">The planet where the capture occurred.</param>
         /// <param name="results">Collection to append the capture result to.</param>
-        private void CaptureOfficer(Officer officer, Planet planet, List<GameResult> results)
+        private void CaptureOfficer(
+            Officer officer,
+            string captorInstanceId,
+            Planet planet,
+            List<GameResult> results
+        )
         {
             officer.IsCaptured = true;
-            officer.CaptorInstanceID = planet?.OwnerInstanceID;
+            officer.CaptorInstanceID = captorInstanceId;
             officer.CanEscape = true;
             results.Add(
                 new OfficerCaptureStateResult

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -914,7 +914,7 @@ namespace Rebellion.Systems
         /// <param name="mission">The mission being checked for detection.</param>
         /// <param name="planet">The planet where the mission is operating.</param>
         /// <returns>The ordered detector units.</returns>
-        private static List<ISceneNode> GetDetectors(Mission mission, Planet planet)
+        private List<ISceneNode> GetDetectors(Mission mission, Planet planet)
         {
             List<ISceneNode> detectors = new List<ISceneNode>();
             AddEligibleDetectors(mission, planet.GetChildren<Starfighter>(), detectors);
@@ -935,7 +935,7 @@ namespace Rebellion.Systems
             {
                 foreach (CapitalShip capitalShip in fleet.GetChildren<CapitalShip>())
                 {
-                    if (mission.IsEligibleDetector(capitalShip))
+                    if (mission.IsEligibleDetector(capitalShip, _game))
                         detectors.Add(capitalShip);
 
                     AddEligibleDetectors(
@@ -956,7 +956,7 @@ namespace Rebellion.Systems
         /// <param name="mission">The mission being checked for detection.</param>
         /// <param name="candidates">The candidate detector units.</param>
         /// <param name="detectors">The collection receiving eligible detectors.</param>
-        private static void AddEligibleDetectors(
+        private void AddEligibleDetectors(
             Mission mission,
             IEnumerable<ISceneNode> candidates,
             ICollection<ISceneNode> detectors
@@ -964,7 +964,7 @@ namespace Rebellion.Systems
         {
             foreach (ISceneNode candidate in candidates)
             {
-                if (mission.IsEligibleDetector(candidate))
+                if (mission.IsEligibleDetector(candidate, _game))
                     detectors.Add(candidate);
             }
         }

--- a/Assets/Tests/EditMode/GameTests/Systems/BombardmentSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/BombardmentSystemTests.cs
@@ -28,6 +28,25 @@ namespace Rebellion.Tests.Systems
             Assert.IsTrue(canExecute);
         }
 
+        [Test]
+        public void CanExecute_DamagedLowBombardmentShip_ReturnsTrue()
+        {
+            GameRoot game = CreateGame();
+            (Planet planet, _) = CreatePlanet(game, "p1", "empire", energy: 10);
+            Fleet fleet = AddBombardmentFleet(
+                game,
+                planet,
+                "alliance",
+                bombardment: 1,
+                currentHull: 53
+            );
+
+            bool canExecute = MakeBombardment(game, new SequenceRNG())
+                .CanExecute(new List<Fleet> { fleet }, planet, BombardmentType.General);
+
+            Assert.IsTrue(canExecute);
+        }
+
         [TestCase(BombardmentType.Military)]
         [TestCase(BombardmentType.Civilian)]
         [TestCase(BombardmentType.General)]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -1222,36 +1222,6 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_NeutralOwnedDetector_DoesNotFoilMission()
-        {
-            (GameRoot game, Planet planet, Officer spy, MovementSystem movement) =
-                BuildOwnPlanetDetectionScene(detectorOwnerId: "neutral");
-
-            StubMission mission = new StubMission("empire", planet.InstanceID);
-            SetFoilTable(game, new Dictionary<int, int> { { 0, 100 } });
-            SetEvasionTable(game, new Dictionary<int, int> { { -200, 0 } });
-            DisableCaptureEvasionInjury(game);
-            game.AttachNode(mission, planet);
-            game.MoveNode(spy, mission);
-
-            MissionSystem system = TestSystems.CreateMissionSystem(
-                game,
-                new FixedRNG(0.01),
-                movement
-            );
-
-            List<GameResult> results = system.UpdateMission(mission);
-
-            Assert.IsFalse(spy.IsCaptured, "A non-belligerent unit should not detect the mission");
-            Assert.IsFalse(
-                results
-                    .OfType<MissionCompletedResult>()
-                    .Any(r => r.Outcome == MissionOutcome.Foiled),
-                "Mission should not be foiled by a neutral-owned unit"
-            );
-        }
-
-        [Test]
         public void UpdateMission_EspionageDetected_AppliesFoiledParticipantConsequences()
         {
             (GameRoot game, Planet planet, Officer spy, Officer defender, MovementSystem movement) =
@@ -3617,7 +3587,7 @@ namespace Rebellion.Tests.Sectors
             Planet planet,
             Officer spy,
             MovementSystem movement
-        ) BuildOwnPlanetDetectionScene(string detectorOwnerId = "rebels")
+        ) BuildOwnPlanetDetectionScene()
         {
             GameConfig config = new GameConfig();
             GameRoot game = new GameRoot(config);
@@ -3650,13 +3620,13 @@ namespace Rebellion.Tests.Sectors
 
             // A hostile unit over one of your own planets rides in an orbiting fleet;
             // a colonized planet only accepts owner-owned regiments/starfighters directly.
-            Fleet fleet = new Fleet { InstanceID = "f1", OwnerInstanceID = detectorOwnerId };
+            Fleet fleet = new Fleet { InstanceID = "f1", OwnerInstanceID = "rebels" };
             game.AttachNode(fleet, planet);
 
             CapitalShip detectorShip = new CapitalShip
             {
                 InstanceID = "cs1",
-                OwnerInstanceID = detectorOwnerId,
+                OwnerInstanceID = "rebels",
                 DetectionRating = 100,
                 ManufacturingStatus = ManufacturingStatus.Complete,
             };

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -1222,6 +1222,36 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void UpdateMission_NeutralOwnedDetector_DoesNotFoilMission()
+        {
+            (GameRoot game, Planet planet, Officer spy, MovementSystem movement) =
+                BuildOwnPlanetDetectionScene(detectorOwnerId: "neutral");
+
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            SetFoilTable(game, new Dictionary<int, int> { { 0, 100 } });
+            SetEvasionTable(game, new Dictionary<int, int> { { -200, 0 } });
+            DisableCaptureEvasionInjury(game);
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+
+            List<GameResult> results = system.UpdateMission(mission);
+
+            Assert.IsFalse(spy.IsCaptured, "A non-belligerent unit should not detect the mission");
+            Assert.IsFalse(
+                results
+                    .OfType<MissionCompletedResult>()
+                    .Any(r => r.Outcome == MissionOutcome.Foiled),
+                "Mission should not be foiled by a neutral-owned unit"
+            );
+        }
+
+        [Test]
         public void UpdateMission_EspionageDetected_AppliesFoiledParticipantConsequences()
         {
             (GameRoot game, Planet planet, Officer spy, Officer defender, MovementSystem movement) =
@@ -3587,7 +3617,7 @@ namespace Rebellion.Tests.Sectors
             Planet planet,
             Officer spy,
             MovementSystem movement
-        ) BuildOwnPlanetDetectionScene()
+        ) BuildOwnPlanetDetectionScene(string detectorOwnerId = "rebels")
         {
             GameConfig config = new GameConfig();
             GameRoot game = new GameRoot(config);
@@ -3618,14 +3648,19 @@ namespace Rebellion.Tests.Sectors
             spy.MissionReturnLocationInstanceID = planet.InstanceID;
             game.AttachNode(spy, planet);
 
-            Regiment regiment = new Regiment
+            // A hostile unit over one of your own planets rides in an orbiting fleet;
+            // a colonized planet only accepts owner-owned regiments/starfighters directly.
+            Fleet fleet = new Fleet { InstanceID = "f1", OwnerInstanceID = detectorOwnerId };
+            game.AttachNode(fleet, planet);
+
+            CapitalShip detectorShip = new CapitalShip
             {
-                InstanceID = "r1",
-                OwnerInstanceID = "rebels",
+                InstanceID = "cs1",
+                OwnerInstanceID = detectorOwnerId,
                 DetectionRating = 100,
                 ManufacturingStatus = ManufacturingStatus.Complete,
             };
-            game.AttachNode(regiment, planet);
+            game.AttachNode(detectorShip, fleet);
 
             MovementSystem movement = new MovementSystem(
                 game,

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -1193,6 +1193,35 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void UpdateMission_EvasionFailsToHostileDetectorOnOwnPlanet_CaptorIsDetectorOwner()
+        {
+            (GameRoot game, Planet planet, Officer spy, MovementSystem movement) =
+                BuildOwnPlanetDetectionScene();
+
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            SetFoilTable(game, new Dictionary<int, int> { { 0, 100 } });
+            SetEvasionTable(game, new Dictionary<int, int> { { -200, 0 } });
+            DisableCaptureEvasionInjury(game);
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+
+            List<GameResult> results = system.UpdateMission(mission);
+
+            Assert.IsTrue(spy.IsCaptured);
+            Assert.AreEqual(
+                "rebels",
+                spy.CaptorInstanceID,
+                "Captor should be the hostile detector's faction, not the planet owner"
+            );
+        }
+
+        [Test]
         public void UpdateMission_EspionageDetected_AppliesFoiledParticipantConsequences()
         {
             (GameRoot game, Planet planet, Officer spy, Officer defender, MovementSystem movement) =
@@ -3551,6 +3580,59 @@ namespace Rebellion.Tests.Sectors
                 MainParticipants = mainParticipants,
                 DecoyParticipants = decoyParticipants,
             };
+        }
+
+        private (
+            GameRoot game,
+            Planet planet,
+            Officer spy,
+            MovementSystem movement
+        ) BuildOwnPlanetDetectionScene()
+        {
+            GameConfig config = new GameConfig();
+            GameRoot game = new GameRoot(config);
+            game.GetFactions().Add(new Faction { InstanceID = "empire" });
+            game.GetFactions().Add(new Faction { InstanceID = "rebels" });
+
+            PlanetSector sector = new PlanetSector
+            {
+                InstanceID = "sector1",
+                PositionX = 0,
+                PositionY = 0,
+            };
+            game.AttachNode(sector, game.Galaxy);
+
+            Planet planet = new Planet
+            {
+                InstanceID = "p1",
+                OwnerInstanceID = "empire",
+                IsColonized = true,
+                PositionX = 0,
+                PositionY = 0,
+                PopularSupport = new Dictionary<string, int> { { "empire", 50 } },
+            };
+            game.AttachNode(planet, sector);
+
+            Officer spy = EntityFactory.CreateOfficer("spy", "empire");
+            spy.MissionReturnParentInstanceID = planet.InstanceID;
+            spy.MissionReturnLocationInstanceID = planet.InstanceID;
+            game.AttachNode(spy, planet);
+
+            Regiment regiment = new Regiment
+            {
+                InstanceID = "r1",
+                OwnerInstanceID = "rebels",
+                DetectionRating = 100,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(regiment, planet);
+
+            MovementSystem movement = new MovementSystem(
+                game,
+                new FogOfWarSystem(game),
+                new FleetSystem(game)
+            );
+            return (game, planet, spy, movement);
         }
 
         private (


### PR DESCRIPTION
## Summary

`ScaleByCondition` floored the *scaled result* (`value * current / maximum`), which zeroed any ship with `Bombardment = 1` the moment it took hull damage (`1 * 534/1000 = 0`). A fleet of damaged Carrack Light Cruisers (Bombardment 1) therefore couldn't bombard at all.

The original REBEXE scales by hull as `value - floor(value * damage / maximum)` — it floors the *loss*, so a low-strength ship keeps its point until it's actually destroyed. Matched that.

Found from a save: 4 Carrack Light Cruisers at ~53–69% hull sitting on an Alliance planet, unable to bombard. Under the original formula each still contributes 1.

## Validation

`BombardmentSystemTests` pass locally in Unity EditMode (33/33), including a new regression (`CanExecute_DamagedLowBombardmentShip_ReturnsTrue`) and the existing damaged-ship test (unaffected — its 50/100 and 5/10 fractions round identically under both formulas). csharpier clean.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.