### PR TITLE
Cancel remote construction on planet capture

### DIFF
--- a/Assets/Scripts/Systems/ManufacturingSystem.cs
+++ b/Assets/Scripts/Systems/ManufacturingSystem.cs
@@ -1494,8 +1494,8 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Clears all manufacturing queues for a planet and destroys items being built.
-        /// Called when planet ownership changes (capture, uprising, diplomacy).
+        /// Clears all manufacturing queues for a planet and cancels remotely produced buildings
+        /// attached there. Called when planet ownership changes (capture, uprising, diplomacy).
         /// </summary>
         /// <param name="planet">The planet whose queues should be cleared.</param>
         public void ClearQueuesOnOwnershipChange(Planet planet)
@@ -1503,6 +1503,28 @@ namespace Rebellion.Systems
             if (planet == null)
             {
                 return;
+            }
+
+            foreach (
+                Building building in planet
+                    .GetChildren<Building>(includeDisabled: true)
+                    .Where(building =>
+                        building.ManufacturingStatus == ManufacturingStatus.Building
+                        && !string.IsNullOrEmpty(building.ProducerPlanetID)
+                        && !string.Equals(
+                            building.ProducerPlanetID,
+                            planet.InstanceID,
+                            StringComparison.Ordinal
+                        )
+                    )
+                    .ToList()
+            )
+            {
+                Planet producer = _game.GetSceneNodeByInstanceID<Planet>(
+                    building.ProducerPlanetID
+                );
+                if (producer != null)
+                    CancelManufacturing(building, producer.GetOwnerInstanceID());
             }
 
             Dictionary<ManufacturingType, List<IManufacturable>> queue =

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -416,10 +416,10 @@ namespace Rebellion.Systems
                     newOwner
                 );
 
+                _manufacturingSystem.ClearQueuesOnOwnershipChange(planet);
                 if (newOwner != null)
                     TransferBuildings(planet, newOwner);
 
-                _manufacturingSystem.ClearQueuesOnOwnershipChange(planet);
                 EvictEnemyUnits(planet, newOwnerId);
                 planet.EndUprising();
                 if (newOwner == null)

--- a/Assets/Tests/EditMode/GameTests/Systems/PlanetaryControlSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/PlanetaryControlSystemTests.cs
@@ -600,6 +600,46 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void TransferPlanet_PlanetWithRemotelyProducedBuilding_CancelsProduction()
+        {
+            _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
+            _targetPlanet.EnergyCapacity = 1;
+
+            ManufacturingSystem manufacturing = new ManufacturingSystem(
+                _game,
+                new FleetSystem(_game)
+            );
+            Building shipyard = new Building
+            {
+                InstanceID = "remote-shipyard",
+                OwnerInstanceID = _empire.InstanceID,
+                BuildingType = BuildingType.Shipyard,
+                ConstructionCost = 100,
+            };
+            bool enqueued = manufacturing.Enqueue(
+                _empirePlanet,
+                shipyard,
+                _targetPlanet,
+                ignoreCost: true
+            );
+            Assert.IsTrue(enqueued, "Setup: remote shipyard should enqueue successfully");
+
+            _ownershipSystem.TransferPlanet(_targetPlanet, _rebels);
+
+            Assert.IsFalse(
+                _empirePlanet
+                    .GetManufacturingQueue()
+                    .Values.SelectMany(items => items)
+                    .Contains(shipyard),
+                "Captured destination must cancel the producer's queued building"
+            );
+            Assert.IsNull(
+                shipyard.GetParent(),
+                "Cancelled remote building must be detached from the captured planet"
+            );
+        }
+
+        [Test]
         public void ClearPlanetOwnership_ActiveDiplomacyMission_PreservesMission()
         {
             _game.ChangeOwnership(_targetPlanet, _rebels.InstanceID);


### PR DESCRIPTION
## Summary
- cancel unfinished buildings delivered from remote producer planets when their destination changes ownership
- clear construction before transferring completed buildings to the new owner
- cover captured destinations with an end-to-end synthetic regression test

## Tests
- Unity EditMode: ManufacturingSystemTests and PlanetaryControlSystemTests (161 passed)