### PR TITLE
Fixing fighter squadron damage scaling.

### DIFF
--- a/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
+++ b/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
@@ -1453,7 +1453,7 @@ namespace Rebellion.Game.Combat
                 if (scansForTarget)
                     ScanForWeaponTargets(targets, engagementDistance);
 
-                double fighterCount = GetRemainingFighterCount();
+                double squadronStrength = GetRemainingSquadronStrength();
                 for (int weaponIndex = 0; weaponIndex < _weaponTargets.Length; weaponIndex++)
                 {
                     TacticalUnit target = _weaponTargets[weaponIndex];
@@ -1465,7 +1465,8 @@ namespace Rebellion.Game.Combat
                         GetDistanceTo(target, engagementDistance),
                         requireRange: true
                     );
-                    double damage = weaponStrength * GetManeuverMultiplier(target) * fighterCount;
+                    double damage =
+                        weaponStrength * GetManeuverMultiplier(target) * squadronStrength;
                     if (damage > 0)
                     {
                         AddPendingDamage(pendingDamage, target, damage, weaponIndex == 2);
@@ -1483,7 +1484,7 @@ namespace Rebellion.Game.Combat
                 double engagementDistance
             )
             {
-                double fighterCount = GetRemainingFighterCount();
+                double squadronStrength = GetRemainingSquadronStrength();
                 for (int weaponIndex = 0; weaponIndex < _weaponTargets.Length; weaponIndex++)
                 {
                     _weaponTargets[weaponIndex] = null;
@@ -1502,7 +1503,7 @@ namespace Rebellion.Game.Combat
                         double candidateDamage =
                             GetWeaponStrength(weaponIndex, engagementRange, requireRange: true)
                             * maneuverMultiplier
-                            * fighterCount;
+                            * squadronStrength;
                         if (candidateDamage <= _weaponTargetDamage[weaponIndex])
                             continue;
 
@@ -1519,7 +1520,7 @@ namespace Rebellion.Game.Combat
                         targetsFighters,
                         engagementDistance: 0,
                         requireRange: true
-                    ) * GetRemainingFighterCount();
+                    ) * GetRemainingSquadronStrength();
             }
 
             /// <inheritdoc />
@@ -1549,16 +1550,20 @@ namespace Rebellion.Game.Combat
             }
 
             /// <summary>
-            /// Returns the durability-adjusted number of surviving fighters.
+            /// Returns the durability-adjusted fraction of the full squadron that survives.
             /// </summary>
-            /// <returns>The surviving fighter count.</returns>
-            private double GetRemainingFighterCount()
+            /// <returns>The surviving fraction of the full squadron.</returns>
+            private double GetRemainingSquadronStrength()
             {
-                return _currentDurability / _durabilityPerFighter;
+                double maximumSquadronSize = Math.Max(Fighter.MaxSquadronSize, 1);
+                return Math.Min(
+                    _currentDurability / (_durabilityPerFighter * maximumSquadronSize),
+                    1
+                );
             }
 
             /// <summary>
-            /// Returns one fighter's usable weapon strength against a target type.
+            /// Returns the squadron's usable weapon strength against a target type.
             /// </summary>
             /// <param name="targetsFighters">Whether the target is a fighter squadron.</param>
             /// <param name="engagementDistance">The abstract distance between combat forces.</param>
@@ -1579,7 +1584,7 @@ namespace Rebellion.Game.Combat
             }
 
             /// <summary>
-            /// Returns one fighter weapon lane's usable strength.
+            /// Returns one squadron weapon lane's usable strength.
             /// </summary>
             /// <param name="weaponIndex">The zero-based weapon lane.</param>
             /// <param name="engagementDistance">The abstract distance to the target.</param>

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -457,11 +457,7 @@ namespace Rebellion.Tests.Game.Combat
         [Test]
         public void Resolve_DamagedFighterSquadron_DealsProportionalDamage()
         {
-            Starfighter attacker = CreateFighter(
-                "attacker",
-                squadronSize: 12,
-                weaponStrength: 12
-            );
+            Starfighter attacker = CreateFighter("attacker", squadronSize: 12, weaponStrength: 12);
             attacker.CurrentSquadronSize = 6;
             CapitalShip defender = CreatePassiveTarget("defender", hull: 100);
             GameConfig.SpaceCombatConfig config = CreateConfig();

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -414,7 +414,7 @@ namespace Rebellion.Tests.Game.Combat
         }
 
         [Test]
-        public void Resolve_LargerFighterSquadron_DealsMoreDamage()
+        public void Resolve_FullFighterSquadronsWithEqualWeaponStrength_DealEqualDamage()
         {
             Starfighter singleFighter = CreateFighter(
                 "single-fighter",
@@ -429,7 +429,12 @@ namespace Rebellion.Tests.Game.Combat
             CapitalShip firstTarget = CreatePassiveTarget("first-target", hull: 100);
             CapitalShip secondTarget = CreatePassiveTarget("second-target", hull: 100);
 
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveMaximumIterations = 1;
+            config.AutoResolveTargetScanDivisor = 1;
+
             SpaceCombatAutoResult first = Resolve(
+                config,
                 new List<CapitalShip>(),
                 new[] { singleFighter },
                 new[] { firstTarget },
@@ -437,6 +442,7 @@ namespace Rebellion.Tests.Game.Combat
                 defenderCanWithdraw: true
             );
             SpaceCombatAutoResult second = Resolve(
+                config,
                 new List<CapitalShip>(),
                 new[] { fullSquadron },
                 new[] { secondTarget },
@@ -444,7 +450,34 @@ namespace Rebellion.Tests.Game.Combat
                 defenderCanWithdraw: true
             );
 
-            Assert.Less(second.IterationsCompleted, first.IterationsCompleted);
+            Assert.AreEqual(99, GetShipOutcome(first, firstTarget).HullAfter);
+            Assert.AreEqual(99, GetShipOutcome(second, secondTarget).HullAfter);
+        }
+
+        [Test]
+        public void Resolve_DamagedFighterSquadron_DealsProportionalDamage()
+        {
+            Starfighter attacker = CreateFighter(
+                "attacker",
+                squadronSize: 12,
+                weaponStrength: 12
+            );
+            attacker.CurrentSquadronSize = 6;
+            CapitalShip defender = CreatePassiveTarget("defender", hull: 100);
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveMaximumIterations = 1;
+            config.AutoResolveTargetScanDivisor = 1;
+
+            SpaceCombatAutoResult result = Resolve(
+                config,
+                new List<CapitalShip>(),
+                new[] { attacker },
+                new[] { defender },
+                new List<Starfighter>(),
+                defenderCanWithdraw: true
+            );
+
+            Assert.AreEqual(94, GetShipOutcome(result, defender).HullAfter);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

- Treating authored starfighter weapon values as whole-squadron output instead of per-fighter output.
- Scaling queued damage, target scoring, and tactical effectiveness by the surviving fraction of the squadron.
- Replacing the incorrect larger-squadron damage expectation with regression tests for full-strength and damaged squadrons.

This fixes full 12-unit squadrons multiplying their authored weapon output by 12. For example, two full Y-wing squadrons now contribute 26 conventional and 6 ion damage before maneuver modifiers, instead of 312 conventional and 72 ion damage.

## Validation

- Local Windows 64-bit player build: succeeded via `StandalonePlayerBuild.Build` (commit `bfdb134c`).
- Unity EditMode suite: 4,640 passed, 0 failed, 0 skipped.
- Confirmed the PR contains only the auto-resolver correction and synthetic regression tests.
- Confirmed a full 12-unit squadron with weapon strength 1 deals 1 damage.
- Confirmed a 6/12 squadron with weapon strength 12 deals 6 damage.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable: no UI builder changes.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable: no content changes.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable: no documentation or setup changes were required.)