### PR TITLE
Route AI assault garrison change results

### DIFF
--- a/Assets/Scripts/AI/Proposals/AIFleetAttackProposal.cs
+++ b/Assets/Scripts/AI/Proposals/AIFleetAttackProposal.cs
@@ -248,6 +248,7 @@ namespace Rebellion.AI.Proposals
                 liveTarget
             );
             context.AddResult(assaultResult);
+            context.AddResults(assaultResult.Events);
             context.AddResult(assaultResult.OwnershipChange);
             TryClearCompletedAttackOrder(context, liveTarget);
         }

--- a/Assets/Tests/EditMode/GameTests/AI/Proposals/AIFleetAttackProposalTests.cs
+++ b/Assets/Tests/EditMode/GameTests/AI/Proposals/AIFleetAttackProposalTests.cs
@@ -147,6 +147,41 @@ namespace Rebellion.Tests.AI.Proposals
             Assert.AreEqual(1, context.Results.OfType<BombardmentResult>().Count());
         }
 
+        [Test]
+        public void Execute_WithSuccessfulPlanetaryAssault_AddsGarrisonChangeResult()
+        {
+            GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction rebels);
+            PlanetSector system = AITestSceneBuilder.AddSector(game, "sys1");
+            Planet target = AITestSceneBuilder.AddPlanet(game, system, "target", rebels.InstanceID);
+            Fleet fleet = AddBattleFleet(game, target, empire.InstanceID);
+            CapitalShip ship = fleet.GetChildren<CapitalShip>().Single();
+            game.AttachNode(AITestSceneBuilder.CreateRegiment("attacker", empire.InstanceID), ship);
+            fleet.Order = new FleetOrder
+            {
+                OrderType = FleetOrderType.Attack,
+                Status = FleetOrderStatus.Ready,
+                TargetPlanetId = target.InstanceID,
+            };
+            AITurnContext context = AITestSceneBuilder.CreateContext(game, empire);
+            AIFleetAttackProposal proposal = new AIFleetAttackProposal(
+                fleet,
+                FleetOrderType.Attack,
+                FleetOrderStatus.Ready,
+                target
+            );
+
+            proposal.Execute(context);
+
+            PlanetaryAssaultResult assault = context
+                .Results.OfType<PlanetaryAssaultResult>()
+                .Single();
+            Assert.IsTrue(assault.Success);
+            Assert.AreSame(
+                target,
+                context.Results.OfType<PlanetGarrisonChangedResult>().Single().Planet
+            );
+        }
+
         private static Fleet AddBattleFleet(GameRoot game, Planet planet, string ownerInstanceId)
         {
             Fleet fleet = EntityFactory.CreateFleet("fleet", ownerInstanceId);


### PR DESCRIPTION
## Summary

- Route nested planetary-assault results through the AI turn result pipeline.
- Ensure AI captures publish the same `PlanetGarrisonChangedResult` emitted by player assaults, allowing uprising and other garrison listeners to react consistently.
- Add a focused regression test covering successful AI planetary assaults.

## Validation

- Unity EditMode: `Rebellion.Tests.AI.Proposals.AIFleetAttackProposalTests` — 5 passed, 0 failed.
- `dotnet build EditorTests.csproj` — passed with 0 warnings and 0 errors.
- `dotnet build GameAssembly.Lint.csproj` — passed; 20 pre-existing generated-input XML documentation warnings.
- `dotnet csharpier format` — passed for both changed files.
- `git diff --check` — passed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. *(Not applicable; no UI changes.)*
- [x] Content path or structure changes were also made in `rebellion2-media`. *(Not applicable; no content changes.)*
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. *(Not applicable; behavior now follows the existing result contract.)*