### PR TITLE
Fixing window screen bounds for Empire.

### DIFF
--- a/Assets/Scripts/UI/Components/UIWindowManager.cs
+++ b/Assets/Scripts/UI/Components/UIWindowManager.cs
@@ -130,7 +130,7 @@ public sealed class UIWindowManager : MonoBehaviour, ICancelable
 
         UIWindow window = GetRequiredWindowShell(view);
         window.SetContent(view);
-        if (ShouldClampInitialPosition(modal, canMove))
+        if (canMove)
         {
             Vector2Int position = ClampPosition(x, y, size);
             x = position.x;
@@ -710,17 +710,6 @@ public sealed class UIWindowManager : MonoBehaviour, ICancelable
             throw new MissingReferenceException($"{view.name} is missing UIWindow.");
 
         return window;
-    }
-
-    /// <summary>
-    /// Determines whether initial placement must stay within configured movement bounds.
-    /// </summary>
-    /// <param name="modal">Whether the window is modal.</param>
-    /// <param name="canMove">Whether the window may move after opening.</param>
-    /// <returns>True when the initial position must be clamped.</returns>
-    private static bool ShouldClampInitialPosition(bool modal, bool canMove)
-    {
-        return canMove || !modal;
     }
 
     /// <summary>

--- a/Assets/Tests/EditMode/GameTests/UI/Components/UIWindowManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/Components/UIWindowManagerTests.cs
@@ -265,6 +265,30 @@ namespace Rebellion.Tests.UI.Components
         }
 
         [Test]
+        public void CreateWindow_ImmovableModelessWindow_PreservesAuthoredPosition()
+        {
+            UIWindowManager windowManager = CreateWindowManager();
+            windowManager.SetMovementBounds(new RectInt(100, 100, 200, 200));
+            TestContent prefab = CreateWindowPrefab<TestContent>();
+
+            UIWindow window = windowManager.CreateWindow(
+                prefab,
+                windowManager.transform,
+                "FixedWindow",
+                500,
+                400,
+                new Vector2Int(100, 80),
+                false,
+                false,
+                false,
+                false,
+                out TestContent _
+            );
+
+            Assert.AreEqual(new Vector2Int(500, 400), new Vector2Int(window.X, window.Y));
+        }
+
+        [Test]
         public void ForEachWindow_MixedContent_VisitsMatchingWindowsOnly()
         {
             UIWindowManager windowManager = CreateWindowManager();

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowControllerTests.cs
@@ -126,12 +126,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
         {
             bool opened = _controller.Open(_sector);
             PlanetSectorWindowView view = GetOpenView(out UIWindow window);
-            Vector2Int requestedPosition = GetWindowPosition(SectorWindowPositions.Left);
-            Vector2Int expectedPosition = _windowManager.ClampPosition(
-                requestedPosition.x,
-                requestedPosition.y,
-                _windowLayer.GetWindowSize(_windowLayer.PlanetSectorWindowPrefab)
-            );
+            Vector2Int expectedPosition = GetWindowPosition(SectorWindowPositions.Left);
 
             Assert.IsTrue(opened);
             Assert.AreEqual($"PlanetSectorWindow-{_planetSector.GetDisplayName()}", view.name);

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Windows/StrategyWindowPlacementControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Windows/StrategyWindowPlacementControllerTests.cs
@@ -93,6 +93,18 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
         }
 
         [Test]
+        public void GetSectorWindowPosition_ConfiguredSlots_DoNotOverlap()
+        {
+            int windowWidth = _windowLayer.GetWindowSize(_windowLayer.PlanetSectorWindowPrefab).x;
+            Vector2Int left = _controller.GetSectorWindowPosition(SectorWindowPositions.Left);
+            Vector2Int middle = _controller.GetSectorWindowPosition(SectorWindowPositions.Middle);
+            Vector2Int right = _controller.GetSectorWindowPosition(SectorWindowPositions.Right);
+
+            Assert.GreaterOrEqual(middle.x, left.x + windowWidth);
+            Assert.GreaterOrEqual(right.x, middle.x + windowWidth);
+        }
+
+        [Test]
         public void GetSectorWindowPosition_UnknownSlot_ThrowsArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>


### PR DESCRIPTION
## Summary

- Clamping initial window placement only for movable windows so fixed modeless planet-sector windows retain their authored positions
- Updating regression coverage for fixed placement and non-overlapping sector slots

## Validation

- Passing 50 Unity EditMode tests with 0 failures
- Passing `dotnet build GameAssembly.csproj --no-restore`
- Passing `dotnet csharpier check` on all changed files
- Passing `git diff --check`

## Checklist

- [x] Passing relevant automated tests
- [x] Reviewing AI-assisted code
- [x] Verifying affected UI through the UI builder
- [x] Including applicable content changes in `rebellion2-media`
- [x] Excluding generated UI prefabs, generated scenes, and copyrighted game assets
- [x] Updating applicable documentation
