### PR TITLE
Use rendered map bounds for strategy windows

### DIFF
--- a/Assets/Scripts/UI/Components/UIWindowManager.cs
+++ b/Assets/Scripts/UI/Components/UIWindowManager.cs
@@ -12,7 +12,7 @@ public sealed class UIWindowManager : MonoBehaviour, ICancelable
     private readonly List<UIWindow> windows = new();
     private UIWindow exclusiveWindow;
     private RectTransform rectTransform;
-    private RectInt? movementBounds;
+    private RectTransform movementBounds;
     private int nextWindowId = 1;
     private IContentAssetSource contentAssets;
 
@@ -66,12 +66,12 @@ public sealed class UIWindowManager : MonoBehaviour, ICancelable
     public UIWindow ActiveWindow { get; private set; }
 
     /// <summary>
-    /// Restricts movable windows to a source-space desktop rectangle.
+    /// Restricts movable windows to an authored desktop region.
     /// </summary>
-    /// <param name="bounds">The allowed source-space movement bounds.</param>
-    public void SetMovementBounds(RectInt bounds)
+    /// <param name="bounds">The transform defining the allowed movement region.</param>
+    public void SetMovementBounds(RectTransform bounds)
     {
-        movementBounds = bounds;
+        movementBounds = bounds ?? throw new ArgumentNullException(nameof(bounds));
     }
 
     /// <summary>
@@ -552,8 +552,8 @@ public sealed class UIWindowManager : MonoBehaviour, ICancelable
     /// <returns>The active movement bounds.</returns>
     private RectInt GetMovementBounds()
     {
-        if (movementBounds.HasValue)
-            return movementBounds.Value;
+        if (movementBounds != null)
+            return UILayout.GetSourceRect(movementBounds);
 
         Vector2Int managerSize = GetSize();
         return new RectInt(0, 0, managerSize.x, managerSize.y);

--- a/Assets/Scripts/UI/Runtime/Themes/StrategyWindowTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/StrategyWindowTheme.cs
@@ -6,8 +6,6 @@ using Rebellion.Util.Serialization;
 [PersistableObject]
 public class StrategyWindowPlacements
 {
-    public SourceRectLayout WindowBounds { get; set; }
-
     public SourcePointLayout SectorLeftPosition { get; set; }
 
     public SourcePointLayout SectorMiddlePosition { get; set; }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -295,7 +295,8 @@ public sealed class StrategyController
         windowPlacementController = new StrategyWindowPlacementController(
             uiContext,
             strategyWindowLayerView,
-            strategyWindowManager
+            strategyWindowManager,
+            galaxyMap.Background
         );
         bool hasModalWindow = strategyWindowManager.HasModalWindow();
         strategyWindowLayerView.RenderModalState(hasModalWindow, hasModalWindow);

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowPlacementController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowPlacementController.cs
@@ -9,6 +9,7 @@ public sealed class StrategyWindowPlacementController
     private readonly UIContext uiContext;
     private readonly StrategyWindowLayerView windowLayer;
     private readonly UIWindowManager windowManager;
+    private readonly RectTransform movementBounds;
 
     /// <summary>
     /// Creates a placement controller for the active presentation context and window layer.
@@ -16,16 +17,20 @@ public sealed class StrategyWindowPlacementController
     /// <param name="uiContext">The active strategy presentation context.</param>
     /// <param name="windowLayer">The authored strategy window layer.</param>
     /// <param name="windowManager">The authoritative strategy-window registry.</param>
+    /// <param name="movementBounds">The authored free-form window movement region.</param>
     public StrategyWindowPlacementController(
         UIContext uiContext,
         StrategyWindowLayerView windowLayer,
-        UIWindowManager windowManager
+        UIWindowManager windowManager,
+        RectTransform movementBounds
     )
     {
         this.uiContext = uiContext ?? throw new ArgumentNullException(nameof(uiContext));
         this.windowLayer = windowLayer ?? throw new ArgumentNullException(nameof(windowLayer));
         this.windowManager =
             windowManager ?? throw new ArgumentNullException(nameof(windowManager));
+        this.movementBounds =
+            movementBounds ?? throw new ArgumentNullException(nameof(movementBounds));
         ApplyMovementBounds();
     }
 
@@ -221,7 +226,7 @@ public sealed class StrategyWindowPlacementController
     /// </summary>
     private void ApplyMovementBounds()
     {
-        windowManager.SetMovementBounds(GetWindowBounds());
+        windowManager.SetMovementBounds(movementBounds);
     }
 
     /// <summary>
@@ -257,13 +262,7 @@ public sealed class StrategyWindowPlacementController
     /// <returns>The validated source-space movement bounds.</returns>
     private RectInt GetWindowBounds()
     {
-        SourceRectLayout bounds = GetPlacements().WindowBounds;
-        if (bounds == null)
-            throw new MissingReferenceException(
-                "StrategyWindowPlacements/WindowBounds is missing."
-            );
-
-        return new RectInt(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+        return UILayout.GetSourceRect(movementBounds);
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Windows/StrategyWindowPlacementControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Windows/StrategyWindowPlacementControllerTests.cs
@@ -15,6 +15,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
 
         private GameObject _rootObject;
         private UIContext _uiContext;
+        private RectTransform _movementBounds;
         private StrategyWindowLayerView _windowLayer;
         private UIWindowManager _windowManager;
         private StrategyWindowPlacements _placements;
@@ -26,12 +27,14 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
             _rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
             _windowLayer = _rootObject.GetComponentInChildren<StrategyWindowLayerView>(true);
             _windowManager = _rootObject.GetComponentInChildren<UIWindowManager>(true);
+            _movementBounds = _rootObject.GetComponentInChildren<GalaxyMapView>(true).Background;
             _uiContext = CreateContext();
             _placements = _uiContext.GetPlayerFactionTheme().StrategyWindowPlacements;
             _controller = new StrategyWindowPlacementController(
                 _uiContext,
                 _windowLayer,
-                _windowManager
+                _windowManager,
+                _movementBounds
             );
         }
 
@@ -46,20 +49,43 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
         public void Constructor_NullDependency_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyWindowPlacementController(null, _windowLayer, _windowManager)
+                new StrategyWindowPlacementController(
+                    null,
+                    _windowLayer,
+                    _windowManager,
+                    _movementBounds
+                )
             );
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyWindowPlacementController(_uiContext, null, _windowManager)
+                new StrategyWindowPlacementController(
+                    _uiContext,
+                    null,
+                    _windowManager,
+                    _movementBounds
+                )
             );
             Assert.Throws<ArgumentNullException>(() =>
-                new StrategyWindowPlacementController(_uiContext, _windowLayer, null)
+                new StrategyWindowPlacementController(
+                    _uiContext,
+                    _windowLayer,
+                    null,
+                    _movementBounds
+                )
+            );
+            Assert.Throws<ArgumentNullException>(() =>
+                new StrategyWindowPlacementController(
+                    _uiContext,
+                    _windowLayer,
+                    _windowManager,
+                    null
+                )
             );
         }
 
         [Test]
-        public void Constructor_ConfiguredBounds_AppliesMovementBoundsToManager()
+        public void Constructor_AuthoredMovementBounds_AppliesMovementBoundsToManager()
         {
-            SourceRectLayout bounds = _placements.WindowBounds;
+            RectInt bounds = UILayout.GetSourceRect(_movementBounds);
             Vector2Int windowSize = new Vector2Int(100, 80);
 
             Vector2Int minimum = _windowManager.ClampPosition(
@@ -73,11 +99,8 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
                 windowSize
             );
 
-            Assert.AreEqual(new Vector2Int(bounds.X, bounds.Y), minimum);
-            Assert.AreEqual(
-                new Vector2Int(bounds.X + bounds.Width - 100, bounds.Y + bounds.Height - 80),
-                maximum
-            );
+            Assert.AreEqual(new Vector2Int(bounds.x, bounds.y), minimum);
+            Assert.AreEqual(new Vector2Int(bounds.xMax - 100, bounds.yMax - 80), maximum);
         }
 
         [Test]
@@ -98,6 +121,27 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 _controller.GetSectorWindowPosition(-1)
             );
+        }
+
+        [Test]
+        public void MovementBounds_AuthoredRegionChanges_UsesCurrentBounds()
+        {
+            UILayout.SetSourceRect(_movementBounds, 123, 43, 693, 348);
+            Vector2Int windowSize = new Vector2Int(235, 304);
+
+            Vector2Int minimum = _windowManager.ClampPosition(
+                int.MinValue,
+                int.MinValue,
+                windowSize
+            );
+            Vector2Int maximum = _windowManager.ClampPosition(
+                int.MaxValue,
+                int.MaxValue,
+                windowSize
+            );
+
+            Assert.AreEqual(new Vector2Int(123, 43), minimum);
+            Assert.AreEqual(new Vector2Int(581, 87), maximum);
         }
 
         [Test]
@@ -227,22 +271,19 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
 
         private Vector2Int GetCenteredPosition(MonoBehaviour prefab)
         {
-            SourceRectLayout bounds = _placements.WindowBounds;
+            RectInt bounds = UILayout.GetSourceRect(_movementBounds);
             Vector2Int size = _windowLayer.GetWindowSize(prefab);
             return new Vector2Int(
-                bounds.X + Mathf.RoundToInt((bounds.Width - size.x) / 2f),
-                bounds.Y + Mathf.RoundToInt((bounds.Height - size.y) / 2f)
+                bounds.x + Mathf.RoundToInt((bounds.width - size.x) / 2f),
+                bounds.y + Mathf.RoundToInt((bounds.height - size.y) / 2f)
             );
         }
 
         private Vector2Int GetMaximumPosition(MonoBehaviour prefab)
         {
-            SourceRectLayout bounds = _placements.WindowBounds;
+            RectInt bounds = UILayout.GetSourceRect(_movementBounds);
             Vector2Int size = _windowLayer.GetWindowSize(prefab);
-            return new Vector2Int(
-                bounds.X + bounds.Width - size.x,
-                bounds.Y + bounds.Height - size.y
-            );
+            return new Vector2Int(bounds.xMax - size.x, bounds.yMax - size.y);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Derive strategy-window movement limits from the rendered galaxy-map background.
- Keep clamping synchronized when the authored viewport changes.
- Remove the redundant window-bounds field from the runtime theme model.
- Verify live RectTransform changes affect minimum and maximum window positions.

## Validation

- `dotnet build GameAssembly.csproj --no-restore --nologo --verbosity quiet` (passes)
- `./build.sh format` (passes)
- Unity EditMode tests could not run because this project is currently open in another Unity Editor instance.
- Paired `rebellion2-media` XML lint and schema validation (passes).

## Checklist

- [ ] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [ ] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.