### PR TITLE
Fixing issue where anti fighter fire does full damage to capital ships.

### DIFF
--- a/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
+++ b/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
@@ -17,7 +17,6 @@ namespace Rebellion.AI.Planners
     /// </summary>
     public sealed class AIProductionPlanner : IAIProposalPlanner
     {
-        private const int _primaryLaserDivisor = 6;
         private const int _primaryWeaponWeight = 100;
         private const int _roleMetricScale = 10;
         private const int _weaponArcCount = 4;
@@ -1214,7 +1213,9 @@ namespace Rebellion.AI.Planners
                 long weight =
                     (long)_primaryWeaponWeight * turbolasers
                     + (long)_primaryWeaponWeight * ionCannons
-                    + (long)_primaryWeaponWeight * laserCannons / _primaryLaserDivisor;
+                    + (long)_primaryWeaponWeight
+                        * laserCannons
+                        / CapitalShip.LaserCannonCapitalShipDamageDivisor;
                 if (weight <= maximumWeight)
                     continue;
 
@@ -1245,7 +1246,7 @@ namespace Rebellion.AI.Planners
                         * GetWeaponCount(capitalShip, PrimaryWeaponType.IonCannon, arc)
                     + (long)_primaryWeaponWeight
                         * GetWeaponCount(capitalShip, PrimaryWeaponType.LaserCannon, arc)
-                        / _primaryLaserDivisor;
+                        / CapitalShip.LaserCannonCapitalShipDamageDivisor;
                 maximumWeight = Math.Max(maximumWeight, weight);
             }
 

--- a/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
+++ b/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
@@ -17,10 +17,6 @@ namespace Rebellion.AI.Planners
     /// </summary>
     public sealed class AIProductionPlanner : IAIProposalPlanner
     {
-        private const int _primaryWeaponWeight = 100;
-        private const int _roleMetricScale = 10;
-        private const int _weaponArcCount = 4;
-
         private readonly AIProductionDemandGenerator _demandGenerator =
             new AIProductionDemandGenerator();
         private readonly Dictionary<ManufacturingType, List<Technology>> _unlockedTechnologies =
@@ -1069,12 +1065,13 @@ namespace Rebellion.AI.Planners
         )
         {
             CapitalShip candidateShip = (CapitalShip)candidate.GetReference();
-            long candidateMetric = GetCapitalShipRoleMetric(candidateShip, role);
+            GameConfig.SpaceCombatConfig combatConfig = context.Game.Config.Combat.SpaceCombat;
+            double candidateMetric = GetCapitalShipRoleMetric(candidateShip, role, combatConfig);
 
             for (int index = 0; index < rankedTechnologies.Count; index++)
             {
                 CapitalShip rankedShip = (CapitalShip)rankedTechnologies[index].GetReference();
-                long rankedMetric = GetCapitalShipRoleMetric(rankedShip, role);
+                double rankedMetric = GetCapitalShipRoleMetric(rankedShip, role, combatConfig);
                 if (
                     candidateMetric < rankedMetric
                     || (
@@ -1162,10 +1159,10 @@ namespace Rebellion.AI.Planners
             return role switch
             {
                 AICapitalShipProductionRole.General => !capitalShip.HasGravityWell
-                    && GetMaximumPrimaryWeaponWeight(capitalShip) > 0,
+                    && GetMaximumPrimaryWeaponStrength(capitalShip) > 0,
                 AICapitalShipProductionRole.TroopTransport => capitalShip.RegimentCapacity > 0
                     && !capitalShip.HasGravityWell
-                    && GetMaximumPrimaryWeaponWeight(capitalShip) == 0,
+                    && GetMaximumPrimaryWeaponStrength(capitalShip) == 0,
                 AICapitalShipProductionRole.Bombardment => capitalShip.Bombardment > 0,
                 AICapitalShipProductionRole.Interdiction => capitalShip.HasGravityWell,
                 _ => false,
@@ -1177,17 +1174,20 @@ namespace Rebellion.AI.Planners
         /// </summary>
         /// <param name="capitalShip">The capital ship to evaluate.</param>
         /// <param name="role">The role.</param>
+        /// <param name="combatConfig">The configured space-combat weapon effectiveness.</param>
         /// <returns>The calculated value.</returns>
-        private static long GetCapitalShipRoleMetric(
+        private static double GetCapitalShipRoleMetric(
             CapitalShip capitalShip,
-            AICapitalShipProductionRole role
+            AICapitalShipProductionRole role,
+            GameConfig.SpaceCombatConfig combatConfig
         )
         {
             return role switch
             {
-                AICapitalShipProductionRole.General => GetPrimaryWeaponMetric(capitalShip)
-                    * _roleMetricScale
-                    / Math.Max(1, capitalShip.MaintenanceCost),
+                AICapitalShipProductionRole.General => GetPrimaryWeaponMetric(
+                    capitalShip,
+                    combatConfig
+                ) / Math.Max(1, capitalShip.MaintenanceCost),
                 AICapitalShipProductionRole.TroopTransport => capitalShip.RegimentCapacity,
                 AICapitalShipProductionRole.Bombardment => capitalShip.Bombardment > 0 ? 1 : 0,
                 AICapitalShipProductionRole.Interdiction => capitalShip.ShieldRechargeRate,
@@ -1199,58 +1199,74 @@ namespace Rebellion.AI.Planners
         /// Returns primary weapon metric.
         /// </summary>
         /// <param name="capitalShip">The capital ship to evaluate.</param>
+        /// <param name="combatConfig">The configured space-combat weapon effectiveness.</param>
         /// <returns>The calculated value.</returns>
-        private static long GetPrimaryWeaponMetric(CapitalShip capitalShip)
+        private static double GetPrimaryWeaponMetric(
+            CapitalShip capitalShip,
+            GameConfig.SpaceCombatConfig combatConfig
+        )
         {
-            long maximumWeight = 0;
+            double maximumEffectiveStrength = 0;
             int selectedWeaponCount = 0;
 
-            for (int arc = 0; arc < _weaponArcCount; arc++)
+            foreach (PrimaryWeaponArc weaponArc in CapitalShip.PrimaryWeaponArcs)
             {
-                int turbolasers = GetWeaponCount(capitalShip, PrimaryWeaponType.Turbolaser, arc);
-                int ionCannons = GetWeaponCount(capitalShip, PrimaryWeaponType.IonCannon, arc);
-                int laserCannons = GetWeaponCount(capitalShip, PrimaryWeaponType.LaserCannon, arc);
-                long weight =
-                    (long)_primaryWeaponWeight * turbolasers
-                    + (long)_primaryWeaponWeight * ionCannons
-                    + (long)_primaryWeaponWeight
-                        * laserCannons
-                        / CapitalShip.LaserCannonCapitalShipDamageDivisor;
-                if (weight <= maximumWeight)
+                int turbolasers = GetWeaponCount(
+                    capitalShip,
+                    PrimaryWeaponType.Turbolaser,
+                    weaponArc
+                );
+                int ionCannons = GetWeaponCount(
+                    capitalShip,
+                    PrimaryWeaponType.IonCannon,
+                    weaponArc
+                );
+                int laserCannons = GetWeaponCount(
+                    capitalShip,
+                    PrimaryWeaponType.LaserCannon,
+                    weaponArc
+                );
+                double effectiveStrength =
+                    turbolasers
+                    + ionCannons
+                    + laserCannons
+                        * Math.Max(
+                            combatConfig.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier,
+                            0
+                        );
+                if (effectiveStrength <= maximumEffectiveStrength)
                     continue;
 
-                maximumWeight = weight;
+                maximumEffectiveStrength = effectiveStrength;
                 selectedWeaponCount = turbolasers + ionCannons + laserCannons;
             }
 
             if (selectedWeaponCount <= 0)
                 return 0;
 
-            return (long)capitalShip.WeaponRecharge * maximumWeight / selectedWeaponCount;
+            return (double)capitalShip.WeaponRecharge
+                * maximumEffectiveStrength
+                / selectedWeaponCount;
         }
 
         /// <summary>
-        /// Returns maximum primary weapon weight.
+        /// Returns maximum primary weapon strength.
         /// </summary>
         /// <param name="capitalShip">The capital ship to evaluate.</param>
         /// <returns>The calculated value.</returns>
-        private static long GetMaximumPrimaryWeaponWeight(CapitalShip capitalShip)
+        private static int GetMaximumPrimaryWeaponStrength(CapitalShip capitalShip)
         {
-            long maximumWeight = 0;
-            for (int arc = 0; arc < _weaponArcCount; arc++)
+            int maximumStrength = 0;
+            foreach (PrimaryWeaponArc weaponArc in CapitalShip.PrimaryWeaponArcs)
             {
-                long weight =
-                    (long)_primaryWeaponWeight
-                        * GetWeaponCount(capitalShip, PrimaryWeaponType.Turbolaser, arc)
-                    + (long)_primaryWeaponWeight
-                        * GetWeaponCount(capitalShip, PrimaryWeaponType.IonCannon, arc)
-                    + (long)_primaryWeaponWeight
-                        * GetWeaponCount(capitalShip, PrimaryWeaponType.LaserCannon, arc)
-                        / CapitalShip.LaserCannonCapitalShipDamageDivisor;
-                maximumWeight = Math.Max(maximumWeight, weight);
+                int strength =
+                    GetWeaponCount(capitalShip, PrimaryWeaponType.Turbolaser, weaponArc)
+                    + GetWeaponCount(capitalShip, PrimaryWeaponType.IonCannon, weaponArc)
+                    + GetWeaponCount(capitalShip, PrimaryWeaponType.LaserCannon, weaponArc);
+                maximumStrength = Math.Max(maximumStrength, strength);
             }
 
-            return maximumWeight;
+            return maximumStrength;
         }
 
         /// <summary>
@@ -1258,24 +1274,24 @@ namespace Rebellion.AI.Planners
         /// </summary>
         /// <param name="capitalShip">The capital ship to evaluate.</param>
         /// <param name="weaponType">The weapon type.</param>
-        /// <param name="arc">The arc.</param>
+        /// <param name="weaponArc">The weapon arc.</param>
         /// <returns>The calculated value.</returns>
         private static int GetWeaponCount(
             CapitalShip capitalShip,
             PrimaryWeaponType weaponType,
-            int arc
+            PrimaryWeaponArc weaponArc
         )
         {
+            int weaponArcIndex = (int)weaponArc;
             if (
                 capitalShip?.PrimaryWeapons == null
                 || !capitalShip.PrimaryWeapons.TryGetValue(weaponType, out int[] values)
                 || values == null
-                || arc < 0
-                || arc >= values.Length
+                || weaponArcIndex >= values.Length
             )
                 return 0;
 
-            return values[arc];
+            return values[weaponArcIndex];
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
+++ b/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
@@ -918,12 +918,7 @@ namespace Rebellion.Game.Combat
                 CurrentShields = _maximumShields;
                 for (int arc = 0; arc < _maximumArcCharge.Length; arc++)
                 {
-                    _maximumArcCharge[arc] = GetArcStrength(
-                        arc,
-                        targetsFighters: false,
-                        engagementDistance: 0,
-                        requireRange: false
-                    );
+                    _maximumArcCharge[arc] = GetRawArcStrength(arc);
                     _currentArcCharge[arc] = _maximumArcCharge[arc];
                 }
             }
@@ -1012,12 +1007,6 @@ namespace Rebellion.Game.Combat
                         for (int weaponIndex = 0; weaponIndex < _weaponTypes.Length; weaponIndex++)
                         {
                             PrimaryWeaponType weaponType = _weaponTypes[weaponIndex];
-                            if (
-                                weaponType == PrimaryWeaponType.IonCannon
-                                && candidate.IsStarfighter
-                            )
-                                continue;
-
                             double candidateDamage =
                                 GetWeaponStrength(
                                     weaponType,
@@ -1025,6 +1014,7 @@ namespace Rebellion.Game.Combat
                                     engagementRange,
                                     requireRange: true
                                 )
+                                * GetTargetTypeMultiplier(weaponType, candidate.IsStarfighter)
                                 * maneuverMultiplier
                                 * condition;
                             if (candidateDamage <= _arcTargetDamage[arc, weaponIndex])
@@ -1060,6 +1050,7 @@ namespace Rebellion.Game.Combat
                             GetDistanceTo(target, startingDistance),
                             requireRange: true
                         )
+                        * GetTargetTypeMultiplier(_weaponTypes[weaponIndex], target.IsStarfighter)
                         * GetManeuverMultiplier(target)
                         * condition;
                 }
@@ -1097,7 +1088,14 @@ namespace Rebellion.Game.Combat
                     if (weaponStrength <= 0)
                         continue;
 
-                    double damage = weaponStrength * GetManeuverMultiplier(target) * condition;
+                    double damage =
+                        weaponStrength
+                        * GetTargetTypeMultiplier(_weaponTypes[weaponIndex], target.IsStarfighter)
+                        * GetManeuverMultiplier(target)
+                        * condition;
+                    if (damage <= 0)
+                        continue;
+
                     AddPendingDamage(
                         pendingDamage,
                         target,
@@ -1323,29 +1321,52 @@ namespace Rebellion.Game.Combat
                 bool requireRange
             )
             {
-                double strength =
-                    GetWeaponStrength(
-                        PrimaryWeaponType.Turbolaser,
-                        arc,
-                        engagementDistance,
-                        requireRange
-                    )
-                    + GetWeaponStrength(
-                        PrimaryWeaponType.LaserCannon,
-                        arc,
-                        engagementDistance,
-                        requireRange
-                    );
-                if (!targetsFighters)
+                double strength = 0;
+                foreach (PrimaryWeaponType weaponType in _weaponTypes)
+                {
+                    strength +=
+                        GetWeaponStrength(weaponType, arc, engagementDistance, requireRange)
+                        * GetTargetTypeMultiplier(weaponType, targetsFighters);
+                }
+                return strength;
+            }
+
+            /// <summary>
+            /// Returns one arc's raw weapon charge before target-type effectiveness is applied.
+            /// </summary>
+            /// <param name="arc">The zero-based firing arc.</param>
+            /// <returns>The arc's raw weapon charge.</returns>
+            private int GetRawArcStrength(int arc)
+            {
+                int strength = 0;
+                foreach (PrimaryWeaponType weaponType in _weaponTypes)
                 {
                     strength += GetWeaponStrength(
-                        PrimaryWeaponType.IonCannon,
+                        weaponType,
                         arc,
-                        engagementDistance,
-                        requireRange
+                        engagementDistance: 0,
+                        requireRange: false
                     );
                 }
                 return strength;
+            }
+
+            /// <summary>
+            /// Returns a capital-ship weapon's effectiveness against the selected target type.
+            /// </summary>
+            /// <param name="type">The weapon type.</param>
+            /// <param name="targetsFighters">Whether the target is a fighter squadron.</param>
+            /// <returns>The target-specific damage multiplier.</returns>
+            private static double GetTargetTypeMultiplier(
+                PrimaryWeaponType type,
+                bool targetsFighters
+            )
+            {
+                if (type == PrimaryWeaponType.IonCannon && targetsFighters)
+                    return 0;
+                if (type == PrimaryWeaponType.LaserCannon && !targetsFighters)
+                    return 1.0 / CapitalShip.LaserCannonCapitalShipDamageDivisor;
+                return 1;
             }
 
             /// <summary>

--- a/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
+++ b/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
@@ -855,15 +855,28 @@ namespace Rebellion.Game.Combat
 
             internal readonly CapitalShip Ship;
             internal readonly int InitialHull;
-            private readonly bool[] _arcQueuedForRecharge = new bool[4];
-            private readonly TacticalUnit[,] _arcTargets = new TacticalUnit[4, 3];
-            private readonly double[,] _arcTargetDamage = new double[4, 3];
-            private readonly double[] _currentArcCharge = new double[4];
+            private readonly bool[] _arcQueuedForRecharge = new bool[
+                CapitalShip.PrimaryWeaponArcs.Count
+            ];
+            private readonly TacticalUnit[,] _arcTargets = new TacticalUnit[
+                CapitalShip.PrimaryWeaponArcs.Count,
+                _weaponTypes.Length
+            ];
+            private readonly double[,] _arcTargetDamage = new double[
+                CapitalShip.PrimaryWeaponArcs.Count,
+                _weaponTypes.Length
+            ];
+            private readonly double[] _currentArcCharge = new double[
+                CapitalShip.PrimaryWeaponArcs.Count
+            ];
             private readonly int[] _ionCannons;
             private readonly int[] _laserCannons;
+            private readonly double _laserCannonDamageAgainstCapitalShipsMultiplier;
             private readonly double _maximumHull;
             private readonly double _maximumShields;
-            private readonly double[] _maximumArcCharge = new double[4];
+            private readonly double[] _maximumArcCharge = new double[
+                CapitalShip.PrimaryWeaponArcs.Count
+            ];
             private readonly Queue<int> _rechargeQueue = new Queue<int>();
             private readonly int[] _turbolasers;
             private int _attackDelay;
@@ -914,6 +927,10 @@ namespace Rebellion.Game.Combat
                 _turbolasers = GetWeaponValues(ship, PrimaryWeaponType.Turbolaser);
                 _laserCannons = GetWeaponValues(ship, PrimaryWeaponType.LaserCannon);
                 _ionCannons = GetWeaponValues(ship, PrimaryWeaponType.IonCannon);
+                _laserCannonDamageAgainstCapitalShipsMultiplier = Math.Max(
+                    config.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier,
+                    0
+                );
                 CurrentHull = InitialHull;
                 CurrentShields = _maximumShields;
                 for (int arc = 0; arc < _maximumArcCharge.Length; arc++)
@@ -1292,7 +1309,7 @@ namespace Rebellion.Game.Combat
             private double GetStrongestArcStrength(bool targetsFighters)
             {
                 double strongestArc = 0;
-                for (int arc = 0; arc < 4; arc++)
+                for (int arc = 0; arc < _maximumArcCharge.Length; arc++)
                     strongestArc = Math.Max(
                         strongestArc,
                         GetArcStrength(
@@ -1357,15 +1374,12 @@ namespace Rebellion.Game.Combat
             /// <param name="type">The weapon type.</param>
             /// <param name="targetsFighters">Whether the target is a fighter squadron.</param>
             /// <returns>The target-specific damage multiplier.</returns>
-            private static double GetTargetTypeMultiplier(
-                PrimaryWeaponType type,
-                bool targetsFighters
-            )
+            private double GetTargetTypeMultiplier(PrimaryWeaponType type, bool targetsFighters)
             {
                 if (type == PrimaryWeaponType.IonCannon && targetsFighters)
                     return 0;
                 if (type == PrimaryWeaponType.LaserCannon && !targetsFighters)
-                    return 1.0 / CapitalShip.LaserCannonCapitalShipDamageDivisor;
+                    return _laserCannonDamageAgainstCapitalShipsMultiplier;
                 return 1;
             }
 
@@ -1396,7 +1410,11 @@ namespace Rebellion.Game.Combat
                     || arc >= values.Length
                     || (
                         requireRange
-                        && (values.Length < 5 || values[4] <= 0 || values[4] < engagementDistance)
+                        && (
+                            values.Length <= CapitalShip.PrimaryWeaponRangeIndex
+                            || values[CapitalShip.PrimaryWeaponRangeIndex] <= 0
+                            || values[CapitalShip.PrimaryWeaponRangeIndex] < engagementDistance
+                        )
                     )
                 )
                     return 0;

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -575,6 +575,8 @@ namespace Rebellion.Game
         [PersistableObject]
         public class SpaceCombatConfig
         {
+            public double CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier { get; set; }
+
             public int AutoResolveMaximumIterations { get; set; }
 
             public int AutoResolveStagnationIterations { get; set; }

--- a/Assets/Scripts/Game/Units/CapitalShip.cs
+++ b/Assets/Scripts/Game/Units/CapitalShip.cs
@@ -14,6 +14,14 @@ namespace Rebellion.Game.Units
         LaserCannon,
     }
 
+    public enum PrimaryWeaponArc
+    {
+        Fore,
+        Aft,
+        Port,
+        Starboard,
+    }
+
     public enum CapitalShipRole
     {
         PrimaryLine,
@@ -30,7 +38,10 @@ namespace Rebellion.Game.Units
     /// </summary>
     public class CapitalShip : ContainerNode, IManufacturable, IMovable
     {
-        internal const int LaserCannonCapitalShipDamageDivisor = 6;
+        public static IReadOnlyList<PrimaryWeaponArc> PrimaryWeaponArcs { get; } =
+            Array.AsReadOnly((PrimaryWeaponArc[])Enum.GetValues(typeof(PrimaryWeaponArc)));
+
+        public static int PrimaryWeaponRangeIndex => PrimaryWeaponArcs.Count;
 
         [PersistableMember(Name = "HasAssignedName")]
         private bool _hasAssignedName;
@@ -90,9 +101,9 @@ namespace Rebellion.Game.Units
             int[]
         >()
         {
-            { PrimaryWeaponType.Turbolaser, new int[5] },
-            { PrimaryWeaponType.IonCannon, new int[5] },
-            { PrimaryWeaponType.LaserCannon, new int[5] },
+            { PrimaryWeaponType.Turbolaser, new int[PrimaryWeaponRangeIndex + 1] },
+            { PrimaryWeaponType.IonCannon, new int[PrimaryWeaponRangeIndex + 1] },
+            { PrimaryWeaponType.LaserCannon, new int[PrimaryWeaponRangeIndex + 1] },
         };
         public int WeaponRecharge;
         public int Bombardment;
@@ -293,9 +304,12 @@ namespace Rebellion.Game.Units
                 return 0;
 
             int strength = 0;
-            int weaponStrengthValueCount = Math.Min(4, weaponValues.Length);
-            for (int i = 0; i < weaponStrengthValueCount; i++)
-                strength += weaponValues[i];
+            foreach (PrimaryWeaponArc weaponArc in PrimaryWeaponArcs)
+            {
+                int weaponArcIndex = (int)weaponArc;
+                if (weaponArcIndex < weaponValues.Length)
+                    strength += weaponValues[weaponArcIndex];
+            }
 
             return strength;
         }

--- a/Assets/Scripts/Game/Units/CapitalShip.cs
+++ b/Assets/Scripts/Game/Units/CapitalShip.cs
@@ -30,6 +30,8 @@ namespace Rebellion.Game.Units
     /// </summary>
     public class CapitalShip : ContainerNode, IManufacturable, IMovable
     {
+        internal const int LaserCannonCapitalShipDamageDivisor = 6;
+
         [PersistableMember(Name = "HasAssignedName")]
         private bool _hasAssignedName;
 

--- a/Assets/Tests/EditMode/GameTests/AI/Planners/AIProductionPlannerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/AI/Planners/AIProductionPlannerTests.cs
@@ -832,6 +832,66 @@ namespace Rebellion.Tests.AI.Planners
         }
 
         [Test]
+        public void Plan_WithFleetDeficit_UsesConfiguredLaserCannonDamageMultiplier()
+        {
+            GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction _);
+            game.Config
+                .Combat
+                .SpaceCombat
+                .CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 0.75;
+            PlanetSector system = AITestSceneBuilder.AddSector(game, "sys1");
+            Planet planet = AITestSceneBuilder.AddPlanet(
+                game,
+                system,
+                "shipyard-world",
+                empire.InstanceID
+            );
+            AITestSceneBuilder.AddProductionFacility(
+                game,
+                planet,
+                "shipyard",
+                BuildingType.Shipyard,
+                ManufacturingType.Ship
+            );
+
+            CapitalShip laserShip = AITestSceneBuilder.CreateCapitalShip(
+                "laser-template",
+                empire.InstanceID,
+                combatStrength: 300,
+                regimentCapacity: 0,
+                starfighterCapacity: 0
+            );
+            laserShip.TypeID = "laser";
+            laserShip.MaintenanceCost = 0;
+            laserShip.PrimaryWeapons[PrimaryWeaponType.Turbolaser][0] = 0;
+            laserShip.PrimaryWeapons[PrimaryWeaponType.LaserCannon][0] = 300;
+            laserShip.WeaponRecharge = 20;
+            CapitalShip turbolaserShip = AITestSceneBuilder.CreateCapitalShip(
+                "turbolaser-template",
+                empire.InstanceID,
+                combatStrength: 200,
+                regimentCapacity: 0,
+                starfighterCapacity: 0
+            );
+            turbolaserShip.TypeID = "turbolaser";
+            turbolaserShip.MaintenanceCost = 0;
+            turbolaserShip.WeaponRecharge = 10;
+            empire.ResearchQueue[ManufacturingType.Ship] = new List<Technology>
+            {
+                new Technology(laserShip),
+                new Technology(turbolaserShip),
+            };
+            AITurnContext context = AITestSceneBuilder.CreateContext(game, empire);
+
+            AIManufactureProposal proposal = new AIProductionPlanner()
+                .Plan(context)
+                .OfType<AIManufactureProposal>()
+                .Single(item => item.Demand.Kind == AIDemandKind.FleetSeedCapitalShip);
+
+            Assert.AreSame(laserShip, proposal.Product.GetReference());
+        }
+
+        [Test]
         public void Plan_WithGeneralDeficit_DoesNotSelectPlanetDestroyingCapitalShip()
         {
             GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction _);

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -104,6 +104,67 @@ namespace Rebellion.Tests.Game.Combat
         }
 
         [Test]
+        public void Resolve_CapitalShipLaserCannonWithMixedTargets_SelectsHighestEffectiveDamageTarget()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 100, weaponStrength: 0);
+            attacker.Maneuverability = 1;
+            attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][0] = 60;
+            attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][4] = 100;
+            CapitalShip defenderShip = CreatePassiveTarget("defender-ship", hull: 100);
+            Starfighter defenderFighter = CreateFighter(
+                "defender-fighter",
+                squadronSize: 12,
+                weaponStrength: 0
+            );
+            defenderFighter.Agility = 10;
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 0.01;
+            config.AutoResolveMaximumIterations = 1;
+            config.AutoResolveTargetScanDivisor = 1;
+            config.AutoResolveStartingDistance = 0;
+
+            SpaceCombatAutoResult result = Resolve(
+                config,
+                new[] { attacker },
+                new List<Starfighter>(),
+                new[] { defenderShip },
+                new[] { defenderFighter },
+                defenderCanWithdraw: true
+            );
+
+            Assert.AreEqual(100, GetShipOutcome(result, defenderShip).HullAfter);
+            Assert.AreEqual(6, GetFighterOutcome(result, defenderFighter).SquadronSizeAfter);
+        }
+
+        [Test]
+        public void Resolve_ZeroIterationStalemate_UsesConfiguredCapitalTargetLaserEffectiveness()
+        {
+            CapitalShip laserShip = CreateShip("laser-ship", hull: 100, weaponStrength: 0);
+            laserShip.PrimaryWeapons[PrimaryWeaponType.LaserCannon][0] = 60;
+            laserShip.PrimaryWeapons[PrimaryWeaponType.LaserCannon][4] = 100;
+            CapitalShip turbolaserShip = CreateShip(
+                "turbolaser-ship",
+                hull: 100,
+                weaponStrength: 20
+            );
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 0.25;
+            config.AutoResolveMaximumIterations = 0;
+
+            SpaceCombatAutoResult result = Resolve(
+                config,
+                new[] { laserShip },
+                new List<Starfighter>(),
+                new[] { turbolaserShip },
+                new List<Starfighter>(),
+                attackerCanWithdraw: true
+            );
+
+            Assert.AreEqual(SpaceCombatSideOutcome.Withdrawn, result.AttackerOutcome);
+            Assert.AreEqual(SpaceCombatSideOutcome.Active, result.DefenderOutcome);
+        }
+
+        [Test]
         public void Resolve_HeavyLineShipAgainstThreeLaserEscorts_DefeatsEscorts()
         {
             CapitalShip[] escorts =

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -56,6 +56,71 @@ namespace Rebellion.Tests.Game.Combat
         }
 
         [Test]
+        public void Resolve_CapitalShipLaserCannonAgainstCapitalShip_DealsOneSixthDamage()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 100, weaponStrength: 0);
+            attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][0] = 60;
+            attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][4] = 100;
+            CapitalShip defender = CreatePassiveTarget("defender", hull: 100);
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveMaximumIterations = 1;
+            config.AutoResolveTargetScanDivisor = 1;
+
+            SpaceCombatAutoResult result = Resolve(
+                config,
+                new[] { attacker },
+                new List<Starfighter>(),
+                new[] { defender },
+                new List<Starfighter>(),
+                defenderCanWithdraw: true
+            );
+
+            Assert.AreEqual(90, GetShipOutcome(result, defender).HullAfter);
+        }
+
+        [Test]
+        public void Resolve_CapitalShipLaserCannonAgainstStarfighters_DealsFullDamage()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 100, weaponStrength: 0);
+            attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][0] = 120;
+            attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][4] = 100;
+            Starfighter defender = CreateFighter("defender", squadronSize: 2, weaponStrength: 0);
+            defender.ShieldStrength = 100;
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveMaximumIterations = 1;
+            config.AutoResolveTargetScanDivisor = 1;
+
+            SpaceCombatAutoResult result = Resolve(
+                config,
+                new[] { attacker },
+                new List<Starfighter>(),
+                new List<CapitalShip>(),
+                new[] { defender },
+                defenderCanWithdraw: true
+            );
+
+            Assert.AreEqual(1, GetFighterOutcome(result, defender).SquadronSizeAfter);
+        }
+
+        [Test]
+        public void Resolve_HeavyLineShipAgainstThreeLaserEscorts_DefeatsEscorts()
+        {
+            CapitalShip[] escorts =
+            {
+                CreateLaserEscort("escort-1"),
+                CreateLaserEscort("escort-2"),
+                CreateLaserEscort("escort-3"),
+            };
+            CapitalShip lineShip = CreateHeavyLineShip("line-ship");
+
+            SpaceCombatAutoResult result = Resolve(escorts, new[] { lineShip });
+
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, result.AttackerOutcome);
+            Assert.AreEqual(SpaceCombatSideOutcome.Active, result.DefenderOutcome);
+            Assert.Greater(GetShipOutcome(result, lineShip).HullAfter, 0);
+        }
+
+        [Test]
         public void Resolve_WeaponOutsideItsConfiguredRange_DoesNotDamageTarget()
         {
             CapitalShip attacker = CreateShip("attacker", hull: 100, weaponStrength: 10);
@@ -885,6 +950,31 @@ namespace Rebellion.Tests.Game.Combat
                 ship.PrimaryWeapons[PrimaryWeaponType.Turbolaser][arc] = weaponStrength;
             if (weaponStrength > 0)
                 ship.PrimaryWeapons[PrimaryWeaponType.Turbolaser][4] = 100;
+            return ship;
+        }
+
+        private static CapitalShip CreateLaserEscort(string instanceId)
+        {
+            CapitalShip ship = CreateShip(instanceId, hull: 500, weaponStrength: 0);
+            ship.MaxShieldStrength = 200;
+            ship.ShieldRechargeRate = 10;
+            ship.SublightSpeed = 6;
+            ship.Maneuverability = 3;
+            ship.WeaponRecharge = 8;
+            ship.PrimaryWeapons[PrimaryWeaponType.LaserCannon] = new[] { 120, 90, 120, 120, 17 };
+            return ship;
+        }
+
+        private static CapitalShip CreateHeavyLineShip(string instanceId)
+        {
+            CapitalShip ship = CreateShip(instanceId, hull: 2750, weaponStrength: 0);
+            ship.MaxShieldStrength = 300;
+            ship.ShieldRechargeRate = 15;
+            ship.SublightSpeed = 4;
+            ship.Maneuverability = 1;
+            ship.WeaponRecharge = 20;
+            ship.PrimaryWeapons[PrimaryWeaponType.Turbolaser] = new[] { 100, 40, 60, 60, 50 };
+            ship.PrimaryWeapons[PrimaryWeaponType.IonCannon] = new[] { 100, 40, 40, 40, 35 };
             return ship;
         }
 

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -56,13 +56,14 @@ namespace Rebellion.Tests.Game.Combat
         }
 
         [Test]
-        public void Resolve_CapitalShipLaserCannonAgainstCapitalShip_DealsOneSixthDamage()
+        public void Resolve_CapitalShipLaserCannonAgainstCapitalShip_UsesConfiguredMultiplier()
         {
             CapitalShip attacker = CreateShip("attacker", hull: 100, weaponStrength: 0);
             attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][0] = 60;
             attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][4] = 100;
             CapitalShip defender = CreatePassiveTarget("defender", hull: 100);
             GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 0.25;
             config.AutoResolveMaximumIterations = 1;
             config.AutoResolveTargetScanDivisor = 1;
 
@@ -75,7 +76,7 @@ namespace Rebellion.Tests.Game.Combat
                 defenderCanWithdraw: true
             );
 
-            Assert.AreEqual(90, GetShipOutcome(result, defender).HullAfter);
+            Assert.AreEqual(85, GetShipOutcome(result, defender).HullAfter);
         }
 
         [Test]
@@ -888,6 +889,7 @@ namespace Rebellion.Tests.Game.Combat
         {
             return new GameConfig.SpaceCombatConfig
             {
+                CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 1.0 / 6.0,
                 AutoResolveMaximumIterations = 4096,
                 AutoResolveStagnationIterations = 1200,
                 AutoResolveRetreatStrengthRatio = 0.33,


### PR DESCRIPTION
## Summary

- Reducing capital-ship laser-cannon damage against capital ships during target selection, queued damage, and tactical-strength calculation.
- Authoring the effectiveness multiplier in SpaceCombatConfig instead of promoting an AI heuristic into a hardcoded combat rule.
- Making AI production ranking consume the same configured multiplier as combat resolution.
- Replacing fixed-point weapon-ranking constants with direct double-precision ratios.
- Representing fore, aft, port, and starboard as PrimaryWeaponArc values instead of hardcoding an arc count.
- Preserving full laser-cannon damage against starfighters and preserve raw weapon strength for arc discharge/recharge timing.
- Adding synthetic regression coverage for configurable capital-target damage, AI use of the configured multiplier, fighter targets, and a heavy line ship fighting three laser escorts.

## Validation

### Before the damage fix

- Ran SpaceCombatAutoResolverTests with the capital-target regression against the previous resolver.
- Result: 30 passed, 1 failed.
- A 60-point laser shot dealt 60 damage to a capital target instead of applying the intended configured effectiveness.
- The anti-starfighter control passed, confirming the regression isolated capital-target effectiveness.

### After the configuration cleanup

- Focused resolver and AI-planner tests: 85/85 passed.
- Target-selection and tactical-strength regressions were mutation-tested by removing each multiplier call independently; the corresponding new test failed in both cases.
- Full Unity EditMode suite: 4,647/4,647 passed.
- Heavy line ship versus three laser escorts: passed; the heavy line ship survives and defeats the escorts.
- CSharpier check: passed for all changed C# files.
- Standalone Windows 64-bit player build: succeeded with StandalonePlayerBuild.Build.
- Local build artifact: build/configured-laser-capital-damage/rebellion2.exe.
- Media schema/config validation: bash build.sh all passed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] Maintainer confirmation required: I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder verification completed by the successful full player build; no UI builder source changed.
- [x] Matching rebellion2-media change is in adasgames/rebellion2-media#80 and uses the automatically resolved fix-laser-capital-damage-media branch.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] N/A: no documentation or setup behavior changed.
