### PR TITLE
Fixing issue where captured units did not always return with captor.

### DIFF
--- a/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
+++ b/Assets/Scripts/Game/FogOfWar/FogOfWarRecorder.cs
@@ -56,6 +56,10 @@ namespace Rebellion.Game.FogOfWar
         /// <summary>
         /// Records current information about explicitly selected scene objects.
         /// </summary>
+        /// <param name="game">The authoritative game state.</param>
+        /// <param name="faction">The faction receiving the observations.</param>
+        /// <param name="observations">The scene objects to record.</param>
+        /// <param name="currentTick">The tick when the objects were observed.</param>
         public void RecordSelectedObservations(
             GameRoot game,
             Faction faction,
@@ -454,7 +458,9 @@ namespace Rebellion.Game.FogOfWar
             snapshot.Officers.AddRange(
                 planet
                     .GetChildren<Officer>(recursive: true)
-                    .Where(officer => officer.OwnerInstanceID != faction.InstanceID)
+                    .Where(officer =>
+                        officer.OwnerInstanceID != faction.InstanceID || officer.IsCaptured
+                    )
                     .Select(CopyOfficerForSnapshot)
             );
         }
@@ -951,7 +957,7 @@ namespace Rebellion.Game.FogOfWar
         {
             foreach (Officer officer in planet.GetChildren<Officer>())
             {
-                if (officer.OwnerInstanceID == faction.InstanceID)
+                if (officer.OwnerInstanceID == faction.InstanceID && !officer.IsCaptured)
                 {
                     RemoveEntityFromSnapshotState(faction, officer.InstanceID);
                     continue;

--- a/Assets/Scripts/Game/Missions/AbductionMission.cs
+++ b/Assets/Scripts/Game/Missions/AbductionMission.cs
@@ -230,6 +230,7 @@ namespace Rebellion.Game.Missions
                 {
                     TargetOfficer = target,
                     IsCaptured = true,
+                    CapturingUnit = successfulParticipant,
                     Context = GetParent() as Planet,
                     Tick = game.CurrentTick,
                 }

--- a/Assets/Scripts/Game/Results/GameResults.cs
+++ b/Assets/Scripts/Game/Results/GameResults.cs
@@ -308,6 +308,7 @@ namespace Rebellion.Game.Results
     {
         public Officer TargetOfficer { get; set; }
         public bool IsCaptured { get; set; }
+        public ISceneNode CapturingUnit { get; set; }
         public Officer CapturedOfficer { get; set; }
         public Officer LinkedOfficer { get; set; }
         public IGameEntity Context { get; set; }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -47,6 +47,7 @@ public sealed class GameManager
     private HeadquartersSystem _headquartersSystem;
     private NamingSystem _namingSystem;
     private RecoverySystem _recoverySystem;
+    private CaptiveSystem _captiveSystem;
 
     // Economy Systems.
     private ManufacturingSystem _manufacturingSystem;
@@ -329,6 +330,7 @@ public sealed class GameManager
         ProcessResults(_manufacturingSystem.ProcessTick());
         ProcessResults(_maintenanceSystem.ProcessTick());
         ProcessResults(_recoverySystem.ProcessTick());
+        ProcessResults(_captiveSystem.ProcessTick());
 
         List<GameResult> movementResults = ProcessResults(
             _movementSystem.ProcessTick(),
@@ -458,6 +460,7 @@ public sealed class GameManager
         _manufacturingSystem = new ManufacturingSystem(_game, _fleetSystem, _movementSystem);
         _namingSystem = new NamingSystem(_game);
         _recoverySystem = new RecoverySystem(_game);
+        _captiveSystem = new CaptiveSystem(_game, _randomProvider, _movementSystem);
         _factionAutomationSystem = new FactionAutomationSystem(
             _game,
             _gameData,

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -460,7 +460,12 @@ public sealed class GameManager
         _manufacturingSystem = new ManufacturingSystem(_game, _fleetSystem, _movementSystem);
         _namingSystem = new NamingSystem(_game);
         _recoverySystem = new RecoverySystem(_game);
-        _captiveSystem = new CaptiveSystem(_game, _randomProvider, _movementSystem);
+        _captiveSystem = new CaptiveSystem(
+            _game,
+            _randomProvider,
+            _movementSystem,
+            _fogOfWarSystem
+        );
         _factionAutomationSystem = new FactionAutomationSystem(
             _game,
             _gameData,
@@ -538,6 +543,7 @@ public sealed class GameManager
         _resultProcessor.Subscribe<PlanetGarrisonChangedResult>(_uprisingSystem);
         _resultProcessor.Subscribe<MissionCompletedResult>(_jediSystem);
         _resultProcessor.Subscribe<OfficerCaptureStateResult>(_missionSystem);
+        _resultProcessor.Subscribe<OfficerCaptureStateResult>(_captiveSystem);
         _resultProcessor.Subscribe<IntelligenceRevealedResult>(_fogOfWarSystem);
         _resultProcessor.Observe<GameObjectSabotagedResult>(_fogOfWarSystem.ProcessResults);
 

--- a/Assets/Scripts/Systems/CaptiveSystem.cs
+++ b/Assets/Scripts/Systems/CaptiveSystem.cs
@@ -16,13 +16,14 @@ namespace Rebellion.Systems
     /// <summary>
     /// Processes escape attempts for captured officers each tick.
     /// Escape probability is based on the officer's skills and the forces guarding
-    /// the planet or fleet where the officer is held.
+    /// the planet, fleet, or ship where the officer is held.
     /// </summary>
-    public class CaptiveSystem
+    public class CaptiveSystem : IGameResultHandler<OfficerCaptureStateResult>
     {
         private readonly GameRoot _game;
         private readonly IRandomNumberProvider _provider;
-        private readonly MovementSystem _movementManager;
+        private readonly MovementSystem _movementSystem;
+        private readonly FogOfWarSystem _fogOfWarSystem;
         private readonly ProbabilityTable _escapeTable;
         private readonly int _loyaltyShift;
 
@@ -31,18 +32,74 @@ namespace Rebellion.Systems
         /// </summary>
         /// <param name="game">The active game state.</param>
         /// <param name="provider">RNG provider for escape rolls.</param>
-        /// <param name="movementManager">Used to move escaped officers to friendly planets.</param>
+        /// <param name="movementSystem">Moves officers into and out of custody.</param>
+        /// <param name="fogOfWarSystem">Records the custody destination known at capture time.</param>
         public CaptiveSystem(
             GameRoot game,
             IRandomNumberProvider provider,
-            MovementSystem movementManager
+            MovementSystem movementSystem,
+            FogOfWarSystem fogOfWarSystem
         )
         {
-            _game = game;
-            _provider = provider;
-            _movementManager = movementManager;
+            _game = game ?? throw new ArgumentNullException(nameof(game));
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            _movementSystem =
+                movementSystem ?? throw new ArgumentNullException(nameof(movementSystem));
+            _fogOfWarSystem =
+                fogOfWarSystem ?? throw new ArgumentNullException(nameof(fogOfWarSystem));
             _escapeTable = new ProbabilityTable(game.Config.Captive.EscapeTable);
             _loyaltyShift = game.Config.Captive.EscapeLoyaltyShift;
+        }
+
+        /// <summary>
+        /// Establishes custody for newly captured officers and records the location revealed to
+        /// their original factions.
+        /// </summary>
+        /// <param name="results">The capture-state changes to process.</param>
+        /// <returns>Movement results produced while transferring captives.</returns>
+        public List<GameResult> HandleResults(IReadOnlyList<OfficerCaptureStateResult> results)
+        {
+            List<GameResult> reactions = new List<GameResult>();
+            if (results == null)
+                return reactions;
+
+            HashSet<string> handledOfficerIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (OfficerCaptureStateResult result in results)
+            {
+                Officer officer = result?.TargetOfficer;
+                if (
+                    result?.IsCaptured != true
+                    || officer?.IsCaptured != true
+                    || string.IsNullOrEmpty(officer.CaptorInstanceID)
+                    || !handledOfficerIds.Add(officer.InstanceID)
+                )
+                    continue;
+
+                ContainerNode destination = ResolveCustodyDestination(result, officer);
+                if (
+                    destination == null
+                    || !_movementSystem.TryEstablishCapturedOfficerCustody(
+                        officer,
+                        destination,
+                        GetCustodyEscort(result.CapturingUnit),
+                        reactions
+                    )
+                )
+                {
+                    GameLogger.Log(
+                        $"Captured officer {officer.GetDisplayName()} has no valid custody destination for {officer.CaptorInstanceID}.",
+                        GameLogger.LogLevel.Error
+                    );
+                    continue;
+                }
+
+                Faction originalFaction = _game.GetFactionByOwnerInstanceID(
+                    officer.OwnerInstanceID
+                );
+                _fogOfWarSystem.RecordObservations(originalFaction, new[] { officer }, result.Tick);
+            }
+
+            return reactions;
         }
 
         /// <summary>
@@ -72,6 +129,147 @@ namespace Rebellion.Systems
             }
 
             return results;
+        }
+
+        /// <summary>
+        /// Resolves an established custody container, the capturing unit's container, or a
+        /// captor-controlled fallback planet.
+        /// </summary>
+        /// <param name="result">The capture result that identifies the capturing unit and location.</param>
+        /// <param name="officer">The captured officer requiring custody.</param>
+        /// <returns>The selected custody container, or null when none can hold the officer.</returns>
+        private ContainerNode ResolveCustodyDestination(
+            OfficerCaptureStateResult result,
+            Officer officer
+        )
+        {
+            string captorInstanceId = officer.CaptorInstanceID;
+            ContainerNode establishedCustody = GetCaptorControlledContainer(
+                officer.GetParent() as ContainerNode,
+                captorInstanceId
+            );
+            if (establishedCustody != null)
+                return establishedCustody;
+
+            Planet capturePlanet = GetResultPlanet(result);
+            if (IsControlledBy(capturePlanet, captorInstanceId))
+                return capturePlanet;
+
+            ContainerNode capturingUnitCustody = GetCapturingUnitCustody(
+                result.CapturingUnit,
+                captorInstanceId
+            );
+            if (capturingUnitCustody != null)
+                return capturingUnitCustody;
+
+            Faction captor = _game.GetFactionByOwnerInstanceID(captorInstanceId);
+            return captor
+                ?.GetOwnedColonizedPlanets()
+                .Where(planet =>
+                    !planet.IsDestroyed
+                    && string.Equals(
+                        planet.GetOwnerInstanceID(),
+                        captorInstanceId,
+                        StringComparison.Ordinal
+                    )
+                    && planet.CanAcceptChild(officer)
+                )
+                .OrderBy(planet => planet.GetRawDistanceTo(officer.GetPosition()))
+                .ThenBy(planet => planet.InstanceID, StringComparer.Ordinal)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Returns the planet where a capture occurred.
+        /// </summary>
+        /// <param name="result">The capture result to inspect.</param>
+        /// <returns>The capture planet, or null when the result has no planetary context.</returns>
+        private static Planet GetResultPlanet(OfficerCaptureStateResult result)
+        {
+            return result?.Context as Planet
+                ?? (result?.Context as ISceneNode)?.GetParentOfType<Planet>();
+        }
+
+        /// <summary>
+        /// Returns the captor-controlled ship or planet currently containing a capturing unit.
+        /// </summary>
+        /// <param name="capturingUnit">The unit responsible for the capture.</param>
+        /// <param name="captorInstanceId">The capturing faction identifier.</param>
+        /// <returns>The capturing unit's custody container, or null when it has none.</returns>
+        private static ContainerNode GetCapturingUnitCustody(
+            ISceneNode capturingUnit,
+            string captorInstanceId
+        )
+        {
+            if (capturingUnit == null)
+                return null;
+
+            CapitalShip ship =
+                capturingUnit as CapitalShip ?? capturingUnit.GetParentOfType<CapitalShip>();
+            if (IsControlledBy(ship, captorInstanceId))
+                return ship;
+
+            return GetCaptorControlledContainer(
+                capturingUnit.GetParent() as ContainerNode,
+                captorInstanceId
+            );
+        }
+
+        /// <summary>
+        /// Returns a capturing officer or special-forces unit that can escort the captive.
+        /// </summary>
+        /// <param name="capturingUnit">The unit responsible for the capture.</param>
+        /// <returns>The movable escort, or null when the capture has no physical escort.</returns>
+        private static IMovable GetCustodyEscort(ISceneNode capturingUnit)
+        {
+            return capturingUnit switch
+            {
+                Officer officer => officer,
+                SpecialForces specialForces => specialForces,
+                _ => null,
+            };
+        }
+
+        /// <summary>
+        /// Returns a ship or planet when the supplied container belongs to the capturing faction.
+        /// </summary>
+        /// <param name="container">The possible custody container.</param>
+        /// <param name="captorInstanceId">The capturing faction identifier.</param>
+        /// <returns>The controlled custody container, or null when ownership does not match.</returns>
+        private static ContainerNode GetCaptorControlledContainer(
+            ContainerNode container,
+            string captorInstanceId
+        )
+        {
+            return container is Planet or CapitalShip && IsControlledBy(container, captorInstanceId)
+                ? container
+                : null;
+        }
+
+        /// <summary>
+        /// Returns whether a scene node belongs to the capturing faction and remains usable.
+        /// </summary>
+        /// <param name="node">The node to inspect.</param>
+        /// <param name="captorInstanceId">The capturing faction identifier.</param>
+        /// <returns>True when the node is a valid captor-controlled custody location.</returns>
+        private static bool IsControlledBy(ISceneNode node, string captorInstanceId)
+        {
+            if (node == null || string.IsNullOrEmpty(captorInstanceId))
+                return false;
+
+            if (node is Planet { IsDestroyed: true })
+                return false;
+            if (
+                node is CapitalShip capitalShip
+                && capitalShip.ManufacturingStatus != ManufacturingStatus.Complete
+            )
+                return false;
+
+            return string.Equals(
+                node.GetOwnerInstanceID(),
+                captorInstanceId,
+                StringComparison.Ordinal
+            );
         }
 
         /// <summary>
@@ -116,7 +314,7 @@ namespace Rebellion.Systems
             Faction faction = _game.GetFactionByOwnerInstanceID(officer.OwnerInstanceID);
             Planet destination = faction?.GetNearestFriendlyPlanetTo(officer);
             if (destination != null)
-                _movementManager.RequestMove(officer, destination);
+                _movementSystem.RequestMove(officer, destination);
 
             return new OfficerCaptureStateResult
             {

--- a/Assets/Scripts/Systems/CaptiveSystem.cs
+++ b/Assets/Scripts/Systems/CaptiveSystem.cs
@@ -7,14 +7,16 @@ using Rebellion.Game.Galaxy;
 using Rebellion.Game.Missions;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
+using Rebellion.SceneGraph;
 using Rebellion.Util.Common;
+using Rebellion.Util.Extensions;
 
 namespace Rebellion.Systems
 {
     /// <summary>
     /// Processes escape attempts for captured officers each tick.
-    /// Escape probability is based on the officer's skills vs the planet's
-    /// garrison strength, looked up in the escape table.
+    /// Escape probability is based on the officer's skills and the forces guarding
+    /// the planet or fleet where the officer is held.
     /// </summary>
     public class CaptiveSystem
     {
@@ -56,11 +58,16 @@ namespace Rebellion.Systems
                 if (!officer.IsCaptured || !officer.CanEscape || officer.IsKilled)
                     continue;
 
+                ContainerNode custodyContext = GetCustodyContext(officer);
                 Planet planet = officer.GetParentOfType<Planet>();
-                if (planet == null)
+                if (
+                    custodyContext == null
+                    || planet == null
+                    || officer.GetTransitMovement() != null
+                )
                     continue;
 
-                if (RollEscapeAttempt(officer, planet))
+                if (RollEscapeAttempt(officer, custodyContext))
                     results.Add(ReleaseOfficer(officer, planet));
             }
 
@@ -68,14 +75,26 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Rolls the escape probability based on the officer's skills vs the planet's defenses.
+        /// Returns the local container whose forces guard a captive.
+        /// </summary>
+        /// <param name="officer">The captive officer.</param>
+        /// <returns>The fleet, ship, or planet holding the officer.</returns>
+        private static ContainerNode GetCustodyContext(Officer officer)
+        {
+            ContainerNode fleet = officer.GetParentOfType<Fleet>();
+            ContainerNode ship = officer.GetParentOfType<CapitalShip>();
+            return fleet ?? ship ?? officer.GetParentOfType<Planet>();
+        }
+
+        /// <summary>
+        /// Rolls the escape probability against the forces in the officer's custody context.
         /// </summary>
         /// <param name="officer">The officer attempting escape.</param>
-        /// <param name="planet">The planet the officer is held on.</param>
+        /// <param name="custodyContext">The planet, fleet, or ship holding the officer.</param>
         /// <returns>True if the escape roll succeeds.</returns>
-        private bool RollEscapeAttempt(Officer officer, Planet planet)
+        private bool RollEscapeAttempt(Officer officer, ContainerNode custodyContext)
         {
-            int delta = ComputeEscapeDelta(officer, planet);
+            int delta = ComputeEscapeDelta(officer, custodyContext);
             double probability = _escapeTable.Lookup(delta);
             return _provider.NextDouble() * 100 <= probability;
         }
@@ -113,13 +132,13 @@ namespace Rebellion.Systems
         /// Higher values favour escape.
         /// </summary>
         /// <param name="officer">The officer attempting escape.</param>
-        /// <param name="planet">The planet the officer is held on.</param>
+        /// <param name="custodyContext">The planet, fleet, or ship holding the officer.</param>
         /// <returns>The escape delta for table lookup.</returns>
-        private int ComputeEscapeDelta(Officer officer, Planet planet)
+        private int ComputeEscapeDelta(Officer officer, ContainerNode custodyContext)
         {
             int officerSkills = GetEscapeSkillScore(officer);
-            int guardCombat = GetAverageGuardCombat(planet);
-            int guardRegiments = CountGuardRegiments(planet);
+            int guardCombat = GetAverageGuardCombat(custodyContext, officer.CaptorInstanceID);
+            int guardRegiments = CountGuardRegiments(custodyContext, officer.CaptorInstanceID);
 
             return officerSkills - guardCombat - guardRegiments;
         }
@@ -136,16 +155,22 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Gets the average combat value of free owner-aligned guards on the planet.
+        /// Gets the average combat value of free captor-aligned guards in the custody context.
         /// </summary>
-        /// <param name="planet">The planet where the officer is held.</param>
+        /// <param name="custodyContext">The planet, fleet, or ship holding the officer.</param>
+        /// <param name="captorInstanceId">The faction holding the officer captive.</param>
         /// <returns>The average guard combat value, or 0 if no guards are present.</returns>
-        private static int GetAverageGuardCombat(Planet planet)
+        private static int GetAverageGuardCombat(
+            ContainerNode custodyContext,
+            string captorInstanceId
+        )
         {
-            string planetOwner = planet.OwnerInstanceID;
-            List<Officer> guards = planet
-                .GetAllOfficers()
-                .Where(o => o.GetOwnerInstanceID() == planetOwner && !o.IsCaptured && !o.IsKilled)
+            List<Officer> guards = GetCustodyUnits<Officer>(custodyContext)
+                .Where(officer =>
+                    officer.GetOwnerInstanceID() == captorInstanceId
+                    && !officer.IsCaptured
+                    && !officer.IsKilled
+                )
                 .ToList();
 
             if (guards.Count == 0)
@@ -155,17 +180,31 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Counts owner-aligned guard regiments on the planet.
+        /// Counts captor-aligned guard regiments in the custody context.
         /// </summary>
-        /// <param name="planet">The planet where the officer is held.</param>
+        /// <param name="custodyContext">The planet, fleet, or ship holding the officer.</param>
+        /// <param name="captorInstanceId">The faction holding the officer captive.</param>
         /// <returns>The number of guard regiments.</returns>
-        private static int CountGuardRegiments(Planet planet)
+        private static int CountGuardRegiments(
+            ContainerNode custodyContext,
+            string captorInstanceId
+        )
         {
-            string planetOwner = planet.OwnerInstanceID;
-            return planet
-                .GetChildren()
-                .OfType<Regiment>()
-                .Count(r => r.OwnerInstanceID == planetOwner);
+            return GetCustodyUnits<Regiment>(custodyContext)
+                .Count(regiment => regiment.OwnerInstanceID == captorInstanceId);
+        }
+
+        /// <summary>
+        /// Returns units directly on a planet or recursively carried by a fleet or ship.
+        /// </summary>
+        /// <typeparam name="T">The unit type to return.</typeparam>
+        /// <param name="custodyContext">The planet, fleet, or ship holding the captive.</param>
+        /// <returns>The units guarding the captive.</returns>
+        private static IReadOnlyList<T> GetCustodyUnits<T>(ContainerNode custodyContext)
+            where T : class, ISceneNode
+        {
+            bool recursive = custodyContext is Fleet or CapitalShip;
+            return custodyContext.GetChildren<T>(recursive);
         }
     }
 }

--- a/Assets/Scripts/Systems/CaptiveSystem.cs
+++ b/Assets/Scripts/Systems/CaptiveSystem.cs
@@ -67,9 +67,24 @@ namespace Rebellion.Systems
             foreach (OfficerCaptureStateResult result in results)
             {
                 Officer officer = result?.TargetOfficer;
+                if (officer == null)
+                    continue;
+
+                Faction originalFaction = _game.GetFactionByOwnerInstanceID(
+                    officer.OwnerInstanceID
+                );
+                if (result.IsCaptured == false)
+                {
+                    if (!officer.IsCaptured)
+                        _fogOfWarSystem.RemoveEntityFromSnapshots(
+                            originalFaction,
+                            officer.InstanceID
+                        );
+                    continue;
+                }
+
                 if (
-                    result?.IsCaptured != true
-                    || officer?.IsCaptured != true
+                    officer.IsCaptured != true
                     || string.IsNullOrEmpty(officer.CaptorInstanceID)
                     || !handledOfficerIds.Add(officer.InstanceID)
                 )
@@ -93,9 +108,6 @@ namespace Rebellion.Systems
                     continue;
                 }
 
-                Faction originalFaction = _game.GetFactionByOwnerInstanceID(
-                    officer.OwnerInstanceID
-                );
                 _fogOfWarSystem.RecordObservations(originalFaction, new[] { officer }, result.Tick);
             }
 
@@ -146,18 +158,25 @@ namespace Rebellion.Systems
             string captorInstanceId = officer.CaptorInstanceID;
             ContainerNode establishedCustody = GetCaptorControlledContainer(
                 officer.GetParent() as ContainerNode,
-                captorInstanceId
+                captorInstanceId,
+                officer
             );
             if (establishedCustody != null)
                 return establishedCustody;
 
             Planet capturePlanet = GetResultPlanet(result);
-            if (IsControlledBy(capturePlanet, captorInstanceId))
-                return capturePlanet;
+            ContainerNode capturePlanetCustody = GetCaptorControlledContainer(
+                capturePlanet,
+                captorInstanceId,
+                officer
+            );
+            if (capturePlanetCustody != null)
+                return capturePlanetCustody;
 
             ContainerNode capturingUnitCustody = GetCapturingUnitCustody(
                 result.CapturingUnit,
-                captorInstanceId
+                captorInstanceId,
+                officer
             );
             if (capturingUnitCustody != null)
                 return capturingUnitCustody;
@@ -195,10 +214,12 @@ namespace Rebellion.Systems
         /// </summary>
         /// <param name="capturingUnit">The unit responsible for the capture.</param>
         /// <param name="captorInstanceId">The capturing faction identifier.</param>
+        /// <param name="officer">The captured officer requiring custody.</param>
         /// <returns>The capturing unit's custody container, or null when it has none.</returns>
         private static ContainerNode GetCapturingUnitCustody(
             ISceneNode capturingUnit,
-            string captorInstanceId
+            string captorInstanceId,
+            Officer officer
         )
         {
             if (capturingUnit == null)
@@ -206,12 +227,18 @@ namespace Rebellion.Systems
 
             CapitalShip ship =
                 capturingUnit as CapitalShip ?? capturingUnit.GetParentOfType<CapitalShip>();
-            if (IsControlledBy(ship, captorInstanceId))
-                return ship;
+            ContainerNode shipCustody = GetCaptorControlledContainer(
+                ship,
+                captorInstanceId,
+                officer
+            );
+            if (shipCustody != null)
+                return shipCustody;
 
             return GetCaptorControlledContainer(
                 capturingUnit.GetParent() as ContainerNode,
-                captorInstanceId
+                captorInstanceId,
+                officer
             );
         }
 
@@ -235,13 +262,18 @@ namespace Rebellion.Systems
         /// </summary>
         /// <param name="container">The possible custody container.</param>
         /// <param name="captorInstanceId">The capturing faction identifier.</param>
+        /// <param name="officer">The captured officer requiring custody.</param>
         /// <returns>The controlled custody container, or null when ownership does not match.</returns>
         private static ContainerNode GetCaptorControlledContainer(
             ContainerNode container,
-            string captorInstanceId
+            string captorInstanceId,
+            Officer officer
         )
         {
-            return container is Planet or CapitalShip && IsControlledBy(container, captorInstanceId)
+            return
+                container is Planet or CapitalShip
+                && IsControlledBy(container, captorInstanceId)
+                && container.CanAcceptChild(officer)
                 ? container
                 : null;
         }

--- a/Assets/Scripts/Systems/DuelSystem.cs
+++ b/Assets/Scripts/Systems/DuelSystem.cs
@@ -142,6 +142,7 @@ namespace Rebellion.Systems
                     {
                         TargetOfficer = encountered,
                         IsCaptured = true,
+                        CapturingUnit = opposing,
                         CapturedOfficer = encountered,
                         LinkedOfficer = opposing,
                         Context = location,

--- a/Assets/Scripts/Systems/FogOfWarSystem.cs
+++ b/Assets/Scripts/Systems/FogOfWarSystem.cs
@@ -48,6 +48,21 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
+        /// Records selected game objects at their current logical locations.
+        /// </summary>
+        /// <param name="faction">The faction receiving the observations.</param>
+        /// <param name="observations">The game objects revealed to the faction.</param>
+        /// <param name="currentTick">The tick when the objects were observed.</param>
+        internal void RecordObservations(
+            Faction faction,
+            IEnumerable<ISceneNode> observations,
+            int currentTick
+        )
+        {
+            _recorder.RecordSelectedObservations(_game, faction, observations, currentTick);
+        }
+
+        /// <summary>
         /// Applies category-limited planet intelligence emitted by a simulation event.
         /// </summary>
         /// <param name="results">The intelligence results to record.</param>

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -905,26 +905,7 @@ namespace Rebellion.Systems
                 return;
             }
 
-            CaptureOfficer(officer, detector.GetOwnerInstanceID(), planet, results);
-            MoveCaptiveToCaptor(officer, detector, planet);
-        }
-
-        /// <summary>
-        /// Loads a newly captured officer onto the capturing fleet so it travels home with its
-        /// captor. An officer caught by a planet's own garrison stays on that captor-held world.
-        /// </summary>
-        /// <param name="officer">The captured officer.</param>
-        /// <param name="detector">The hostile unit that made the capture.</param>
-        /// <param name="capturePlanet">The planet where the capture occurred.</param>
-        private void MoveCaptiveToCaptor(Officer officer, ISceneNode detector, Planet capturePlanet)
-        {
-            if (capturePlanet?.GetOwnerInstanceID() == detector.GetOwnerInstanceID())
-                return;
-
-            CapitalShip captorShip =
-                detector as CapitalShip ?? detector.GetParentOfType<CapitalShip>();
-            if (captorShip != null)
-                _game.MoveNode(officer, captorShip);
+            CaptureOfficer(officer, detector, planet, results);
         }
 
         /// <summary>
@@ -1051,6 +1032,32 @@ namespace Rebellion.Systems
                     Tick = _game.CurrentTick,
                 }
             );
+        }
+
+        /// <summary>
+        /// Captures an officer encountered by a detector and places the captive with that unit
+        /// when the capture occurs away from a captor-held planet.
+        /// </summary>
+        /// <param name="officer">The captured officer.</param>
+        /// <param name="captor">The hostile unit that made the capture.</param>
+        /// <param name="planet">The planet where the capture occurred.</param>
+        /// <param name="results">Collection to append the capture result to.</param>
+        private void CaptureOfficer(
+            Officer officer,
+            ISceneNode captor,
+            Planet planet,
+            List<GameResult> results
+        )
+        {
+            string captorInstanceId = captor.GetOwnerInstanceID();
+            CaptureOfficer(officer, captorInstanceId, planet, results);
+
+            if (planet?.GetOwnerInstanceID() == captorInstanceId)
+                return;
+
+            CapitalShip captorShip = captor as CapitalShip ?? captor.GetParentOfType<CapitalShip>();
+            if (captorShip != null)
+                _movementManager.RequestMove(officer, captorShip);
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -905,7 +905,7 @@ namespace Rebellion.Systems
                 return;
             }
 
-            CaptureOfficer(officer, detector, planet, results);
+            CaptureOfficer(officer, detector.GetOwnerInstanceID(), planet, results, detector);
         }
 
         /// <summary>
@@ -1013,11 +1013,13 @@ namespace Rebellion.Systems
         /// <param name="captorInstanceId">The faction taking the officer captive.</param>
         /// <param name="planet">The planet where the capture occurred.</param>
         /// <param name="results">Collection to append the capture result to.</param>
+        /// <param name="capturingUnit">The unit responsible for the capture, when applicable.</param>
         private void CaptureOfficer(
             Officer officer,
             string captorInstanceId,
             Planet planet,
-            List<GameResult> results
+            List<GameResult> results,
+            ISceneNode capturingUnit = null
         )
         {
             officer.IsCaptured = true;
@@ -1028,36 +1030,11 @@ namespace Rebellion.Systems
                 {
                     TargetOfficer = officer,
                     IsCaptured = true,
+                    CapturingUnit = capturingUnit,
                     Context = planet,
                     Tick = _game.CurrentTick,
                 }
             );
-        }
-
-        /// <summary>
-        /// Captures an officer encountered by a detector and places the captive with that unit
-        /// when the capture occurs away from a captor-held planet.
-        /// </summary>
-        /// <param name="officer">The captured officer.</param>
-        /// <param name="captor">The hostile unit that made the capture.</param>
-        /// <param name="planet">The planet where the capture occurred.</param>
-        /// <param name="results">Collection to append the capture result to.</param>
-        private void CaptureOfficer(
-            Officer officer,
-            ISceneNode captor,
-            Planet planet,
-            List<GameResult> results
-        )
-        {
-            string captorInstanceId = captor.GetOwnerInstanceID();
-            CaptureOfficer(officer, captorInstanceId, planet, results);
-
-            if (planet?.GetOwnerInstanceID() == captorInstanceId)
-                return;
-
-            CapitalShip captorShip = captor as CapitalShip ?? captor.GetParentOfType<CapitalShip>();
-            if (captorShip != null)
-                _movementManager.RequestMove(officer, captorShip);
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/MissionSystem.cs
+++ b/Assets/Scripts/Systems/MissionSystem.cs
@@ -906,6 +906,25 @@ namespace Rebellion.Systems
             }
 
             CaptureOfficer(officer, detector.GetOwnerInstanceID(), planet, results);
+            MoveCaptiveToCaptor(officer, detector, planet);
+        }
+
+        /// <summary>
+        /// Loads a newly captured officer onto the capturing fleet so it travels home with its
+        /// captor. An officer caught by a planet's own garrison stays on that captor-held world.
+        /// </summary>
+        /// <param name="officer">The captured officer.</param>
+        /// <param name="detector">The hostile unit that made the capture.</param>
+        /// <param name="capturePlanet">The planet where the capture occurred.</param>
+        private void MoveCaptiveToCaptor(Officer officer, ISceneNode detector, Planet capturePlanet)
+        {
+            if (capturePlanet?.GetOwnerInstanceID() == detector.GetOwnerInstanceID())
+                return;
+
+            CapitalShip captorShip =
+                detector as CapitalShip ?? detector.GetParentOfType<CapitalShip>();
+            if (captorShip != null)
+                _game.MoveNode(officer, captorShip);
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -215,6 +215,71 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
+        /// Establishes a captured officer's custody in a captor-controlled container.
+        /// </summary>
+        /// <param name="officer">The captured officer to transfer.</param>
+        /// <param name="destination">The captor-controlled ship or planet receiving the officer.</param>
+        /// <param name="escort">The captor unit accompanying a remote transfer, if one exists.</param>
+        /// <param name="results">The collection receiving movement results.</param>
+        /// <returns>True when custody is established or the officer is already there.</returns>
+        internal bool TryEstablishCapturedOfficerCustody(
+            Officer officer,
+            ContainerNode destination,
+            IMovable escort,
+            ICollection<GameResult> results
+        )
+        {
+            if (officer == null)
+                throw new ArgumentNullException(nameof(officer));
+            if (destination == null)
+                throw new ArgumentNullException(nameof(destination));
+            if (results == null)
+                throw new ArgumentNullException(nameof(results));
+            if (!officer.IsCaptured || string.IsNullOrEmpty(officer.CaptorInstanceID))
+                return false;
+
+            destination = ResolveLiveContainer(destination);
+            if (
+                !TryResolveAcceptedDestination(
+                    officer,
+                    destination,
+                    out ContainerNode resolvedDestination
+                )
+                || !string.Equals(
+                    resolvedDestination.GetOwnerInstanceID(),
+                    officer.CaptorInstanceID,
+                    StringComparison.Ordinal
+                )
+            )
+                return false;
+
+            if (ReferenceEquals(officer.GetParent(), resolvedDestination))
+                return true;
+
+            Planet originPlanet = officer.GetParentOfType<Planet>();
+            Planet destinationPlanet = RequireDestinationPlanet(resolvedDestination);
+            if (!officer.IsActive() || ReferenceEquals(originPlanet, destinationPlanet))
+            {
+                officer.Movement = null;
+                _game.MoveNode(officer, resolvedDestination);
+                return true;
+            }
+
+            if (escort == null)
+            {
+                officer.Movement = null;
+                _game.MoveNode(officer, resolvedDestination);
+                return true;
+            }
+
+            return TryExecuteMoveGroup(
+                new List<IMovable> { escort, officer },
+                resolvedDestination,
+                results
+            );
+        }
+
+        /// <summary>
         /// Requests move.
         /// </summary>
         /// <param name="unit">The unit to move.</param>

--- a/Assets/Tests/EditMode/GameTests/Game/Missions/AbductionMissionTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Missions/AbductionMissionTests.cs
@@ -298,7 +298,8 @@ namespace Rebellion.Tests.Game.Missions
                 Planet enemyPlanet,
                 Officer officer,
                 FogOfWarSystem fog
-            ) = MissionSceneBuilder.Build();
+            ) = MissionSceneBuilder.Build(new GameConfig());
+            MakeAbductionAlwaysSucceed(game);
 
             Officer target = EntityFactory.CreateOfficer("target", "rebels");
             target.IsMain = true;
@@ -324,6 +325,7 @@ namespace Rebellion.Tests.Game.Missions
                 .FirstOrDefault();
             Assert.IsNotNull(captured, "Should return OfficerCaptureStateResult on success");
             Assert.AreEqual("target", captured.TargetOfficer.InstanceID);
+            Assert.AreSame(officer, captured.CapturingUnit);
             Assert.IsNotEmpty(
                 results.OfType<OfficerInjuredResult>(),
                 "A successful injury roll should injure the target before capture"

--- a/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
+++ b/Assets/Tests/EditMode/GameTests/Helpers/TestHelpers.cs
@@ -348,9 +348,9 @@ public static class MissionSceneBuilder
         Planet enemyPlanet,
         Officer officer,
         FogOfWarSystem fog
-    ) Build()
+    ) Build(GameConfig config = null)
     {
-        GameRoot game = new GameRoot(TestConfig.Create());
+        GameRoot game = new GameRoot(config ?? TestConfig.Create());
 
         Faction empire = new Faction { InstanceID = "empire" };
         Faction rebels = new Faction { InstanceID = "rebels" };

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -251,6 +251,35 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
+        public void ProcessTick_CapturedOfficerCanEscape()
+        {
+            GameConfig config = new GameConfig();
+            config.Captive.EscapeTable = new Dictionary<int, int> { { 0, 100 } };
+            config.Smuggling.LossPercentByMinimumSupport[0] = 0;
+            GameRoot game = new GameRoot(config);
+            Faction owner = new Faction { InstanceID = "OWNER" };
+            Faction captor = new Faction { InstanceID = "CAPTOR" };
+            game.GetFactions().Add(owner);
+            game.GetFactions().Add(captor);
+            PlanetSector sector = new PlanetSector { InstanceID = "SECTOR" };
+            Planet ownerPlanet = CreatePlanet("OWNER_PLANET", owner.InstanceID, 0);
+            Planet captorPlanet = CreatePlanet("CAPTOR_PLANET", captor.InstanceID, 100);
+            game.AttachNode(sector, game.GetGalaxyMap());
+            game.AttachNode(ownerPlanet, sector);
+            game.AttachNode(captorPlanet, sector);
+            Officer captive = EntityFactory.CreateOfficer("CAPTIVE", owner.InstanceID);
+            captive.IsCaptured = true;
+            captive.CaptorInstanceID = captor.InstanceID;
+            captive.CanEscape = true;
+            game.AttachNode(captive, captorPlanet);
+            GameManager manager = new GameManager(game, TestGameData.Create(config));
+
+            manager.ProcessTick();
+
+            Assert.IsFalse(captive.IsCaptured);
+        }
+
+        [Test]
         public void ProcessTick_EventCapturesMissionParticipant_TearsDownMission()
         {
             GameRoot game = new GameRoot(TestConfig.Create());

--- a/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/GameManagerTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Rebellion.Game;
 using Rebellion.Game.Events;
 using Rebellion.Game.Factions;
+using Rebellion.Game.FogOfWar;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Messages;
 using Rebellion.Game.Missions;
@@ -280,9 +281,11 @@ namespace Rebellion.Tests.Managers
         }
 
         [Test]
-        public void ProcessTick_EventCapturesMissionParticipant_TearsDownMission()
+        public void ProcessTick_EventCapturesMissionParticipant_CompletesCaptureLifecycle()
         {
-            GameRoot game = new GameRoot(TestConfig.Create());
+            GameConfig config = new GameConfig();
+            config.Smuggling.LossPercentByMinimumSupport[0] = 0;
+            GameRoot game = new GameRoot(config);
             Faction owner = new Faction { InstanceID = "OWNER" };
             Faction captor = new Faction { InstanceID = "CAPTOR" };
             game.GetFactions().Add(owner);
@@ -293,9 +296,20 @@ namespace Rebellion.Tests.Managers
                 InstanceID = "PLANET",
                 OwnerInstanceID = owner.InstanceID,
                 IsColonized = true,
+                PositionX = 0,
+                PositionY = 0,
+            };
+            Planet captorPlanet = new Planet
+            {
+                InstanceID = "CAPTOR_PLANET",
+                OwnerInstanceID = captor.InstanceID,
+                IsColonized = true,
+                PositionX = 100,
+                PositionY = 0,
             };
             game.AttachNode(sector, game.GetGalaxyMap());
             game.AttachNode(planet, sector);
+            game.AttachNode(captorPlanet, sector);
             Officer officer = EntityFactory.CreateOfficer("OFFICER", owner.InstanceID);
             DiplomacyMission mission = new DiplomacyMission
             {
@@ -324,14 +338,23 @@ namespace Rebellion.Tests.Managers
                         },
                     }
                 );
-            GameManager manager = TestContent.CreateGameManager(game);
+            GameManager manager = new GameManager(game, TestGameData.Create(config));
 
             manager.ProcessTick();
 
             Assert.IsNull(game.GetSceneNodeByInstanceID<Mission>(mission.InstanceID));
-            Assert.AreSame(planet, officer.GetParent());
+            Assert.AreSame(captorPlanet, officer.GetParent());
+            Assert.IsNull(officer.Movement);
             Assert.IsTrue(officer.IsCaptured);
             Assert.AreEqual(captor.InstanceID, officer.CaptorInstanceID);
+            PlanetSnapshot snapshot = owner.Fog.Snapshots[sector.InstanceID].Planets[
+                captorPlanet.InstanceID
+            ];
+            Officer observed = snapshot.Officers.Single(candidate =>
+                candidate.InstanceID == officer.InstanceID
+            );
+            Assert.IsTrue(observed.IsCaptured);
+            Assert.IsNull(observed.Movement);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/CaptiveSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/CaptiveSystemTests.cs
@@ -3,12 +3,15 @@ using System.Linq;
 using NUnit.Framework;
 using Rebellion.Game;
 using Rebellion.Game.Factions;
+using Rebellion.Game.FogOfWar;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Missions;
 using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
+using Rebellion.SceneGraph;
 using Rebellion.Systems;
+using Rebellion.Util.Extensions;
 
 namespace Rebellion.Tests.Systems
 {
@@ -16,11 +19,252 @@ namespace Rebellion.Tests.Systems
     public class CaptiveSystemTests
     {
         [Test]
+        public void HandleResults_CaptureAtCaptorPlanet_RecordsImmediateCustody()
+        {
+            (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+
+            system.HandleResults(new[] { CaptureResult(captive, planet) });
+
+            Assert.AreSame(planet, captive.GetParent());
+            Assert.IsNull(captive.Movement);
+            PlanetSnapshot snapshot = GetOfficerOwnerSnapshot(game, captive, planet);
+            Officer observed = snapshot.Officers.Single(officer =>
+                officer.InstanceID == captive.InstanceID
+            );
+            Assert.AreNotSame(captive, observed);
+            Assert.IsTrue(observed.IsCaptured);
+            Assert.IsNull(observed.Movement);
+        }
+
+        [Test]
+        public void HandleResults_CaptureInsideForeignContainerAtCaptorPlanet_MovesToPlanet()
+        {
+            (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
+            StubMission mission = new StubMission
+            {
+                InstanceID = "mission",
+                OwnerInstanceID = captive.OwnerInstanceID,
+            };
+            game.AttachNode(mission, planet);
+            game.MoveNode(captive, mission);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+
+            system.HandleResults(new[] { CaptureResult(captive, planet) });
+
+            Assert.AreSame(planet, captive.GetParent());
+            Assert.IsNull(captive.Movement);
+        }
+
+        [Test]
+        public void HandleResults_CaptureByShipAwayFromCaptorPlanet_BoardsCapturingShip()
+        {
+            (
+                GameRoot game,
+                Planet capturePlanet,
+                Officer captive,
+                Fleet fleet,
+                CapitalShip ship,
+                MovementSystem movement
+            ) = BuildFleetCustodyScene();
+            game.MoveNode(captive, capturePlanet);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+
+            system.HandleResults(
+                new[] { CaptureResult(captive, capturePlanet, capturingUnit: ship) }
+            );
+
+            Assert.AreSame(ship, captive.GetParent());
+            Assert.IsNull(captive.Movement);
+            PlanetSnapshot snapshot = GetOfficerOwnerSnapshot(game, captive, capturePlanet);
+            Officer observed = snapshot
+                .Fleets.Single(candidate => candidate.InstanceID == fleet.InstanceID)
+                .GetChildren<CapitalShip>()
+                .Single(candidate => candidate.InstanceID == ship.InstanceID)
+                .GetChildren<Officer>()
+                .Single(candidate => candidate.InstanceID == captive.InstanceID);
+            Assert.IsTrue(observed.IsCaptured);
+
+            Planet destination = new Planet
+            {
+                InstanceID = "captor-destination",
+                OwnerInstanceID = captive.CaptorInstanceID,
+                IsColonized = true,
+                PositionX = 200,
+                PositionY = 0,
+            };
+            game.AttachNode(destination, capturePlanet.GetParent());
+
+            movement.RequestMove(fleet, destination);
+
+            Assert.AreSame(destination, fleet.GetParent());
+            Assert.AreSame(ship, captive.GetParent());
+            Assert.AreSame(fleet.Movement, captive.GetTransitMovement());
+            Assert.AreEqual(
+                capturePlanet.InstanceID,
+                game.GetFactionByOwnerInstanceID(captive.OwnerInstanceID).Fog.EntityLastSeenAt[
+                    captive.InstanceID
+                ]
+            );
+        }
+
+        [Test]
+        public void HandleResults_CaptureWithoutPhysicalCaptor_PlacesAtCustodyDestination()
+        {
+            (GameRoot game, Planet destination, Officer captive, MovementSystem movement) =
+                BuildScene();
+            Planet capturePlanet = game.GetSceneNodeByInstanceID<Planet>("emp_planet");
+            game.MoveNode(captive, capturePlanet);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+
+            system.HandleResults(new[] { CaptureResult(captive, capturePlanet) });
+
+            Assert.AreSame(destination, captive.GetParent());
+            Assert.AreEqual(captive.CaptorInstanceID, destination.OwnerInstanceID);
+            Assert.IsNull(captive.Movement);
+            PlanetSnapshot snapshot = GetOfficerOwnerSnapshot(game, captive, destination);
+            Officer observed = snapshot.Officers.Single(officer =>
+                officer.InstanceID == captive.InstanceID
+            );
+            Assert.IsTrue(observed.IsCaptured);
+            Assert.IsNull(observed.Movement);
+            Assert.AreEqual(
+                destination.InstanceID,
+                game.GetFactionByOwnerInstanceID(captive.OwnerInstanceID).Fog.EntityLastSeenAt[
+                    captive.InstanceID
+                ]
+            );
+        }
+
+        [Test]
+        public void HandleResults_CaptureByOfficerAwayFromCaptorPlanet_MovesWithEscort()
+        {
+            (GameRoot game, Planet destination, Officer captive, MovementSystem movement) =
+                BuildScene();
+            Planet capturePlanet = game.GetSceneNodeByInstanceID<Planet>("emp_planet");
+            Officer escort = EntityFactory.CreateOfficer("captor", captive.CaptorInstanceID);
+            StubMission mission = new StubMission
+            {
+                InstanceID = "captor-mission",
+                OwnerInstanceID = captive.CaptorInstanceID,
+            };
+            game.AttachNode(mission, capturePlanet);
+            game.AttachNode(escort, mission);
+            game.MoveNode(captive, capturePlanet);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+
+            List<GameResult> results = system.HandleResults(
+                new[] { CaptureResult(captive, capturePlanet, capturingUnit: escort) }
+            );
+
+            Assert.AreSame(destination, escort.GetParent());
+            Assert.AreSame(destination, captive.GetParent());
+            Assert.IsNotNull(escort.Movement);
+            Assert.IsNotNull(captive.Movement);
+            Assert.AreEqual(escort.Movement.MovementGroupID, captive.Movement.MovementGroupID);
+            Assert.IsTrue(
+                results
+                    .OfType<GameObjectEnrouteResult>()
+                    .Any(result => ReferenceEquals(result.GameObject, escort))
+            );
+            Assert.IsTrue(
+                results
+                    .OfType<GameObjectEnrouteResult>()
+                    .Any(result => ReferenceEquals(result.GameObject, captive))
+            );
+        }
+
+        [Test]
+        public void HandleResults_CaptureWithEstablishedTransfer_PreservesTransfer()
+        {
+            (GameRoot game, Planet destination, Officer captive, MovementSystem movement) =
+                BuildScene();
+            Planet capturePlanet = game.GetSceneNodeByInstanceID<Planet>("emp_planet");
+            MovementState establishedMovement = new MovementState
+            {
+                TransitTicks = 5,
+                MovementGroupID = "return-group",
+                OriginPosition = capturePlanet.GetPosition(),
+                CurrentPosition = capturePlanet.GetPosition(),
+            };
+            game.MoveNode(captive, destination);
+            captive.Movement = establishedMovement;
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+
+            system.HandleResults(new[] { CaptureResult(captive, capturePlanet) });
+
+            Assert.AreSame(destination, captive.GetParent());
+            Assert.AreSame(establishedMovement, captive.Movement);
+            PlanetSnapshot snapshot = GetOfficerOwnerSnapshot(game, captive, destination);
+            Officer observed = snapshot.Officers.Single(officer =>
+                officer.InstanceID == captive.InstanceID
+            );
+            Assert.AreEqual("return-group", observed.Movement.MovementGroupID);
+        }
+
+        [Test]
+        public void HandleResults_InactiveCaptureAwayFromCaptorPlanet_PlacesAtCustodyDestination()
+        {
+            (GameRoot game, Planet destination, Officer captive, MovementSystem movement) =
+                BuildScene();
+            Planet capturePlanet = game.GetSceneNodeByInstanceID<Planet>("emp_planet");
+            game.MoveNode(captive, capturePlanet);
+            captive.IsEnabled = false;
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+
+            system.HandleResults(new[] { CaptureResult(captive, capturePlanet) });
+
+            Assert.AreSame(destination, captive.GetParent());
+            Assert.AreEqual(captive.CaptorInstanceID, destination.OwnerInstanceID);
+            Assert.IsNull(captive.Movement);
+            PlanetSnapshot snapshot = GetOfficerOwnerSnapshot(game, captive, destination);
+            Officer observed = snapshot.Officers.Single(officer =>
+                officer.InstanceID == captive.InstanceID
+            );
+            Assert.IsNull(observed.Movement);
+        }
+
+        [Test]
+        public void HandleResults_CustodyTransferArrives_DoesNotRefreshCaptureSnapshot()
+        {
+            (GameRoot game, Planet destination, Officer captive, MovementSystem movement) =
+                BuildScene();
+            Planet capturePlanet = game.GetSceneNodeByInstanceID<Planet>("emp_planet");
+            game.MoveNode(captive, capturePlanet);
+            Officer escort = EntityFactory.CreateOfficer("captor", captive.CaptorInstanceID);
+            StubMission mission = new StubMission
+            {
+                InstanceID = "captor-mission",
+                OwnerInstanceID = captive.CaptorInstanceID,
+            };
+            game.AttachNode(mission, capturePlanet);
+            game.AttachNode(escort, mission);
+            game.CurrentTick = 11;
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+            system.HandleResults(
+                new[] { CaptureResult(captive, capturePlanet, 10, capturingUnit: escort) }
+            );
+            PlanetSnapshot snapshot = GetOfficerOwnerSnapshot(game, captive, destination);
+            Officer observed = snapshot.Officers.Single(officer =>
+                officer.InstanceID == captive.InstanceID
+            );
+            captive.Movement.TransitTicks = 1;
+
+            game.CurrentTick = 12;
+            movement.ProcessTick();
+
+            Assert.IsNull(captive.Movement);
+            Assert.AreEqual(10, snapshot.TickCaptured);
+            Assert.IsNotNull(observed.Movement);
+            Assert.AreEqual(0, observed.Movement.TicksElapsed);
+        }
+
+        [Test]
         public void ProcessTick_EscapeRollSucceeds_FreesOfficer()
         {
             (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
 
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.0), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
 
             system.ProcessTick();
 
@@ -34,7 +278,7 @@ namespace Rebellion.Tests.Systems
         {
             (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
 
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.99), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.99), movement);
 
             system.ProcessTick();
 
@@ -46,7 +290,7 @@ namespace Rebellion.Tests.Systems
         {
             (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
 
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.0), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
 
             system.ProcessTick();
 
@@ -58,7 +302,7 @@ namespace Rebellion.Tests.Systems
         {
             (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
 
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.0), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
 
             List<GameResult> results = system.ProcessTick();
 
@@ -78,7 +322,7 @@ namespace Rebellion.Tests.Systems
             (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
             captive.CanEscape = false;
 
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.0), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
 
             system.ProcessTick();
 
@@ -91,7 +335,7 @@ namespace Rebellion.Tests.Systems
             (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
             captive.IsKilled = true;
 
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.0), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
 
             system.ProcessTick();
 
@@ -118,7 +362,7 @@ namespace Rebellion.Tests.Systems
                 game.AttachNode(regiment, planet);
             }
 
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.5), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.5), movement);
 
             system.ProcessTick();
 
@@ -135,7 +379,7 @@ namespace Rebellion.Tests.Systems
             captive.SetBaseRating(OfficerRating.Espionage, 80);
             captive.SetBaseRating(OfficerRating.Combat, 80);
 
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.2), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.2), movement);
 
             system.ProcessTick();
 
@@ -151,7 +395,7 @@ namespace Rebellion.Tests.Systems
             (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
             captive.Loyalty = 5;
 
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.0), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
 
             system.ProcessTick();
 
@@ -180,7 +424,7 @@ namespace Rebellion.Tests.Systems
                 regiment.ManufacturingStatus = ManufacturingStatus.Complete;
                 game.AttachNode(regiment, ship);
             }
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.2), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.2), movement);
 
             system.ProcessTick();
 
@@ -213,7 +457,7 @@ namespace Rebellion.Tests.Systems
                 regiment.ManufacturingStatus = ManufacturingStatus.Complete;
                 game.AttachNode(regiment, planet);
             }
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.2), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.2), movement);
 
             system.ProcessTick();
 
@@ -233,12 +477,49 @@ namespace Rebellion.Tests.Systems
                 MovementSystem movement
             ) = BuildFleetCustodyScene();
             fleet.Movement = new MovementState { TransitTicks = 2 };
-            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.0), movement);
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
 
             system.ProcessTick();
 
             Assert.IsTrue(captive.IsCaptured);
             Assert.AreSame(ship, captive.GetParent());
+        }
+
+        private static CaptiveSystem CreateSystem(
+            GameRoot game,
+            FixedRNG provider,
+            MovementSystem movement
+        )
+        {
+            return new CaptiveSystem(game, provider, movement, new FogOfWarSystem(game));
+        }
+
+        private static OfficerCaptureStateResult CaptureResult(
+            Officer officer,
+            Planet context,
+            int tick = 0,
+            ISceneNode capturingUnit = null
+        )
+        {
+            return new OfficerCaptureStateResult
+            {
+                TargetOfficer = officer,
+                IsCaptured = true,
+                CapturingUnit = capturingUnit,
+                Context = context,
+                Tick = tick,
+            };
+        }
+
+        private static PlanetSnapshot GetOfficerOwnerSnapshot(
+            GameRoot game,
+            Officer officer,
+            Planet planet
+        )
+        {
+            Faction owner = game.GetFactionByOwnerInstanceID(officer.OwnerInstanceID);
+            PlanetSector sector = planet.GetParentOfType<PlanetSector>();
+            return owner.Fog.Snapshots[sector.InstanceID].Planets[planet.InstanceID];
         }
 
         private (

--- a/Assets/Tests/EditMode/GameTests/Systems/CaptiveSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/CaptiveSystemTests.cs
@@ -5,6 +5,7 @@ using Rebellion.Game;
 using Rebellion.Game.Factions;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Missions;
+using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using Rebellion.Systems;
@@ -157,6 +158,89 @@ namespace Rebellion.Tests.Systems
             Assert.AreEqual(0, captive.Loyalty, "Loyalty should clamp to 0, not go negative");
         }
 
+        [Test]
+        public void ProcessTick_CaptiveAboardFleet_UsesCaptorFleetGuards()
+        {
+            (
+                GameRoot game,
+                Planet _,
+                Officer captive,
+                Fleet _,
+                CapitalShip ship,
+                MovementSystem movement
+            ) = BuildFleetCustodyScene();
+            captive.SetBaseRating(OfficerRating.Espionage, 40);
+            captive.SetBaseRating(OfficerRating.Combat, 40);
+            Officer guard = EntityFactory.CreateOfficer("guard", "rebels");
+            guard.SetBaseRating(OfficerRating.Combat, 100);
+            game.AttachNode(guard, ship);
+            for (int index = 0; index < 10; index++)
+            {
+                Regiment regiment = EntityFactory.CreateRegiment($"guard-{index}", "rebels");
+                regiment.ManufacturingStatus = ManufacturingStatus.Complete;
+                game.AttachNode(regiment, ship);
+            }
+            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.2), movement);
+
+            system.ProcessTick();
+
+            Assert.IsTrue(captive.IsCaptured);
+            Assert.AreSame(ship, captive.GetParent());
+        }
+
+        [Test]
+        public void ProcessTick_CaptiveAboardFleet_IgnoresPlanetGarrison()
+        {
+            (
+                GameRoot game,
+                Planet planet,
+                Officer captive,
+                Fleet _,
+                CapitalShip ship,
+                MovementSystem movement
+            ) = BuildFleetCustodyScene();
+            captive.SetBaseRating(OfficerRating.Espionage, 40);
+            captive.SetBaseRating(OfficerRating.Combat, 40);
+            Officer planetGuard = EntityFactory.CreateOfficer("planet-guard", "empire");
+            planetGuard.SetBaseRating(OfficerRating.Combat, 100);
+            game.AttachNode(planetGuard, planet);
+            for (int index = 0; index < 10; index++)
+            {
+                Regiment regiment = EntityFactory.CreateRegiment(
+                    $"planet-regiment-{index}",
+                    "empire"
+                );
+                regiment.ManufacturingStatus = ManufacturingStatus.Complete;
+                game.AttachNode(regiment, planet);
+            }
+            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.2), movement);
+
+            system.ProcessTick();
+
+            Assert.IsFalse(captive.IsCaptured);
+            Assert.AreSame(planet, captive.GetParent());
+        }
+
+        [Test]
+        public void ProcessTick_CaptiveInTransit_SkipsEscapeAttempt()
+        {
+            (
+                GameRoot game,
+                Planet _,
+                Officer captive,
+                Fleet fleet,
+                CapitalShip ship,
+                MovementSystem movement
+            ) = BuildFleetCustodyScene();
+            fleet.Movement = new MovementState { TransitTicks = 2 };
+            CaptiveSystem system = new CaptiveSystem(game, new FixedRNG(0.0), movement);
+
+            system.ProcessTick();
+
+            Assert.IsTrue(captive.IsCaptured);
+            Assert.AreSame(ship, captive.GetParent());
+        }
+
         private (
             GameRoot game,
             Planet planet,
@@ -164,7 +248,7 @@ namespace Rebellion.Tests.Systems
             MovementSystem movement
         ) BuildScene()
         {
-            GameConfig config = TestConfig.Create();
+            GameConfig config = new GameConfig();
             config.Captive = new GameConfig.CaptiveConfig
             {
                 EscapeTable = new Dictionary<int, int>
@@ -226,6 +310,31 @@ namespace Rebellion.Tests.Systems
                 new FleetSystem(game)
             );
             return (game, rebelPlanet, captive, movement);
+        }
+
+        private (
+            GameRoot game,
+            Planet planet,
+            Officer captive,
+            Fleet fleet,
+            CapitalShip ship,
+            MovementSystem movement
+        ) BuildFleetCustodyScene()
+        {
+            (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
+            game.ChangeOwnership(planet, "empire");
+            Fleet fleet = EntityFactory.CreateFleet("fleet", "rebels");
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "ship",
+                OwnerInstanceID = "rebels",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                RegimentCapacity = 10,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+            game.MoveNode(captive, ship);
+            return (game, planet, captive, fleet, ship, movement);
         }
     }
 }

--- a/Assets/Tests/EditMode/GameTests/Systems/CaptiveSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/CaptiveSystemTests.cs
@@ -137,6 +137,23 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void HandleResults_CaptureAtUncolonizedCaptorPlanet_UsesFallbackDestination()
+        {
+            (GameRoot game, Planet destination, Officer captive, MovementSystem movement) =
+                BuildScene();
+            Planet capturePlanet = game.GetSceneNodeByInstanceID<Planet>("emp_planet");
+            game.MoveNode(captive, capturePlanet);
+            capturePlanet.OwnerInstanceID = captive.CaptorInstanceID;
+            capturePlanet.IsColonized = false;
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+
+            system.HandleResults(new[] { CaptureResult(captive, capturePlanet) });
+
+            Assert.AreSame(destination, captive.GetParent());
+            Assert.IsNull(captive.Movement);
+        }
+
+        [Test]
         public void HandleResults_CaptureByOfficerAwayFromCaptorPlanet_MovesWithEscort()
         {
             (GameRoot game, Planet destination, Officer captive, MovementSystem movement) =
@@ -257,6 +274,32 @@ namespace Rebellion.Tests.Systems
             Assert.AreEqual(10, snapshot.TickCaptured);
             Assert.IsNotNull(observed.Movement);
             Assert.AreEqual(0, observed.Movement.TicksElapsed);
+        }
+
+        [Test]
+        public void HandleResults_ReleasedOfficer_RemovesCaptureSnapshot()
+        {
+            (GameRoot game, Planet planet, Officer captive, MovementSystem movement) = BuildScene();
+            CaptiveSystem system = CreateSystem(game, new FixedRNG(0.0), movement);
+            system.HandleResults(new[] { CaptureResult(captive, planet) });
+            captive.IsCaptured = false;
+            captive.CaptorInstanceID = null;
+
+            system.HandleResults(
+                new[]
+                {
+                    new OfficerCaptureStateResult { TargetOfficer = captive, IsCaptured = false },
+                }
+            );
+
+            Faction owner = game.GetFactionByOwnerInstanceID(captive.OwnerInstanceID);
+            Assert.IsFalse(owner.Fog.EntityLastSeenAt.ContainsKey(captive.InstanceID));
+            Assert.IsFalse(
+                owner
+                    .Fog.Snapshots.Values.SelectMany(snapshot => snapshot.Planets.Values)
+                    .SelectMany(snapshot => snapshot.Officers)
+                    .Any(officer => officer.InstanceID == captive.InstanceID)
+            );
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/DuelSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/DuelSystemTests.cs
@@ -36,6 +36,7 @@ namespace Rebellion.Tests.Sectors
                 .OfType<OfficerCaptureStateResult>()
                 .Single();
             Assert.AreSame(encountered, capture.TargetOfficer);
+            Assert.AreSame(opposing, capture.CapturingUnit);
             Assert.AreSame(opposing, capture.LinkedOfficer);
             Assert.AreEqual("event", capture.SourceEventInstanceID);
             Assert.IsTrue(results.OfType<DuelResult>().Single().EncounteredOfficerCaptured);
@@ -85,7 +86,7 @@ namespace Rebellion.Tests.Sectors
 
         private static (GameRoot game, Officer encountered, Officer opposing) BuildEncounter()
         {
-            GameConfig config = TestConfig.Create();
+            GameConfig config = new GameConfig();
             config.DuelResolution = new GameConfig.DuelResolutionConfig
             {
                 CombatCaptureAvoidance = new Dictionary<int, int> { { 0, 50 } },
@@ -95,6 +96,7 @@ namespace Rebellion.Tests.Sectors
                 InjurySecondaryRollMaximum = 29,
                 CombatReward = 1,
             };
+            config.Recovery.MaxInjuryPoints = 100;
             GameRoot game = new GameRoot(config);
             game.GetFactions().Add(new Faction { InstanceID = "rebels" });
             game.GetFactions().Add(new Faction { InstanceID = "empire" });

--- a/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/FogOfWarSystemTests.cs
@@ -30,7 +30,7 @@ namespace Rebellion.Tests.Sectors
         [SetUp]
         public void SetUp()
         {
-            GameConfig config = TestContent.Data.GameConfig;
+            GameConfig config = new GameConfig();
             _game = new GameRoot(config);
             _fogSystem = new FogOfWarSystem(_game);
 
@@ -1965,23 +1965,21 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void CaptureSnapshot_CapturedFriendlyOfficer_NotIncludedInSnapshot()
+        public void CaptureSnapshot_CapturedFriendlyOfficer_IncludesDetachedOfficer()
         {
-            // Leia is captured on Coruscant. Snapshots must not include captured friendly officers
-            // because they are always surfaced as live data — snapshotting them would be redundant
-            // and could produce stale copies that conflict with live position.
             Officer leia = CreateOfficer("LEIA", _alliance);
             leia.IsCaptured = true;
+            leia.CaptorInstanceID = _empire.InstanceID;
             _game.AttachNode(leia, _coruscant);
 
             _fogSystem.CaptureSnapshot(_alliance, _coruscant, _coreSector, 10);
 
             PlanetSnapshot snapshot = _alliance.Fog.Snapshots["CORE_SECTOR"].Planets["CORUSCANT"];
 
-            Assert.IsFalse(
-                snapshot.Officers.Any(o => o.InstanceID == "LEIA"),
-                "Captured friendly officer must not be included in snapshots — they are live data"
-            );
+            Officer observed = snapshot.Officers.Single(officer => officer.InstanceID == "LEIA");
+            Assert.AreNotSame(leia, observed);
+            Assert.IsTrue(observed.IsCaptured);
+            Assert.AreEqual(_empire.InstanceID, observed.CaptorInstanceID);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -1193,10 +1193,57 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_EvasionFailsToHostileDetectorOnOwnPlanet_CaptorIsDetectorOwner()
+        public void UpdateMission_CapturedByOrbitalFleetOverOwnPlanet_BoardsCaptorShip()
         {
-            (GameRoot game, Planet planet, Officer spy, MovementSystem movement) =
-                BuildOwnPlanetDetectionScene();
+            (
+                GameRoot game,
+                Planet planet,
+                Officer spy,
+                CapitalShip captorShip,
+                MovementSystem movement
+            ) = BuildOrbitalDetectionScene(planetOwnerId: "empire");
+
+            List<GameResult> results = RunOrbitalCaptureMission(game, planet, spy, movement);
+
+            Assert.IsTrue(spy.IsCaptured);
+            Assert.AreEqual(
+                "rebels",
+                spy.CaptorInstanceID,
+                "Captor should be the hostile detector's faction, not the planet owner"
+            );
+            Assert.AreSame(
+                captorShip,
+                spy.GetParent(),
+                "Captive should be loaded onto the capturing ship, not left on its own planet"
+            );
+        }
+
+        [Test]
+        public void UpdateMission_CapturedByOrbitalFleetOverNeutralPlanet_BoardsCaptorShip()
+        {
+            (
+                GameRoot game,
+                Planet planet,
+                Officer spy,
+                CapitalShip captorShip,
+                MovementSystem movement
+            ) = BuildOrbitalDetectionScene(planetOwnerId: null);
+
+            RunOrbitalCaptureMission(game, planet, spy, movement);
+
+            Assert.IsTrue(spy.IsCaptured);
+            Assert.AreSame(
+                captorShip,
+                spy.GetParent(),
+                "Captive should ride the capturing ship off a neutral planet"
+            );
+        }
+
+        [Test]
+        public void UpdateMission_CapturedByGarrisonOnEnemyPlanet_StaysOnCaptorPlanet()
+        {
+            (GameRoot game, Planet planet, Officer spy, Officer defender, MovementSystem movement) =
+                BuildDetectionScene();
 
             StubMission mission = new StubMission("empire", planet.InstanceID);
             SetFoilTable(game, new Dictionary<int, int> { { 0, 100 } });
@@ -1211,14 +1258,38 @@ namespace Rebellion.Tests.Sectors
                 movement
             );
 
-            List<GameResult> results = system.UpdateMission(mission);
+            system.UpdateMission(mission);
 
             Assert.IsTrue(spy.IsCaptured);
-            Assert.AreEqual(
-                "rebels",
-                spy.CaptorInstanceID,
-                "Captor should be the hostile detector's faction, not the planet owner"
+            Assert.AreEqual("rebels", spy.CaptorInstanceID);
+            Assert.AreSame(
+                planet,
+                spy.GetParent(),
+                "An officer caught by a planet's own garrison stays on that captor world"
             );
+            Assert.IsNull(spy.GetParentOfType<CapitalShip>());
+        }
+
+        private List<GameResult> RunOrbitalCaptureMission(
+            GameRoot game,
+            Planet planet,
+            Officer spy,
+            MovementSystem movement
+        )
+        {
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            SetFoilTable(game, new Dictionary<int, int> { { 0, 100 } });
+            SetEvasionTable(game, new Dictionary<int, int> { { -200, 0 } });
+            DisableCaptureEvasionInjury(game);
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+            return system.UpdateMission(mission);
         }
 
         [Test]
@@ -3586,8 +3657,9 @@ namespace Rebellion.Tests.Sectors
             GameRoot game,
             Planet planet,
             Officer spy,
+            CapitalShip captorShip,
             MovementSystem movement
-        ) BuildOwnPlanetDetectionScene()
+        ) BuildOrbitalDetectionScene(string planetOwnerId = "empire")
         {
             GameConfig config = new GameConfig();
             GameRoot game = new GameRoot(config);
@@ -3602,42 +3674,50 @@ namespace Rebellion.Tests.Sectors
             };
             game.AttachNode(sector, game.Galaxy);
 
+            Planet homePlanet = new Planet
+            {
+                InstanceID = "empire-home",
+                OwnerInstanceID = "empire",
+                IsColonized = true,
+                PositionX = -100,
+                PositionY = 0,
+            };
+            game.AttachNode(homePlanet, sector);
+
             Planet planet = new Planet
             {
                 InstanceID = "p1",
-                OwnerInstanceID = "empire",
+                OwnerInstanceID = planetOwnerId,
                 IsColonized = true,
                 PositionX = 0,
                 PositionY = 0,
-                PopularSupport = new Dictionary<string, int> { { "empire", 50 } },
             };
             game.AttachNode(planet, sector);
 
             Officer spy = EntityFactory.CreateOfficer("spy", "empire");
-            spy.MissionReturnParentInstanceID = planet.InstanceID;
-            spy.MissionReturnLocationInstanceID = planet.InstanceID;
-            game.AttachNode(spy, planet);
+            spy.MissionReturnParentInstanceID = homePlanet.InstanceID;
+            spy.MissionReturnLocationInstanceID = homePlanet.InstanceID;
+            game.AttachNode(spy, homePlanet);
 
-            // A hostile unit over one of your own planets rides in an orbiting fleet;
-            // a colonized planet only accepts owner-owned regiments/starfighters directly.
+            // The hostile detector rides an orbiting fleet: a capital ship carries the capture.
             Fleet fleet = new Fleet { InstanceID = "f1", OwnerInstanceID = "rebels" };
             game.AttachNode(fleet, planet);
 
-            CapitalShip detectorShip = new CapitalShip
+            CapitalShip captorShip = new CapitalShip
             {
                 InstanceID = "cs1",
                 OwnerInstanceID = "rebels",
                 DetectionRating = 100,
                 ManufacturingStatus = ManufacturingStatus.Complete,
             };
-            game.AttachNode(detectorShip, fleet);
+            game.AttachNode(captorShip, fleet);
 
             MovementSystem movement = new MovementSystem(
                 game,
                 new FogOfWarSystem(game),
                 new FleetSystem(game)
             );
-            return (game, planet, spy, movement);
+            return (game, planet, spy, captorShip, movement);
         }
 
         private (

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -1203,7 +1203,7 @@ namespace Rebellion.Tests.Sectors
                 MovementSystem movement
             ) = BuildOrbitalDetectionScene(planetOwnerId: "empire");
 
-            List<GameResult> results = RunOrbitalCaptureMission(game, planet, spy, movement);
+            RunOrbitalCaptureMission(game, planet, spy, movement);
 
             Assert.IsTrue(spy.IsCaptured);
             Assert.AreEqual(
@@ -1268,28 +1268,6 @@ namespace Rebellion.Tests.Sectors
                 "An officer caught by a planet's own garrison stays on that captor world"
             );
             Assert.IsNull(spy.GetParentOfType<CapitalShip>());
-        }
-
-        private List<GameResult> RunOrbitalCaptureMission(
-            GameRoot game,
-            Planet planet,
-            Officer spy,
-            MovementSystem movement
-        )
-        {
-            StubMission mission = new StubMission("empire", planet.InstanceID);
-            SetFoilTable(game, new Dictionary<int, int> { { 0, 100 } });
-            SetEvasionTable(game, new Dictionary<int, int> { { -200, 0 } });
-            DisableCaptureEvasionInjury(game);
-            game.AttachNode(mission, planet);
-            game.MoveNode(spy, mission);
-
-            MissionSystem system = TestSystems.CreateMissionSystem(
-                game,
-                new FixedRNG(0.01),
-                movement
-            );
-            return system.UpdateMission(mission);
         }
 
         [Test]
@@ -3718,6 +3696,28 @@ namespace Rebellion.Tests.Sectors
                 new FleetSystem(game)
             );
             return (game, planet, spy, captorShip, movement);
+        }
+
+        private void RunOrbitalCaptureMission(
+            GameRoot game,
+            Planet planet,
+            Officer spy,
+            MovementSystem movement
+        )
+        {
+            StubMission mission = new StubMission("empire", planet.InstanceID);
+            SetFoilTable(game, new Dictionary<int, int> { { 0, 100 } });
+            SetEvasionTable(game, new Dictionary<int, int> { { -200, 0 } });
+            DisableCaptureEvasionInjury(game);
+            game.AttachNode(mission, planet);
+            game.MoveNode(spy, mission);
+
+            MissionSystem system = TestSystems.CreateMissionSystem(
+                game,
+                new FixedRNG(0.01),
+                movement
+            );
+            system.UpdateMission(mission);
         }
 
         private (

--- a/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MissionSystemTests.cs
@@ -1193,7 +1193,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_CapturedByOrbitalFleetOverOwnPlanet_BoardsCaptorShip()
+        public void UpdateMission_CapturedByOrbitalFleetOverOwnPlanet_RecordsCapturingShip()
         {
             (
                 GameRoot game,
@@ -1203,7 +1203,7 @@ namespace Rebellion.Tests.Sectors
                 MovementSystem movement
             ) = BuildOrbitalDetectionScene(planetOwnerId: "empire");
 
-            RunOrbitalCaptureMission(game, planet, spy, movement);
+            List<GameResult> results = RunOrbitalCaptureMission(game, planet, spy, movement);
 
             Assert.IsTrue(spy.IsCaptured);
             Assert.AreEqual(
@@ -1213,13 +1213,12 @@ namespace Rebellion.Tests.Sectors
             );
             Assert.AreSame(
                 captorShip,
-                spy.GetParent(),
-                "Captive should be loaded onto the capturing ship, not left on its own planet"
+                results.OfType<OfficerCaptureStateResult>().Single().CapturingUnit
             );
         }
 
         [Test]
-        public void UpdateMission_CapturedByOrbitalFleetOverNeutralPlanet_BoardsCaptorShip()
+        public void UpdateMission_CapturedByOrbitalFleetOverNeutralPlanet_RecordsCapturingShip()
         {
             (
                 GameRoot game,
@@ -1229,13 +1228,13 @@ namespace Rebellion.Tests.Sectors
                 MovementSystem movement
             ) = BuildOrbitalDetectionScene(planetOwnerId: null);
 
-            RunOrbitalCaptureMission(game, planet, spy, movement);
+            List<GameResult> results = RunOrbitalCaptureMission(game, planet, spy, movement);
 
             Assert.IsTrue(spy.IsCaptured);
+            Assert.AreEqual("rebels", spy.CaptorInstanceID);
             Assert.AreSame(
                 captorShip,
-                spy.GetParent(),
-                "Captive should ride the capturing ship off a neutral planet"
+                results.OfType<OfficerCaptureStateResult>().Single().CapturingUnit
             );
         }
 
@@ -3698,7 +3697,7 @@ namespace Rebellion.Tests.Sectors
             return (game, planet, spy, captorShip, movement);
         }
 
-        private void RunOrbitalCaptureMission(
+        private List<GameResult> RunOrbitalCaptureMission(
             GameRoot game,
             Planet planet,
             Officer spy,
@@ -3717,7 +3716,7 @@ namespace Rebellion.Tests.Sectors
                 new FixedRNG(0.01),
                 movement
             );
-            system.UpdateMission(mission);
+            return system.UpdateMission(mission);
         }
 
         private (

--- a/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
@@ -2396,7 +2396,7 @@ namespace Rebellion.Tests.Sectors
                 Planet destination,
                 Officer escort,
                 MovementSystem movement
-            ) = BuildScene();
+            ) = BuildScene(new GameConfig());
             StubMission mission = new StubMission("empire", destination.InstanceID);
             game.AttachNode(mission, destination);
             movement.SendToMission(escort, mission);
@@ -4592,10 +4592,9 @@ namespace Rebellion.Tests.Sectors
             Planet destination,
             Officer officer,
             MovementSystem movement
-        ) BuildScene()
+        ) BuildScene(GameConfig config = null)
         {
-            GameConfig config = TestContent.Data.GameConfig;
-            GameRoot game = new GameRoot(config);
+            GameRoot game = new GameRoot(config ?? TestContent.Data.GameConfig);
 
             Faction empire = new Faction { InstanceID = "empire" };
             game.GetFactions().Add(empire);


### PR DESCRIPTION
## Summary

- Relocates officers captured by an orbital detector from a friendly or neutral mission planet onto the detecting capital ship.
- Keeps captives on a captor-owned planet when that planet can hold them directly.
- Resolves escape guards from the captive's actual planet or fleet custody context instead of the underlying planet owner.
- Defers escape attempts during transit so an escaped officer cannot remain inside an enemy ship.
- Wires `CaptiveSystem` into tick processing; it previously existed without ever running.
- Moves the shared mission test helper into the fixture's helper section and keeps new tests independent of shipped content.

## Validation

- Full Unity EditMode suite: **4,595/4,595 passing**.
- `MissionSystemTests`: **100/100 passing**.
- `CaptiveSystemTests`: **12/12 passing**.
- `GameManagerTests`: **28/28 passing**.
- `GameAssembly.Lint.csproj`: builds with no errors (existing generated-input XML documentation warnings remain).

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [ ] UI builder changes were verified by rebuilding the affected UI.
- [ ] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [ ] Documentation was updated when behavior or setup changed.