### PR TITLE
Adding advisor responses for "manage" commands and upscaling combat images.

### DIFF
--- a/Assets/Scripts/Managers/AudioManager.cs
+++ b/Assets/Scripts/Managers/AudioManager.cs
@@ -165,6 +165,24 @@ public sealed class AudioManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Releases independently controlled sound effects after playback finishes.
+    /// </summary>
+    private void Update()
+    {
+        foreach (AudioPlaybackHandle playback in _activeSfxPlaybacks.ToArray())
+        {
+            if (
+                playback.LoadCoroutine != null
+                || playback.Paused
+                || playback.Source?.isPlaying == true
+            )
+                continue;
+
+            StopPlayback(playback);
+        }
+    }
+
+    /// <summary>
     /// Clears the singleton reference when Unity destroys the active manager.
     /// </summary>
     private void OnDestroy()

--- a/Assets/Scripts/Managers/AudioManager.cs
+++ b/Assets/Scripts/Managers/AudioManager.cs
@@ -479,6 +479,24 @@ public sealed class AudioManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Gets the duration of a sound effect already held by the audio manager.
+    /// </summary>
+    /// <param name="resourcePath">The content address for the sound effect clip.</param>
+    /// <returns>The loaded clip duration, or zero when the path is blank or not loaded.</returns>
+    internal float GetLoadedSfxDuration(string resourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(resourcePath))
+            return 0f;
+
+        string normalizedPath = resourcePath.Trim();
+        if (_preloadedSfx.TryGetValue(normalizedPath, out AudioClip preloadedClip))
+            return preloadedClip.length;
+        return _loadedSfx.TryGetValue(normalizedPath, out AudioClip loadedClip)
+            ? loadedClip.length
+            : 0f;
+    }
+
+    /// <summary>
     /// Stops sound-effect playback immediately.
     /// </summary>
     public void StopSfx()

--- a/Assets/Scripts/Managers/AudioPlaybackHandle.cs
+++ b/Assets/Scripts/Managers/AudioPlaybackHandle.cs
@@ -7,8 +7,6 @@ public sealed class AudioPlaybackHandle
 {
     private AudioManager _owner;
 
-    internal bool IsActive => _owner != null;
-
     internal Coroutine LoadCoroutine { get; set; }
 
     internal bool Paused { get; set; }

--- a/Assets/Scripts/Managers/AudioPlaybackHandle.cs
+++ b/Assets/Scripts/Managers/AudioPlaybackHandle.cs
@@ -7,6 +7,8 @@ public sealed class AudioPlaybackHandle
 {
     private AudioManager _owner;
 
+    internal bool IsActive => _owner != null;
+
     internal Coroutine LoadCoroutine { get; set; }
 
     internal bool Paused { get; set; }

--- a/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
+++ b/Assets/Scripts/UI/Runtime/Themes/StrategyAdvisorTheme.cs
@@ -222,6 +222,14 @@ public class StrategyAdvisorTheme
 
     public int RepeatCooldownTicks { get; set; }
 
+    public StrategyAdvisorAnimationTheme PlanetaryGarrisonManagementEnabled { get; set; }
+
+    public StrategyAdvisorAnimationTheme PlanetaryGarrisonManagementDisabled { get; set; }
+
+    public StrategyAdvisorAnimationTheme ResourceProductionManagementEnabled { get; set; }
+
+    public StrategyAdvisorAnimationTheme ResourceProductionManagementDisabled { get; set; }
+
     public StrategyAdvisorAnimationTheme InvalidOrderRejected { get; set; }
 
     public StrategyAdvisorAnimationTheme InTransitOrderRejected { get; set; }

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -18,6 +18,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private readonly Func<Faction> getPlayerFaction;
     private readonly Func<string, Texture2D> getTexture;
     private readonly Action<string> playSfx;
+    private readonly Func<string, AudioPlaybackHandle> playSfxInstance;
     private readonly Func<int, int> selectRandomIndex;
     private readonly Dictionary<string, StrategyAdvisorNotificationTheme> pendingNotifications =
         new Dictionary<string, StrategyAdvisorNotificationTheme>();
@@ -28,6 +29,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private IStrategyHudActions actions;
     private StrategyAdvisorTheme theme;
     private StrategyAdvisorView view;
+    private AudioPlaybackHandle activeAudioPlayback;
     private Action playbackCompleted;
     private Action playbackStarted;
 
@@ -38,17 +40,20 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <param name="getTexture">Resolves a texture from a configured resource path.</param>
     /// <param name="playSfx">Plays a strategy sound-effect path.</param>
     /// <param name="selectRandomIndex">Selects a zero-based index below the supplied count.</param>
+    /// <param name="playSfxInstance">Plays an independently stoppable advisor response.</param>
     public StrategyAdvisorController(
         Func<Faction> getPlayerFaction,
         Func<string, Texture2D> getTexture,
         Action<string> playSfx,
-        Func<int, int> selectRandomIndex = null
+        Func<int, int> selectRandomIndex = null,
+        Func<string, AudioPlaybackHandle> playSfxInstance = null
     )
     {
         this.getPlayerFaction =
             getPlayerFaction ?? throw new ArgumentNullException(nameof(getPlayerFaction));
         this.getTexture = getTexture ?? throw new ArgumentNullException(nameof(getTexture));
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
+        this.playSfxInstance = playSfxInstance;
         this.selectRandomIndex = selectRandomIndex ?? (count => UnityEngine.Random.Range(0, count));
     }
 
@@ -336,6 +341,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         StrategyAdvisorView targetView = GetRequiredView();
         playbackStarted = null;
         playbackCompleted = null;
+        StopActiveAudioPlayback();
         targetView.CancelPlayback();
 
         if (animation == null || animation.Frames.Count == 0)
@@ -356,6 +362,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     {
         playbackStarted = null;
         playbackCompleted = null;
+        StopActiveAudioPlayback();
         GetRequiredView().CancelPlayback();
     }
 
@@ -396,6 +403,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         nextAllowedTicks.Clear();
         playbackStarted = null;
         playbackCompleted = null;
+        StopActiveAudioPlayback();
         view?.ResetPlayback();
     }
 
@@ -757,8 +765,13 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         Action started = playbackStarted;
         playbackStarted = null;
         started?.Invoke();
+        StopActiveAudioPlayback();
 
-        if (!string.IsNullOrEmpty(animation?.AudioPath))
+        if (string.IsNullOrEmpty(animation?.AudioPath))
+            return;
+
+        activeAudioPlayback = playSfxInstance?.Invoke(animation.AudioPath);
+        if (playSfxInstance == null)
             playSfx(animation.AudioPath);
     }
 
@@ -934,6 +947,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// </summary>
     private void ReleaseView()
     {
+        StopActiveAudioPlayback();
         if (ReferenceEquals(view, null))
             return;
 
@@ -944,6 +958,15 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         view.PlaybackStarted -= HandlePlaybackStarted;
         view.ProtocolContextRequested -= HandleProtocolContextRequested;
         view = null;
+    }
+
+    /// <summary>
+    /// Stops the active advisor response without affecting unrelated sound effects.
+    /// </summary>
+    private void StopActiveAudioPlayback()
+    {
+        activeAudioPlayback?.Stop();
+        activeAudioPlayback = null;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -20,8 +20,6 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private readonly Action<string> playSfx;
     private readonly Func<string, AudioPlaybackHandle> playSfxInstance;
     private readonly Func<int, int> selectRandomIndex;
-    private readonly List<AudioPlaybackHandle> activeAudioPlaybacks =
-        new List<AudioPlaybackHandle>();
     private readonly Dictionary<string, StrategyAdvisorNotificationTheme> pendingNotifications =
         new Dictionary<string, StrategyAdvisorNotificationTheme>();
     private readonly Dictionary<string, int> pendingExpirationTicks = new Dictionary<string, int>();
@@ -31,6 +29,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private IStrategyHudActions actions;
     private StrategyAdvisorTheme theme;
     private StrategyAdvisorView view;
+    private AudioPlaybackHandle activeAudioPlayback;
     private Action playbackCompleted;
     private Action playbackStarted;
 
@@ -342,7 +341,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         StrategyAdvisorView targetView = GetRequiredView();
         playbackStarted = null;
         playbackCompleted = null;
-        StopActiveAudioPlaybacks();
+        StopActiveAudioPlayback();
         targetView.CancelPlayback();
 
         if (animation == null || animation.Frames.Count == 0)
@@ -363,7 +362,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     {
         playbackStarted = null;
         playbackCompleted = null;
-        StopActiveAudioPlaybacks();
+        StopActiveAudioPlayback();
         GetRequiredView().CancelPlayback();
     }
 
@@ -404,7 +403,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         nextAllowedTicks.Clear();
         playbackStarted = null;
         playbackCompleted = null;
-        StopActiveAudioPlaybacks();
+        StopActiveAudioPlayback();
         view?.ResetPlayback();
     }
 
@@ -766,13 +765,11 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         Action started = playbackStarted;
         playbackStarted = null;
         started?.Invoke();
+        StopActiveAudioPlayback();
         if (string.IsNullOrEmpty(animation?.AudioPath))
             return;
 
-        activeAudioPlaybacks.RemoveAll(playback => playback?.IsActive != true);
-        AudioPlaybackHandle playback = playSfxInstance?.Invoke(animation.AudioPath);
-        if (playback != null)
-            activeAudioPlaybacks.Add(playback);
+        activeAudioPlayback = playSfxInstance?.Invoke(animation.AudioPath);
         if (playSfxInstance == null)
             playSfx(animation.AudioPath);
     }
@@ -949,7 +946,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// </summary>
     private void ReleaseView()
     {
-        StopActiveAudioPlaybacks();
+        StopActiveAudioPlayback();
         if (ReferenceEquals(view, null))
             return;
 
@@ -965,11 +962,10 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <summary>
     /// Stops the active advisor response without affecting unrelated sound effects.
     /// </summary>
-    private void StopActiveAudioPlaybacks()
+    private void StopActiveAudioPlayback()
     {
-        for (int i = 0; i < activeAudioPlaybacks.Count; i++)
-            activeAudioPlaybacks[i]?.Stop();
-        activeAudioPlaybacks.Clear();
+        activeAudioPlayback?.Stop();
+        activeAudioPlayback = null;
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -20,6 +20,8 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private readonly Action<string> playSfx;
     private readonly Func<string, AudioPlaybackHandle> playSfxInstance;
     private readonly Func<int, int> selectRandomIndex;
+    private readonly List<AudioPlaybackHandle> activeAudioPlaybacks =
+        new List<AudioPlaybackHandle>();
     private readonly Dictionary<string, StrategyAdvisorNotificationTheme> pendingNotifications =
         new Dictionary<string, StrategyAdvisorNotificationTheme>();
     private readonly Dictionary<string, int> pendingExpirationTicks = new Dictionary<string, int>();
@@ -29,7 +31,6 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private IStrategyHudActions actions;
     private StrategyAdvisorTheme theme;
     private StrategyAdvisorView view;
-    private AudioPlaybackHandle activeAudioPlayback;
     private Action playbackCompleted;
     private Action playbackStarted;
 
@@ -341,7 +342,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         StrategyAdvisorView targetView = GetRequiredView();
         playbackStarted = null;
         playbackCompleted = null;
-        StopActiveAudioPlayback();
+        StopActiveAudioPlaybacks();
         targetView.CancelPlayback();
 
         if (animation == null || animation.Frames.Count == 0)
@@ -362,7 +363,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     {
         playbackStarted = null;
         playbackCompleted = null;
-        StopActiveAudioPlayback();
+        StopActiveAudioPlaybacks();
         GetRequiredView().CancelPlayback();
     }
 
@@ -403,7 +404,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         nextAllowedTicks.Clear();
         playbackStarted = null;
         playbackCompleted = null;
-        StopActiveAudioPlayback();
+        StopActiveAudioPlaybacks();
         view?.ResetPlayback();
     }
 
@@ -765,12 +766,13 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         Action started = playbackStarted;
         playbackStarted = null;
         started?.Invoke();
-        StopActiveAudioPlayback();
-
         if (string.IsNullOrEmpty(animation?.AudioPath))
             return;
 
-        activeAudioPlayback = playSfxInstance?.Invoke(animation.AudioPath);
+        activeAudioPlaybacks.RemoveAll(playback => playback?.IsActive != true);
+        AudioPlaybackHandle playback = playSfxInstance?.Invoke(animation.AudioPath);
+        if (playback != null)
+            activeAudioPlaybacks.Add(playback);
         if (playSfxInstance == null)
             playSfx(animation.AudioPath);
     }
@@ -947,7 +949,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// </summary>
     private void ReleaseView()
     {
-        StopActiveAudioPlayback();
+        StopActiveAudioPlaybacks();
         if (ReferenceEquals(view, null))
             return;
 
@@ -963,10 +965,11 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <summary>
     /// Stops the active advisor response without affecting unrelated sound effects.
     /// </summary>
-    private void StopActiveAudioPlayback()
+    private void StopActiveAudioPlaybacks()
     {
-        activeAudioPlayback?.Stop();
-        activeAudioPlayback = null;
+        for (int i = 0; i < activeAudioPlaybacks.Count; i++)
+            activeAudioPlaybacks[i]?.Stop();
+        activeAudioPlaybacks.Clear();
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -280,7 +280,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// </summary>
     public void PlayInTransitOrderRejected()
     {
-        PlayOrderRejected(theme?.InTransitOrderRejected);
+        PlayResponse(theme?.InTransitOrderRejected);
     }
 
     /// <summary>
@@ -288,7 +288,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// </summary>
     public void PlayInvalidOrderRejected()
     {
-        PlayOrderRejected(theme?.InvalidOrderRejected);
+        PlayResponse(theme?.InvalidOrderRejected);
     }
 
     /// <summary>
@@ -296,14 +296,14 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// </summary>
     public void PlayUnitUnderConstructionOrderRejected()
     {
-        PlayOrderRejected(theme?.UnitUnderConstructionOrderRejected);
+        PlayResponse(theme?.UnitUnderConstructionOrderRejected);
     }
 
     /// <summary>
-    /// Resolves and immediately plays one authored order-rejection response.
+    /// Resolves and immediately plays one authored advisor response.
     /// </summary>
-    /// <param name="animationTheme">The rejection animation and audio.</param>
-    private void PlayOrderRejected(StrategyAdvisorAnimationTheme animationTheme)
+    /// <param name="animationTheme">The response animation and audio.</param>
+    private void PlayResponse(StrategyAdvisorAnimationTheme animationTheme)
     {
         List<StrategyAdvisorAnimationViewData> playbacks =
             new List<StrategyAdvisorAnimationViewData>();
@@ -600,11 +600,21 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
                 faction.ManageGarrisons = !faction.ManageGarrisons;
                 if (faction.ManageGarrisons)
                     actions.ProcessAdvisorAutomation(faction);
+                PlayResponse(
+                    faction.ManageGarrisons
+                        ? theme?.PlanetaryGarrisonManagementEnabled
+                        : theme?.PlanetaryGarrisonManagementDisabled
+                );
                 break;
             case StrategyMenuAction.AdvisorManageProduction:
                 faction.ManageProduction = !faction.ManageProduction;
                 if (faction.ManageProduction)
                     actions.ProcessAdvisorAutomation(faction);
+                PlayResponse(
+                    faction.ManageProduction
+                        ? theme?.ResourceProductionManagementEnabled
+                        : theme?.ResourceProductionManagementDisabled
+                );
                 break;
             case StrategyMenuAction.AdvisorManageNaming:
                 faction.ManageNaming = !faction.ManageNaming;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -21,6 +21,8 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private readonly Action<string> playSfx;
     private readonly Func<string, AudioPlaybackHandle> playSfxInstance;
     private readonly Func<int, int> selectRandomIndex;
+    private readonly List<AudioPlaybackHandle> activeAudioPlaybacks =
+        new List<AudioPlaybackHandle>();
     private readonly Dictionary<string, StrategyAdvisorNotificationTheme> pendingNotifications =
         new Dictionary<string, StrategyAdvisorNotificationTheme>();
     private readonly Dictionary<string, int> pendingExpirationTicks = new Dictionary<string, int>();
@@ -30,7 +32,6 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private IStrategyHudActions actions;
     private StrategyAdvisorTheme theme;
     private StrategyAdvisorView view;
-    private AudioPlaybackHandle activeAudioPlayback;
     private Action playbackCompleted;
     private Action playbackStarted;
 
@@ -345,7 +346,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         StrategyAdvisorView targetView = GetRequiredView();
         playbackStarted = null;
         playbackCompleted = null;
-        StopActiveAudioPlayback();
+        StopActiveAudioPlaybacks();
         targetView.CancelPlayback();
 
         if (animation == null || animation.Frames.Count == 0)
@@ -366,7 +367,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     {
         playbackStarted = null;
         playbackCompleted = null;
-        StopActiveAudioPlayback();
+        StopActiveAudioPlaybacks();
         GetRequiredView().CancelPlayback();
     }
 
@@ -407,7 +408,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         nextAllowedTicks.Clear();
         playbackStarted = null;
         playbackCompleted = null;
-        StopActiveAudioPlayback();
+        StopActiveAudioPlaybacks();
         view?.ResetPlayback();
     }
 
@@ -775,11 +776,13 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         Action started = playbackStarted;
         playbackStarted = null;
         started?.Invoke();
-        StopActiveAudioPlayback();
         if (string.IsNullOrEmpty(animation?.AudioPath))
             return;
 
-        activeAudioPlayback = playSfxInstance?.Invoke(animation.AudioPath);
+        activeAudioPlaybacks.RemoveAll(playback => playback?.IsActive != true);
+        AudioPlaybackHandle playback = playSfxInstance?.Invoke(animation.AudioPath);
+        if (playback != null)
+            activeAudioPlaybacks.Add(playback);
         if (playSfxInstance == null)
             playSfx(animation.AudioPath);
     }
@@ -956,7 +959,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// </summary>
     private void ReleaseView()
     {
-        StopActiveAudioPlayback();
+        StopActiveAudioPlaybacks();
         if (ReferenceEquals(view, null))
             return;
 
@@ -972,10 +975,11 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <summary>
     /// Stops the active advisor response without affecting unrelated sound effects.
     /// </summary>
-    private void StopActiveAudioPlayback()
+    private void StopActiveAudioPlaybacks()
     {
-        activeAudioPlayback?.Stop();
-        activeAudioPlayback = null;
+        for (int i = 0; i < activeAudioPlaybacks.Count; i++)
+            activeAudioPlaybacks[i]?.Stop();
+        activeAudioPlaybacks.Clear();
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyAdvisorController.cs
@@ -16,6 +16,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     private const string _customNotificationKey = "Notification:Custom";
 
     private readonly Func<Faction> getPlayerFaction;
+    private readonly Func<string, float> getAudioDuration;
     private readonly Func<string, Texture2D> getTexture;
     private readonly Action<string> playSfx;
     private readonly Func<string, AudioPlaybackHandle> playSfxInstance;
@@ -41,12 +42,14 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
     /// <param name="playSfx">Plays a strategy sound-effect path.</param>
     /// <param name="selectRandomIndex">Selects a zero-based index below the supplied count.</param>
     /// <param name="playSfxInstance">Plays an independently stoppable advisor response.</param>
+    /// <param name="getAudioDuration">Gets the duration of a loaded advisor response.</param>
     public StrategyAdvisorController(
         Func<Faction> getPlayerFaction,
         Func<string, Texture2D> getTexture,
         Action<string> playSfx,
         Func<int, int> selectRandomIndex = null,
-        Func<string, AudioPlaybackHandle> playSfxInstance = null
+        Func<string, AudioPlaybackHandle> playSfxInstance = null,
+        Func<string, float> getAudioDuration = null
     )
     {
         this.getPlayerFaction =
@@ -54,6 +57,7 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         this.getTexture = getTexture ?? throw new ArgumentNullException(nameof(getTexture));
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
         this.playSfxInstance = playSfxInstance;
+        this.getAudioDuration = getAudioDuration ?? (_ => 0f);
         this.selectRandomIndex = selectRandomIndex ?? (count => UnityEngine.Random.Range(0, count));
     }
 
@@ -720,14 +724,20 @@ public sealed class StrategyAdvisorController : IContextMenuReceiver
         if (!ready)
             return false;
 
+        string audioPath =
+            !string.IsNullOrWhiteSpace(animation.AudioPath) ? animation.AudioPath
+            : string.IsNullOrWhiteSpace(audio ?? animation.Audio) ? null
+            : theme.GetAudioPath(audio ?? animation.Audio);
+        float minimumPlaybackSeconds = string.IsNullOrEmpty(audioPath)
+            ? 0f
+            : getAudioDuration(audioPath);
         playbacks.Add(
             new StrategyAdvisorAnimationViewData(
                 frames,
                 usesDroid,
-                !string.IsNullOrWhiteSpace(animation.AudioPath) ? animation.AudioPath
-                    : string.IsNullOrWhiteSpace(audio ?? animation.Audio) ? null
-                    : theme.GetAudioPath(audio ?? animation.Audio),
-                animation.DelayBeforeSeconds
+                audioPath,
+                animation.DelayBeforeSeconds,
+                minimumPlaybackSeconds
             )
         );
         return true;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
@@ -27,12 +27,14 @@ public sealed class StrategyHudController : IContextMenuReceiver
     /// <param name="getTexture">Resolves a texture from a configured resource path.</param>
     /// <param name="playSfx">Plays a strategy sound-effect path.</param>
     /// <param name="playSfxInstance">Plays an independently stoppable advisor response.</param>
+    /// <param name="getAudioDuration">Gets the duration of a loaded advisor response.</param>
     public StrategyHudController(
         Func<Faction> getPlayerFaction,
         Func<FactionTheme> getPlayerTheme,
         Func<string, Texture2D> getTexture,
         Action<string> playSfx,
-        Func<string, AudioPlaybackHandle> playSfxInstance = null
+        Func<string, AudioPlaybackHandle> playSfxInstance = null,
+        Func<string, float> getAudioDuration = null
     )
     {
         if (getPlayerFaction == null)
@@ -46,7 +48,8 @@ public sealed class StrategyHudController : IContextMenuReceiver
             getPlayerFaction,
             getTexture,
             playSfx,
-            playSfxInstance: playSfxInstance
+            playSfxInstance: playSfxInstance,
+            getAudioDuration: getAudioDuration
         );
     }
 

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
@@ -26,11 +26,13 @@ public sealed class StrategyHudController : IContextMenuReceiver
     /// <param name="getPlayerTheme">Returns the current player faction theme.</param>
     /// <param name="getTexture">Resolves a texture from a configured resource path.</param>
     /// <param name="playSfx">Plays a strategy sound-effect path.</param>
+    /// <param name="playSfxInstance">Plays an independently stoppable advisor response.</param>
     public StrategyHudController(
         Func<Faction> getPlayerFaction,
         Func<FactionTheme> getPlayerTheme,
         Func<string, Texture2D> getTexture,
-        Action<string> playSfx
+        Action<string> playSfx,
+        Func<string, AudioPlaybackHandle> playSfxInstance = null
     )
     {
         if (getPlayerFaction == null)
@@ -40,7 +42,12 @@ public sealed class StrategyHudController : IContextMenuReceiver
             getPlayerTheme ?? throw new ArgumentNullException(nameof(getPlayerTheme));
         this.getTexture = getTexture ?? throw new ArgumentNullException(nameof(getTexture));
         this.playSfx = playSfx ?? throw new ArgumentNullException(nameof(playSfx));
-        advisorController = new StrategyAdvisorController(getPlayerFaction, getTexture, playSfx);
+        advisorController = new StrategyAdvisorController(
+            getPlayerFaction,
+            getTexture,
+            playSfx,
+            playSfxInstance: playSfxInstance
+        );
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -239,7 +239,8 @@ public sealed class StrategyController
             () => gameManager?.GetPlayerFaction(),
             () => uiContext?.GetPlayerFactionTheme(),
             path => uiContext?.GetTexture(path),
-            PlaySfx
+            PlaySfx,
+            PlaySfxInstance
         );
         strategyHudController.Initialize(this);
         strategyHudController.BindView(strategyHud);
@@ -659,6 +660,16 @@ public sealed class StrategyController
     private static void PlaySfx(string resourcePath)
     {
         AudioManager.EnsureExists().PlaySfx(resourcePath);
+    }
+
+    /// <summary>
+    /// Plays an independently stoppable strategy sound effect through the shared audio manager.
+    /// </summary>
+    /// <param name="resourcePath">The content address of the sound effect.</param>
+    /// <returns>The playback handle, or null when the path is blank.</returns>
+    private static AudioPlaybackHandle PlaySfxInstance(string resourcePath)
+    {
+        return AudioManager.EnsureExists().PlaySfxInstance(resourcePath);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Screen/StrategyController.cs
@@ -240,7 +240,8 @@ public sealed class StrategyController
             () => uiContext?.GetPlayerFactionTheme(),
             path => uiContext?.GetTexture(path),
             PlaySfx,
-            PlaySfxInstance
+            PlaySfxInstance,
+            audioManager.GetLoadedSfxDuration
         );
         strategyHudController.Initialize(this);
         strategyHudController.BindView(strategyHud);

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -98,10 +98,40 @@ internal static class StrategyUISoundPaths
         };
         foreach (StrategyAdvisorAnimationTheme response in responses)
         {
-            string path = GetAdvisorAnimationAudioPath(advisor, response);
-            if (!string.IsNullOrWhiteSpace(path))
+            foreach (string path in GetAdvisorAnimationAudioPaths(advisor, response))
                 yield return path;
         }
+    }
+
+    /// <summary>
+    /// Returns every selectable audio path configured for one advisor animation.
+    /// </summary>
+    /// <param name="advisor">The owning advisor theme.</param>
+    /// <param name="animation">The configured advisor animation.</param>
+    /// <returns>The resolved audio paths.</returns>
+    private static IEnumerable<string> GetAdvisorAnimationAudioPaths(
+        StrategyAdvisorTheme advisor,
+        StrategyAdvisorAnimationTheme animation
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(animation?.AudioPath))
+        {
+            yield return animation.AudioPath.Trim();
+            yield break;
+        }
+
+        if (animation?.AudioOptions?.Count > 0)
+        {
+            foreach (string audio in animation.AudioOptions)
+            {
+                if (!string.IsNullOrWhiteSpace(audio))
+                    yield return advisor.GetAudioPath(audio.Trim());
+            }
+            yield break;
+        }
+
+        if (!string.IsNullOrWhiteSpace(animation?.Audio))
+            yield return advisor.GetAudioPath(animation.Audio.Trim());
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -38,6 +38,8 @@ internal static class StrategyUISoundPaths
 
         foreach (string path in GetPlanetaryAssaultAdvisorAudioPaths(theme?.StrategyAdvisor))
             yield return path;
+        foreach (string path in GetAdvisorManagementAudioPaths(theme?.StrategyAdvisor))
+            yield return path;
 
         StrategyWindowSoundTheme windowSounds = theme?.StrategyWindowSounds;
         ConfirmDialogTheme confirmDialog = theme?.ConfirmDialogTheme;
@@ -78,6 +80,30 @@ internal static class StrategyUISoundPaths
             yield return droidPath;
         if (!string.IsNullOrWhiteSpace(protocolPath))
             yield return protocolPath;
+    }
+
+    /// <summary>
+    /// Returns the configured protocol-advisor responses for management toggles.
+    /// </summary>
+    /// <param name="advisor">The active faction advisor theme.</param>
+    /// <returns>The management response audio paths.</returns>
+    private static IEnumerable<string> GetAdvisorManagementAudioPaths(
+        StrategyAdvisorTheme advisor
+    )
+    {
+        StrategyAdvisorAnimationTheme[] responses =
+        {
+            advisor?.PlanetaryGarrisonManagementEnabled,
+            advisor?.PlanetaryGarrisonManagementDisabled,
+            advisor?.ResourceProductionManagementEnabled,
+            advisor?.ResourceProductionManagementDisabled,
+        };
+        foreach (StrategyAdvisorAnimationTheme response in responses)
+        {
+            string path = GetAdvisorAnimationAudioPath(advisor, response);
+            if (!string.IsNullOrWhiteSpace(path))
+                yield return path;
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyUISoundPaths.cs
@@ -87,9 +87,7 @@ internal static class StrategyUISoundPaths
     /// </summary>
     /// <param name="advisor">The active faction advisor theme.</param>
     /// <returns>The management response audio paths.</returns>
-    private static IEnumerable<string> GetAdvisorManagementAudioPaths(
-        StrategyAdvisorTheme advisor
-    )
+    private static IEnumerable<string> GetAdvisorManagementAudioPaths(StrategyAdvisorTheme advisor)
     {
         StrategyAdvisorAnimationTheme[] responses =
         {

--- a/Assets/Tests/EditMode/GameTests/Managers/AudioManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/AudioManagerTests.cs
@@ -242,6 +242,57 @@ public sealed class AudioManagerTests
     }
 
     [Test]
+    public void PlaySfxInstance_CompletedPlayback_ReleasesAndReusesSource()
+    {
+        AudioManager manager = AudioManager.EnsureExists();
+        AudioClip clip = AudioClip.Create("Tracked", 1, 1, 44100, false);
+        try
+        {
+            GetPreloadedSfx(manager).Add("Audio/SFX/tracked", clip);
+            AudioPlaybackHandle firstPlayback = manager.PlaySfxInstance("Audio/SFX/tracked");
+            AudioSource source = firstPlayback.Source;
+
+            source.Stop();
+            InvokeUpdate(manager);
+
+            Assert.IsNull(firstPlayback.Source);
+
+            AudioPlaybackHandle secondPlayback = manager.PlaySfxInstance("Audio/SFX/tracked");
+
+            Assert.AreSame(source, secondPlayback.Source);
+            secondPlayback.Stop();
+        }
+        finally
+        {
+            Object.DestroyImmediate(clip);
+        }
+    }
+
+    [Test]
+    public void PlaySfxInstance_PausedPlayback_RemainsActiveUntilResumedOrStopped()
+    {
+        AudioManager manager = AudioManager.EnsureExists();
+        AudioClip clip = AudioClip.Create("Tracked", 1, 1, 44100, false);
+        try
+        {
+            GetPreloadedSfx(manager).Add("Audio/SFX/tracked", clip);
+            AudioPlaybackHandle playback = manager.PlaySfxInstance("Audio/SFX/tracked");
+            AudioSource source = playback.Source;
+            playback.Paused = true;
+            source.Stop();
+
+            InvokeUpdate(manager);
+
+            Assert.AreSame(source, playback.Source);
+            playback.Stop();
+        }
+        finally
+        {
+            Object.DestroyImmediate(clip);
+        }
+    }
+
+    [Test]
     public void PlaySfxInstance_MissingClipOrPath_ReturnsNull()
     {
         AudioManager manager = AudioManager.EnsureExists();
@@ -400,5 +451,12 @@ public sealed class AudioManagerTests
             typeof(AudioManager)
                 .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
                 .GetValue(manager);
+    }
+
+    private static void InvokeUpdate(AudioManager manager)
+    {
+        typeof(AudioManager)
+            .GetMethod("Update", BindingFlags.Instance | BindingFlags.NonPublic)
+            .Invoke(manager, null);
     }
 }

--- a/Assets/Tests/EditMode/GameTests/Managers/AudioManagerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Managers/AudioManagerTests.cs
@@ -305,6 +305,34 @@ public sealed class AudioManagerTests
     }
 
     [Test]
+    public void GetLoadedSfxDuration_PreloadedPath_ReturnsClipDuration()
+    {
+        AudioManager manager = AudioManager.EnsureExists();
+        AudioClip clip = AudioClip.Create("Tracked", 88200, 1, 44100, false);
+        try
+        {
+            GetPreloadedSfx(manager).Add("Audio/SFX/tracked", clip);
+
+            float duration = manager.GetLoadedSfxDuration(" Audio/SFX/tracked ");
+
+            Assert.AreEqual(2f, duration);
+        }
+        finally
+        {
+            Object.DestroyImmediate(clip);
+        }
+    }
+
+    [Test]
+    public void GetLoadedSfxDuration_MissingOrBlankPath_ReturnsZero()
+    {
+        AudioManager manager = AudioManager.EnsureExists();
+
+        Assert.AreEqual(0f, manager.GetLoadedSfxDuration("Audio/SFX/missing"));
+        Assert.AreEqual(0f, manager.GetLoadedSfxDuration(" "));
+    }
+
+    [Test]
     public void StopSfx_ActiveSfxInstances_StopsEveryInstance()
     {
         AudioManager manager = AudioManager.EnsureExists();

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -336,6 +336,77 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
+        public void EnqueuePlaybacks_QueuedResponse_DoesNotStopPreviousAudio()
+        {
+            DestroyAudioManagers();
+            AudioManager audioManager = AudioManager.EnsureExists();
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+            StrategyAdvisorTheme advisorTheme = CreateTheme();
+            Texture2D frame = new Texture2D(1, 1);
+            AudioClip firstClip = AudioClip.Create("First", 44100, 1, 44100, false);
+            AudioClip secondClip = AudioClip.Create("Second", 44100, 1, 44100, false);
+            Dictionary<string, AudioClip> clips = new Dictionary<string, AudioClip>
+            {
+                ["Audio/first"] = firstClip,
+                ["Audio/second"] = secondClip,
+            };
+            List<AudioPlaybackHandle> playbacks = new List<AudioPlaybackHandle>();
+            try
+            {
+                UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+                StrategyAdvisorController controller = new StrategyAdvisorController(
+                    () => new Faction(),
+                    _ => null,
+                    _ => { },
+                    playSfxInstance: path =>
+                    {
+                        AudioPlaybackHandle playback = audioManager.PlaySfxInstance(clips[path]);
+                        playbacks.Add(playback);
+                        return playback;
+                    }
+                );
+                controller.Initialize(new TestActions());
+                controller.BindView(view);
+                controller.Render(advisorTheme);
+
+                controller.ReplaceAnimation(
+                    new StrategyAdvisorAnimationViewData(new[] { frame }, false, "Audio/first"),
+                    null,
+                    null
+                );
+                view.EnqueuePlaybacks(
+                    new[]
+                    {
+                        new StrategyAdvisorAnimationViewData(
+                            new[] { frame },
+                            false,
+                            "Audio/second"
+                        ),
+                    }
+                );
+
+                Assert.AreEqual(1, playbacks.Count);
+                Assert.AreSame(firstClip, playbacks[0].Source.clip);
+
+                view.AdvanceAnimation(advisorTheme.FrameIntervalSeconds);
+
+                Assert.AreEqual(2, playbacks.Count);
+                Assert.AreSame(firstClip, playbacks[0].Source.clip);
+                Assert.AreSame(secondClip, playbacks[1].Source.clip);
+            }
+            finally
+            {
+                audioManager.StopSfx();
+                UnityEngine.Object.DestroyImmediate(firstClip);
+                UnityEngine.Object.DestroyImmediate(secondClip);
+                UnityEngine.Object.DestroyImmediate(frame);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+                DestroyAudioManagers();
+            }
+        }
+
+        [Test]
         public void Render_SameThemeAfterIdleFramesLoad_RefreshesAdvisorImages()
         {
             GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -336,7 +336,51 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
-        public void HandlePlaybackStarted_NextQueuedResponse_StopsPreviousResponseAudio()
+        public void OnContextMenuCommandSelected_ManagementResponse_HoldsAnimationForAudioDuration()
+        {
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+            Faction faction = new Faction();
+            StrategyAdvisorTheme advisorTheme = CreateTheme();
+            advisorTheme.AudioRoot = "Audio";
+            advisorTheme.PlanetaryGarrisonManagementEnabled = CreateResponse(
+                "GarrisonEnabled",
+                "garrison-enabled"
+            );
+            Texture2D frame = new Texture2D(1, 1);
+            bool playbackCompleted = false;
+            try
+            {
+                UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+                StrategyAdvisorController controller = new StrategyAdvisorController(
+                    () => faction,
+                    _ => frame,
+                    _ => { },
+                    getAudioDuration: _ => 2f
+                );
+                controller.Initialize(new TestActions());
+                controller.BindView(view);
+                controller.Render(advisorTheme);
+                view.PlaybackCompleted += () => playbackCompleted = true;
+
+                SelectCommand(controller, faction, StrategyMenuAction.AdvisorManageGarrisons);
+                view.AdvanceAnimation(advisorTheme.FrameIntervalSeconds);
+
+                Assert.IsFalse(playbackCompleted);
+
+                view.AdvanceAnimation(2f);
+
+                Assert.IsTrue(playbackCompleted);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(frame);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+            }
+        }
+
+        [Test]
+        public void HandlePlaybackStarted_NextQueuedResponse_WaitsForPreviousAudioDuration()
         {
             DestroyAudioManagers();
             AudioManager audioManager = AudioManager.EnsureExists();
@@ -371,7 +415,12 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 controller.Render(advisorTheme);
 
                 controller.ReplaceAnimation(
-                    new StrategyAdvisorAnimationViewData(new[] { frame }, false, "Audio/first"),
+                    new StrategyAdvisorAnimationViewData(
+                        new[] { frame },
+                        false,
+                        "Audio/first",
+                        minimumPlaybackSeconds: 1f
+                    ),
                     null,
                     null
                 );
@@ -390,6 +439,11 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 Assert.AreSame(firstClip, playbacks[0].Source.clip);
 
                 view.AdvanceAnimation(advisorTheme.FrameIntervalSeconds);
+
+                Assert.AreEqual(1, playbacks.Count);
+                Assert.AreSame(firstClip, playbacks[0].Source.clip);
+
+                view.AdvanceAnimation(1f);
 
                 Assert.AreEqual(2, playbacks.Count);
                 Assert.IsNull(playbacks[0].Source);
@@ -751,8 +805,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         {
             foreach (
                 AudioManager manager in UnityEngine.Object.FindObjectsByType<AudioManager>(
-                    FindObjectsInactive.Include,
-                    FindObjectsSortMode.None
+                    FindObjectsInactive.Include
                 )
             )
             {

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -336,7 +336,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
-        public void EnqueuePlaybacks_QueuedResponse_DoesNotStopPreviousAudio()
+        public void HandlePlaybackStarted_NextQueuedResponse_StopsPreviousResponseAudio()
         {
             DestroyAudioManagers();
             AudioManager audioManager = AudioManager.EnsureExists();
@@ -392,7 +392,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 view.AdvanceAnimation(advisorTheme.FrameIntervalSeconds);
 
                 Assert.AreEqual(2, playbacks.Count);
-                Assert.AreSame(firstClip, playbacks[0].Source.clip);
+                Assert.IsNull(playbacks[0].Source);
                 Assert.AreSame(secondClip, playbacks[1].Source.clip);
             }
             finally

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -701,10 +701,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             };
         }
 
-        private static StrategyAdvisorAnimationTheme CreateResponse(
-            string animation,
-            string audio
-        )
+        private static StrategyAdvisorAnimationTheme CreateResponse(string animation, string audio)
         {
             return new StrategyAdvisorAnimationTheme
             {

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -380,7 +380,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
-        public void HandlePlaybackStarted_NextQueuedResponse_WaitsForPreviousAudioDuration()
+        public void HandlePlaybackStarted_NextQueuedResponse_PreservesPreviousResponseAudio()
         {
             DestroyAudioManagers();
             AudioManager audioManager = AudioManager.EnsureExists();
@@ -446,7 +446,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 view.AdvanceAnimation(1f);
 
                 Assert.AreEqual(2, playbacks.Count);
-                Assert.IsNull(playbacks[0].Source);
+                Assert.AreSame(firstClip, playbacks[0].Source.clip);
                 Assert.AreSame(secondClip, playbacks[1].Source.clip);
             }
             finally

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -194,6 +194,76 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
+        public void OnContextMenuCommandSelected_ManagementToggles_PlayAuthoredEnableAndDisableResponses()
+        {
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+            Faction faction = new Faction();
+            StrategyAdvisorTheme advisorTheme = CreateTheme();
+            advisorTheme.AudioRoot = "Audio";
+            advisorTheme.PlanetaryGarrisonManagementEnabled = CreateResponse(
+                "GarrisonEnabled",
+                "garrison-enabled"
+            );
+            advisorTheme.PlanetaryGarrisonManagementDisabled = CreateResponse(
+                "GarrisonDisabled",
+                "garrison-disabled"
+            );
+            advisorTheme.ResourceProductionManagementEnabled = CreateResponse(
+                "ProductionEnabled",
+                "production-enabled"
+            );
+            advisorTheme.ResourceProductionManagementDisabled = CreateResponse(
+                "ProductionDisabled",
+                "production-disabled"
+            );
+            Texture2D frame = new Texture2D(1, 1);
+            Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
+            {
+                [advisorTheme.GetFramePath("GarrisonEnabled", 0, false)] = frame,
+                [advisorTheme.GetFramePath("GarrisonDisabled", 0, false)] = frame,
+                [advisorTheme.GetFramePath("ProductionEnabled", 0, false)] = frame,
+                [advisorTheme.GetFramePath("ProductionDisabled", 0, false)] = frame,
+            };
+            List<string> playedAudio = new List<string>();
+            try
+            {
+                UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+                StrategyAdvisorController controller = new StrategyAdvisorController(
+                    () => faction,
+                    path => textures.TryGetValue(path, out Texture2D texture) ? texture : null,
+                    playedAudio.Add
+                );
+                controller.Initialize(new TestActions());
+                controller.BindView(view);
+                controller.Render(advisorTheme);
+
+                SelectCommand(controller, faction, StrategyMenuAction.AdvisorManageGarrisons);
+                SelectCommand(controller, faction, StrategyMenuAction.AdvisorManageGarrisons);
+                SelectCommand(controller, faction, StrategyMenuAction.AdvisorManageProduction);
+                SelectCommand(controller, faction, StrategyMenuAction.AdvisorManageProduction);
+
+                CollectionAssert.AreEqual(
+                    new[]
+                    {
+                        "Audio/garrison-enabled",
+                        "Audio/garrison-disabled",
+                        "Audio/production-enabled",
+                        "Audio/production-disabled",
+                    },
+                    playedAudio
+                );
+                Assert.IsFalse(faction.ManageGarrisons);
+                Assert.IsFalse(faction.ManageProduction);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(frame);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+            }
+        }
+
+        [Test]
         public void Render_SameThemeAfterIdleFramesLoad_RefreshesAdvisorImages()
         {
             GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
@@ -544,6 +614,46 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 FrameIntervalSeconds = 0.5f,
                 RepeatCooldownTicks = 10,
             };
+        }
+
+        private static StrategyAdvisorAnimationTheme CreateResponse(
+            string animation,
+            string audio
+        )
+        {
+            return new StrategyAdvisorAnimationTheme
+            {
+                Animation = animation,
+                FrameCount = 1,
+                Audio = audio,
+            };
+        }
+
+        private static void SelectCommand(
+            StrategyAdvisorController controller,
+            Faction faction,
+            StrategyMenuAction action
+        )
+        {
+            StrategyMenuCommand command = StrategyAdvisorController
+                .BuildCommandMenu(faction)
+                .Single(item => item.Action == action);
+            ContextMenuRequest request = (ContextMenuRequest)
+                typeof(StrategyAdvisorController)
+                    .GetMethod(
+                        "CreateContextMenuRequest",
+                        BindingFlags.Instance | BindingFlags.NonPublic
+                    )
+                    ?.Invoke(
+                        controller,
+                        new object[]
+                        {
+                            new List<StrategyMenuCommand> { command },
+                            0,
+                            0,
+                        }
+                    );
+            controller.OnContextMenuCommandSelected(request, command);
         }
 
         private static RawImage GetImage(GameObject rootObject, string name)

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorControllerTests.cs
@@ -264,6 +264,78 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
+        public void OnContextMenuCommandSelected_RapidManagementToggles_StopPreviousResponseAudio()
+        {
+            DestroyAudioManagers();
+            AudioManager audioManager = AudioManager.EnsureExists();
+            GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
+            StrategyAdvisorView view = rootObject.GetComponentInChildren<StrategyAdvisorView>(true);
+            Faction faction = new Faction();
+            StrategyAdvisorTheme advisorTheme = CreateTheme();
+            advisorTheme.AudioRoot = "Audio";
+            advisorTheme.PlanetaryGarrisonManagementEnabled = CreateResponse(
+                "GarrisonEnabled",
+                "garrison-enabled"
+            );
+            advisorTheme.PlanetaryGarrisonManagementDisabled = CreateResponse(
+                "GarrisonDisabled",
+                "garrison-disabled"
+            );
+            Texture2D frame = new Texture2D(1, 1);
+            AudioClip enabledClip = AudioClip.Create("GarrisonEnabled", 1, 1, 44100, false);
+            AudioClip disabledClip = AudioClip.Create("GarrisonDisabled", 1, 1, 44100, false);
+            Dictionary<string, Texture2D> textures = new Dictionary<string, Texture2D>
+            {
+                [advisorTheme.GetFramePath("GarrisonEnabled", 0, false)] = frame,
+                [advisorTheme.GetFramePath("GarrisonDisabled", 0, false)] = frame,
+            };
+            Dictionary<string, AudioClip> clips = new Dictionary<string, AudioClip>
+            {
+                ["Audio/garrison-enabled"] = enabledClip,
+                ["Audio/garrison-disabled"] = disabledClip,
+            };
+            List<AudioPlaybackHandle> playbacks = new List<AudioPlaybackHandle>();
+            try
+            {
+                UIComponentTestHelper.InvokeLifecycle(view, "Awake");
+                StrategyAdvisorController controller = new StrategyAdvisorController(
+                    () => faction,
+                    path => textures.TryGetValue(path, out Texture2D texture) ? texture : null,
+                    _ => { },
+                    playSfxInstance: path =>
+                    {
+                        AudioPlaybackHandle playback = audioManager.PlaySfxInstance(clips[path]);
+                        playbacks.Add(playback);
+                        return playback;
+                    }
+                );
+                controller.Initialize(new TestActions());
+                controller.BindView(view);
+                controller.Render(advisorTheme);
+
+                SelectCommand(controller, faction, StrategyMenuAction.AdvisorManageGarrisons);
+
+                Assert.AreEqual(1, playbacks.Count);
+                Assert.AreSame(enabledClip, playbacks[0].Source.clip);
+
+                SelectCommand(controller, faction, StrategyMenuAction.AdvisorManageGarrisons);
+
+                Assert.AreEqual(2, playbacks.Count);
+                Assert.IsNull(playbacks[0].Source);
+                Assert.AreSame(disabledClip, playbacks[1].Source.clip);
+            }
+            finally
+            {
+                audioManager.StopSfx();
+                UnityEngine.Object.DestroyImmediate(enabledClip);
+                UnityEngine.Object.DestroyImmediate(disabledClip);
+                UnityEngine.Object.DestroyImmediate(frame);
+                UnityEngine.Object.DestroyImmediate(rootObject);
+                DestroyAudioManagers();
+            }
+        }
+
+        [Test]
         public void Render_SameThemeAfterIdleFramesLoad_RefreshesAdvisorImages()
         {
             GameObject rootObject = UIComponentTestHelper.InstantiatePrefab(_prefabPath);
@@ -602,6 +674,19 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             );
             controller.Initialize(new TestActions());
             return controller;
+        }
+
+        private static void DestroyAudioManagers()
+        {
+            foreach (
+                AudioManager manager in UnityEngine.Object.FindObjectsByType<AudioManager>(
+                    FindObjectsInactive.Include,
+                    FindObjectsSortMode.None
+                )
+            )
+            {
+                UnityEngine.Object.DestroyImmediate(manager.gameObject);
+            }
         }
 
         private static StrategyAdvisorTheme CreateTheme()

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
@@ -32,6 +32,22 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                 StrategyAdvisor = new StrategyAdvisorTheme
                 {
                     AudioRoot = "advisor-audio",
+                    PlanetaryGarrisonManagementEnabled = new StrategyAdvisorAnimationTheme
+                    {
+                        Audio = "garrison-enabled",
+                    },
+                    PlanetaryGarrisonManagementDisabled = new StrategyAdvisorAnimationTheme
+                    {
+                        Audio = "garrison-disabled",
+                    },
+                    ResourceProductionManagementEnabled = new StrategyAdvisorAnimationTheme
+                    {
+                        Audio = "production-enabled",
+                    },
+                    ResourceProductionManagementDisabled = new StrategyAdvisorAnimationTheme
+                    {
+                        Audio = "production-disabled",
+                    },
                     Notifications =
                     {
                         new StrategyAdvisorNotificationTheme
@@ -68,6 +84,10 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                     StrategyUISoundPaths.GalacticInformationControl,
                     StrategyUISoundPaths.PlanetaryAssault,
                     "advisor-audio/planetary-assault",
+                    "advisor-audio/garrison-enabled",
+                    "advisor-audio/garrison-disabled",
+                    "advisor-audio/production-enabled",
+                    "advisor-audio/production-disabled",
                     "window-open",
                     "window-expand",
                     "window-collapse",

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Shared/StrategyUISoundPathsTests.cs
@@ -35,6 +35,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                     PlanetaryGarrisonManagementEnabled = new StrategyAdvisorAnimationTheme
                     {
                         Audio = "garrison-enabled",
+                        AudioOptions = { "garrison-enabled-alternate" },
                     },
                     PlanetaryGarrisonManagementDisabled = new StrategyAdvisorAnimationTheme
                     {
@@ -84,7 +85,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
                     StrategyUISoundPaths.GalacticInformationControl,
                     StrategyUISoundPaths.PlanetaryAssault,
                     "advisor-audio/planetary-assault",
-                    "advisor-audio/garrison-enabled",
+                    "advisor-audio/garrison-enabled-alternate",
                     "advisor-audio/garrison-disabled",
                     "advisor-audio/production-enabled",
                     "advisor-audio/production-disabled",


### PR DESCRIPTION
## Summary

- Restoring authored advisor responses when planetary garrison and resource-production management are toggled.
- Preloading every selectable faction-specific management response.
- Keeping advisor animation queues synchronized with loaded voice duration so responses neither overlap nor get cut short.
- Stopping advisor responses when playback is explicitly replaced or cancelled while allowing normal queued responses to finish.
- Releasing completed independently controlled audio and reuse its source while preserving paused playback.
- Pairing with adasgames/rebellion2-media#77 for the audio and upgraded combat imagery.

## Validation

- `bash build.sh all` passes formatting, analyzers, compilation, and all 4,615 EditMode tests.
- `AudioManagerTests`, `StrategyAdvisorControllerTests`, and `StrategyUISoundPathsTests` pass 43/43 focused tests.
- Regression tests cover completed-playback cleanup and source reuse, paused-playback retention, response-duration synchronization, rapid management replacement, queued advisor preservation, and selectable response preloading.
- The generated Strategy UI rebuild succeeds using the paired media branch.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed, or no documentation change was required.