### PR TITLE
Fixing carrier-dependent combat withdrawal.

### DIFF
--- a/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
+++ b/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
@@ -643,37 +643,29 @@ namespace Rebellion.Game.Combat
                         && carrier.Ship.StarfighterCapacity > 0
                     )
                     .ToList();
-                List<StarfighterState> fighters = _units
-                    .OfType<StarfighterState>()
+                List<StarfighterState> fighterStates = _units.OfType<StarfighterState>().ToList();
+                List<StarfighterState> survivingFighters = fighterStates
                     .Where(fighter => fighter.IsTargetable)
                     .ToList();
                 Dictionary<CapitalShipState, int> remainingCapacity = carriers.ToDictionary(
                     carrier => carrier,
-                    carrier => Math.Max(carrier.Ship.StarfighterCapacity, 0)
+                    carrier => GetAvailableRecoveryCapacity(carrier, fighterStates)
                 );
                 HashSet<TacticalUnit> recoverableUnits = new HashSet<TacticalUnit>();
 
                 foreach (CapitalShipState carrier in carriers)
                 {
-                    IEnumerable<StarfighterState> assignedFighters = fighters.Where(fighter =>
-                        !fighter.CanWithdrawIndependently
-                        && ReferenceEquals(
-                            fighter.Fighter.GetParentOfType<CapitalShip>(),
-                            carrier.Ship
-                        )
+                    IEnumerable<StarfighterState> assignedFighters = survivingFighters.Where(
+                        fighter =>
+                            !fighter.CanWithdrawIndependently
+                            && IsAssignedToCarrier(fighter, carrier)
                     );
                     foreach (StarfighterState fighter in assignedFighters)
-                    {
-                        if (remainingCapacity[carrier] <= 0)
-                            break;
-
-                        remainingCapacity[carrier]--;
                         recoverableUnits.Add(fighter);
-                    }
                 }
 
                 foreach (
-                    StarfighterState fighter in fighters.Where(fighter =>
+                    StarfighterState fighter in survivingFighters.Where(fighter =>
                         !fighter.CanWithdrawIndependently && !recoverableUnits.Contains(fighter)
                     )
                 )
@@ -689,6 +681,42 @@ namespace Rebellion.Game.Combat
                 }
 
                 return recoverableUnits;
+            }
+
+            /// <summary>
+            /// Calculates the carrier bays available after already-resolved fighter outcomes are
+            /// applied. Existing inactive occupants continue to reserve their bays.
+            /// </summary>
+            /// <param name="carrier">The carrier receiving displaced fighters.</param>
+            /// <param name="fighterStates">All fighters that participated in the battle.</param>
+            /// <returns>The number of bays available for reassignment.</returns>
+            private static int GetAvailableRecoveryCapacity(
+                CapitalShipState carrier,
+                IReadOnlyList<StarfighterState> fighterStates
+            )
+            {
+                int releasedCapacity = fighterStates.Count(fighter =>
+                    IsAssignedToCarrier(fighter, carrier)
+                    && (!fighter.IsAlive || fighter.CanWithdrawIndependently)
+                );
+                return Math.Max(carrier.Ship.GetExcessStarfighterCapacity() + releasedCapacity, 0);
+            }
+
+            /// <summary>
+            /// Returns whether a fighter is currently assigned to a specified carrier.
+            /// </summary>
+            /// <param name="fighter">The fighter assignment to inspect.</param>
+            /// <param name="carrier">The expected carrier.</param>
+            /// <returns>True when the fighter is a child of the carrier.</returns>
+            private static bool IsAssignedToCarrier(
+                StarfighterState fighter,
+                CapitalShipState carrier
+            )
+            {
+                return ReferenceEquals(
+                    fighter.Fighter.GetParentOfType<CapitalShip>(),
+                    carrier.Ship
+                );
             }
         }
 

--- a/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
+++ b/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
@@ -372,21 +372,16 @@ namespace Rebellion.Game.Combat
         /// <param name="force">The force to complete.</param>
         private static void CompleteStalematedForce(CombatForce force)
         {
-            bool withdrew = force.HasWithdrawnUnits;
-            foreach (TacticalUnit unit in force.Units.Where(unit => unit.IsTargetable))
+            foreach (TacticalUnit unit in force.Units.Where(unit => unit.IsTargetable).ToList())
             {
                 if (unit.CanWithdraw)
-                {
                     unit.CompleteWithdrawal();
-                    withdrew = true;
-                }
-                else
-                {
-                    unit.Destroy();
-                }
             }
 
-            if (withdrew)
+            foreach (TacticalUnit unit in force.Units.Where(unit => unit.IsTargetable))
+                unit.Destroy();
+
+            if (force.HasWithdrawnUnits)
                 force.Outcome = SpaceCombatSideOutcome.Withdrawn;
             else
                 force.Outcome = SpaceCombatSideOutcome.Destroyed;
@@ -621,9 +616,81 @@ namespace Rebellion.Game.Combat
             /// </summary>
             internal void CompleteWithdrawal()
             {
-                foreach (TacticalUnit unit in _units.Where(unit => unit.IsAlive))
-                    unit.FinishWithdrawal();
+                HashSet<TacticalUnit> recoverableUnits = GetRecoverableUnits();
+                foreach (TacticalUnit unit in _units.Where(unit => unit.IsTargetable))
+                {
+                    if (unit.CanWithdrawIndependently || recoverableUnits.Contains(unit))
+                        unit.FinishWithdrawal();
+                    else
+                        unit.CancelWithdrawal();
+                }
                 IsWithdrawing = false;
+            }
+
+            /// <summary>
+            /// Assigns surviving non-hyperdrive fighters to withdrawing carrier capacity.
+            /// Existing mother-ship assignments are honored first, followed by deterministic
+            /// reassignment to another carrier that is still able to leave the battle.
+            /// </summary>
+            /// <returns>The carrier-dependent fighters that can leave with the group.</returns>
+            private HashSet<TacticalUnit> GetRecoverableUnits()
+            {
+                List<CapitalShipState> carriers = _units
+                    .OfType<CapitalShipState>()
+                    .Where(carrier =>
+                        carrier.IsTargetable
+                        && carrier.CanWithdrawIndependently
+                        && carrier.Ship.StarfighterCapacity > 0
+                    )
+                    .ToList();
+                List<StarfighterState> fighters = _units
+                    .OfType<StarfighterState>()
+                    .Where(fighter => fighter.IsTargetable)
+                    .ToList();
+                Dictionary<CapitalShipState, int> remainingCapacity = carriers.ToDictionary(
+                    carrier => carrier,
+                    carrier => Math.Max(carrier.Ship.StarfighterCapacity, 0)
+                );
+                HashSet<TacticalUnit> recoverableUnits = new HashSet<TacticalUnit>();
+
+                foreach (CapitalShipState carrier in carriers)
+                {
+                    IEnumerable<StarfighterState> assignedFighters = fighters
+                        .Where(fighter =>
+                            ReferenceEquals(
+                                fighter.Fighter.GetParentOfType<CapitalShip>(),
+                                carrier.Ship
+                            )
+                        )
+                        .OrderBy(fighter => fighter.CanWithdrawIndependently ? 1 : 0);
+                    foreach (StarfighterState fighter in assignedFighters)
+                    {
+                        if (remainingCapacity[carrier] <= 0)
+                            break;
+
+                        remainingCapacity[carrier]--;
+                        if (!fighter.CanWithdrawIndependently)
+                            recoverableUnits.Add(fighter);
+                    }
+                }
+
+                foreach (
+                    StarfighterState fighter in fighters.Where(fighter =>
+                        !fighter.CanWithdrawIndependently && !recoverableUnits.Contains(fighter)
+                    )
+                )
+                {
+                    CapitalShipState recoveryCarrier = carriers.FirstOrDefault(carrier =>
+                        remainingCapacity[carrier] > 0
+                    );
+                    if (recoveryCarrier == null)
+                        continue;
+
+                    remainingCapacity[recoveryCarrier]--;
+                    recoverableUnits.Add(fighter);
+                }
+
+                return recoverableUnits;
             }
         }
 
@@ -640,6 +707,7 @@ namespace Rebellion.Game.Combat
             protected double MinimumManeuverRatio => _minimumManeuverRatio;
             internal abstract ISceneNode Node { get; }
             internal abstract bool IsAlive { get; }
+            internal abstract bool CanWithdrawIndependently { get; }
             internal abstract double ManeuverRate { get; }
             internal abstract double ClosingSpeed { get; }
             internal virtual double WithdrawalSpeed => ClosingSpeed;
@@ -827,6 +895,15 @@ namespace Rebellion.Game.Combat
             }
 
             /// <summary>
+            /// Returns a unit to combat when it reaches the boundary without a way to enter
+            /// hyperspace or recover aboard a surviving carrier.
+            /// </summary>
+            internal void CancelWithdrawal()
+            {
+                IsWithdrawing = false;
+            }
+
+            /// <summary>
             /// Calculates the original maneuver-rate adjustment used against fighter targets.
             /// </summary>
             /// <param name="target">The target unit.</param>
@@ -873,6 +950,7 @@ namespace Rebellion.Game.Combat
             internal double CurrentShields { get; private set; }
             internal override ISceneNode Node => Ship;
             internal override bool IsAlive => CurrentHull > 0;
+            internal override bool CanWithdrawIndependently => Ship.Hyperdrive > 0;
             internal override bool IsStarfighter => false;
             internal override double RemainingDurability => CurrentHull + CurrentShields;
             internal override bool IsAttackDelayed => _attackDelay > 0;
@@ -1416,6 +1494,7 @@ namespace Rebellion.Game.Combat
                     : 0;
             internal override ISceneNode Node => Fighter;
             internal override bool IsAlive => _currentDurability > 0;
+            internal override bool CanWithdrawIndependently => Fighter.Hyperdrive > 0;
             internal override bool IsStarfighter => true;
             internal override double RemainingDurability => _currentDurability;
             internal override bool CanScanForTargets =>

--- a/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
+++ b/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
@@ -655,22 +655,20 @@ namespace Rebellion.Game.Combat
 
                 foreach (CapitalShipState carrier in carriers)
                 {
-                    IEnumerable<StarfighterState> assignedFighters = fighters
-                        .Where(fighter =>
-                            ReferenceEquals(
-                                fighter.Fighter.GetParentOfType<CapitalShip>(),
-                                carrier.Ship
-                            )
+                    IEnumerable<StarfighterState> assignedFighters = fighters.Where(fighter =>
+                        !fighter.CanWithdrawIndependently
+                        && ReferenceEquals(
+                            fighter.Fighter.GetParentOfType<CapitalShip>(),
+                            carrier.Ship
                         )
-                        .OrderBy(fighter => fighter.CanWithdrawIndependently ? 1 : 0);
+                    );
                     foreach (StarfighterState fighter in assignedFighters)
                     {
                         if (remainingCapacity[carrier] <= 0)
                             break;
 
                         remainingCapacity[carrier]--;
-                        if (!fighter.CanWithdrawIndependently)
-                            recoverableUnits.Add(fighter);
+                        recoverableUnits.Add(fighter);
                     }
                 }
 

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -2418,6 +2418,18 @@ namespace Rebellion.Systems
             string evictingOwnerInstanceID = null
         )
         {
+            if (unit == null)
+                throw new ArgumentNullException(nameof(unit));
+
+            if (!CanTravelBetweenPlanets(unit))
+            {
+                unit.Movement = null;
+                GameLogger.Warning(
+                    $"{unit.GetDisplayName()} has no hyperdrive or carrier and cannot evacuate."
+                );
+                return;
+            }
+
             string ownerID = GetMovementControlOwner(unit);
             if (string.IsNullOrEmpty(ownerID))
             {
@@ -2461,6 +2473,8 @@ namespace Rebellion.Systems
         internal bool CanEvacuateToNearestFriendlyPlanet(IMovable unit)
         {
             if (unit == null)
+                return false;
+            if (!CanTravelBetweenPlanets(unit))
                 return false;
 
             string ownerId = GetMovementControlOwner(unit);
@@ -2507,7 +2521,12 @@ namespace Rebellion.Systems
             if (units == null)
                 throw new ArgumentNullException(nameof(units));
 
-            foreach (IMovable unit in units.Where(unit => unit != null).ToList())
+            foreach (
+                IMovable unit in units
+                    .Where(unit => unit != null)
+                    .OrderBy(unit => unit is Starfighter fighter && fighter.Hyperdrive <= 0 ? 0 : 1)
+                    .ToList()
+            )
             {
                 ISceneNode node = unit;
                 CapitalShip currentShip = node?.GetParentOfType<CapitalShip>();
@@ -2523,9 +2542,33 @@ namespace Rebellion.Systems
                     );
                 if (destination != null)
                     _game.MoveNode(node, destination);
-                else
+                else if (CanTravelBetweenPlanets(unit))
                     EvacuateToNearestFriendlyPlanet(unit);
             }
+        }
+
+        /// <summary>
+        /// Returns whether a unit can cross interplanetary space under its own power or as part
+        /// of a fleet with at least one operational hyperdrive.
+        /// </summary>
+        /// <param name="unit">The unit attempting to travel.</param>
+        /// <returns>True when the unit has a valid interplanetary movement source.</returns>
+        private static bool CanTravelBetweenPlanets(IMovable unit)
+        {
+            return unit switch
+            {
+                Starfighter fighter => fighter.Hyperdrive > 0,
+                CapitalShip capitalShip => capitalShip.Hyperdrive > 0,
+                Fleet fleet => fleet
+                    .GetChildren<CapitalShip>()
+                    .Any(ship =>
+                        ship.ManufacturingStatus == ManufacturingStatus.Complete
+                        && ship.Movement == null
+                        && ship.CurrentHullStrength > 0
+                        && ship.Hyperdrive > 0
+                    ),
+                _ => unit != null,
+            };
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -2531,16 +2531,48 @@ namespace Rebellion.Systems
                 ISceneNode node = unit;
                 CapitalShip currentShip = node?.GetParentOfType<CapitalShip>();
                 Fleet fleet = node?.GetParentOfType<Fleet>();
-                CapitalShip destination = fleet
-                    ?.GetChildren<CapitalShip>()
-                    .FirstOrDefault(ship =>
+                List<CapitalShip> availableShips = (
+                    fleet?.GetChildren<CapitalShip>() ?? Array.Empty<CapitalShip>()
+                )
+                    .Where(ship =>
                         ship != currentShip
                         && ship.ManufacturingStatus == ManufacturingStatus.Complete
                         && ship.Movement == null
                         && ship.CurrentHullStrength > 0
-                        && ship.CanAcceptChild(node)
-                    );
-                if (destination != null)
+                    )
+                    .ToList();
+                CapitalShip destination = availableShips.FirstOrDefault(ship =>
+                    ship.CanAcceptChild(node)
+                );
+                Starfighter independentlyMobileOccupant = null;
+                if (
+                    destination == null
+                    && unit is Starfighter starfighter
+                    && starfighter.Hyperdrive <= 0
+                )
+                {
+                    foreach (CapitalShip availableShip in availableShips)
+                    {
+                        independentlyMobileOccupant = availableShip
+                            .GetChildren<Starfighter>()
+                            .FirstOrDefault(fighter =>
+                                fighter.ManufacturingStatus == ManufacturingStatus.Complete
+                                && fighter.Movement == null
+                                && fighter.Hyperdrive > 0
+                                && CanEvacuateToNearestFriendlyPlanet(fighter)
+                            );
+                        if (independentlyMobileOccupant == null)
+                            continue;
+
+                        destination = availableShip;
+                        break;
+                    }
+                }
+
+                if (independentlyMobileOccupant != null)
+                    EvacuateToNearestFriendlyPlanet(independentlyMobileOccupant);
+
+                if (destination?.CanAcceptChild(node) == true)
                     _game.MoveNode(node, destination);
                 else if (CanTravelBetweenPlanets(unit))
                     EvacuateToNearestFriendlyPlanet(unit);

--- a/Assets/Scripts/Systems/SpaceCombatSystem.cs
+++ b/Assets/Scripts/Systems/SpaceCombatSystem.cs
@@ -659,7 +659,10 @@ namespace Rebellion.Systems
         {
             return fleets?.Count > 0
                 && !IsRetreatBlockedByGravityWell(fleets, opponents)
-                && fleets.All(_movement.CanEvacuateToNearestFriendlyPlanet);
+                && fleets.All(fleet =>
+                    HasHyperdriveCapableShip(fleet)
+                    && _movement.CanEvacuateToNearestFriendlyPlanet(fleet)
+                );
         }
 
         /// <summary>
@@ -683,8 +686,9 @@ namespace Rebellion.Systems
                 return groups;
 
             foreach (
-                Fleet fleet in (fleets ?? Array.Empty<Fleet>()).Where(
-                    _movement.CanEvacuateToNearestFriendlyPlanet
+                Fleet fleet in (fleets ?? Array.Empty<Fleet>()).Where(fleet =>
+                    HasHyperdriveCapableShip(fleet)
+                    && _movement.CanEvacuateToNearestFriendlyPlanet(fleet)
                 )
             )
             {
@@ -706,6 +710,16 @@ namespace Rebellion.Systems
             }
 
             return groups;
+        }
+
+        /// <summary>
+        /// Returns whether a fleet has a surviving capital ship capable of entering hyperspace.
+        /// </summary>
+        /// <param name="fleet">The fleet whose withdrawal capability is being checked.</param>
+        /// <returns>True when at least one active capital ship has a hyperdrive.</returns>
+        private static bool HasHyperdriveCapableShip(Fleet fleet)
+        {
+            return fleet != null && GetActiveCapitalShips(fleet).Any(ship => ship.Hyperdrive > 0);
         }
 
         /// <summary>
@@ -740,6 +754,8 @@ namespace Rebellion.Systems
                 return false;
 
             if (!ignoreGravityWell && IsRetreatBlockedByGravityWell(fleets, opponents))
+                return false;
+            if (fleets.Any(fleet => !HasHyperdriveCapableShip(fleet)))
                 return false;
 
             bool allRetreated = true;

--- a/Assets/Scripts/Systems/SpaceCombatSystem.cs
+++ b/Assets/Scripts/Systems/SpaceCombatSystem.cs
@@ -1585,8 +1585,8 @@ namespace Rebellion.Systems
             IReadOnlyList<Fleet> defenderFleets
         )
         {
-            List<GameResult> events = ApplyShipDamage(shipDamage);
             ApplyFighterSquadronLosses(fighterLosses);
+            List<GameResult> events = ApplyShipDamage(shipDamage);
 
             foreach (
                 Fleet fleet in attackerFleets

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -870,6 +870,78 @@ namespace Rebellion.Tests.Game.Combat
         }
 
         [Test]
+        public void Resolve_HyperdriveFighterOccupiesRecoveryCarrier_WithdrawsBothFighters()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 1000, weaponStrength: 10);
+            CapitalShip destroyedCarrier = CreateShip(
+                "destroyed-carrier",
+                hull: 1,
+                weaponStrength: 1
+            );
+            destroyedCarrier.StarfighterCapacity = 1;
+            destroyedCarrier.SublightSpeed = 10;
+            CapitalShip recoveryCarrier = CreateShip(
+                "recovery-carrier",
+                hull: 1000,
+                weaponStrength: 1
+            );
+            recoveryCarrier.StarfighterCapacity = 1;
+            recoveryCarrier.SublightSpeed = 10;
+            Starfighter hyperdriveFighter = CreateFighter(
+                "hyperdrive-fighter",
+                squadronSize: 12,
+                weaponStrength: 0
+            );
+            hyperdriveFighter.Hyperdrive = 1;
+            hyperdriveFighter.ShieldStrength = 100;
+            hyperdriveFighter.SublightSpeed = 10;
+            Starfighter nonHyperdriveFighter = CreateFighter(
+                "non-hyperdrive-fighter",
+                squadronSize: 12,
+                weaponStrength: 0
+            );
+            nonHyperdriveFighter.Hyperdrive = 0;
+            nonHyperdriveFighter.ShieldStrength = 100;
+            nonHyperdriveFighter.SublightSpeed = 10;
+            Fleet fleet = new Fleet();
+            fleet.AddChild(destroyedCarrier);
+            fleet.AddChild(recoveryCarrier);
+            destroyedCarrier.AddChild(nonHyperdriveFighter);
+            recoveryCarrier.AddChild(hyperdriveFighter);
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveRetreatStrengthRatio = 1.01;
+            config.AutoResolveStartingDistance = 0;
+            config.AutoResolveWithdrawalDistance = 20;
+            config.AutoResolveTargetScanDivisor = 1;
+            IReadOnlyList<IReadOnlyCollection<ISceneNode>> withdrawalGroups =
+                new IReadOnlyCollection<ISceneNode>[]
+                {
+                    new ISceneNode[]
+                    {
+                        destroyedCarrier,
+                        recoveryCarrier,
+                        hyperdriveFighter,
+                        nonHyperdriveFighter,
+                    },
+                };
+
+            SpaceCombatAutoResult result = CreateResolver(config, new ArcDamageRNG())
+                .Resolve(
+                    new[] { attacker },
+                    new List<Starfighter>(),
+                    new[] { destroyedCarrier, recoveryCarrier },
+                    new[] { hyperdriveFighter, nonHyperdriveFighter },
+                    Array.Empty<IReadOnlyCollection<ISceneNode>>(),
+                    withdrawalGroups
+                );
+
+            Assert.AreEqual(0, GetShipOutcome(result, destroyedCarrier).HullAfter);
+            Assert.IsTrue(GetShipOutcome(result, recoveryCarrier).Withdrew);
+            Assert.IsTrue(GetFighterOutcome(result, hyperdriveFighter).Withdrew);
+            Assert.IsTrue(GetFighterOutcome(result, nonHyperdriveFighter).Withdrew);
+        }
+
+        [Test]
         public void Resolve_UnarmedForcesWithoutWithdrawal_DestroysBothForces()
         {
             CapitalShip attacker = CreateShip("attacker", hull: 100, weaponStrength: 0);

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -739,6 +739,137 @@ namespace Rebellion.Tests.Game.Combat
         }
 
         [Test]
+        public void Resolve_CarriedNonHyperdriveFighterWithdraws_PreservesFighter()
+        {
+            CapitalShip attacker = CreatePassiveTarget("attacker", hull: 100);
+            CapitalShip carrier = CreateShip("carrier", hull: 100, weaponStrength: 1);
+            carrier.StarfighterCapacity = 1;
+            carrier.SublightSpeed = 10;
+            Starfighter fighter = CreateFighter("fighter", squadronSize: 12, weaponStrength: 0);
+            fighter.Hyperdrive = 0;
+            fighter.SublightSpeed = 10;
+            Fleet fleet = new Fleet();
+            fleet.AddChild(carrier);
+            carrier.AddChild(fighter);
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveRetreatStrengthRatio = 1.01;
+            config.AutoResolveStartingDistance = 0;
+            IReadOnlyList<IReadOnlyCollection<ISceneNode>> withdrawalGroups =
+                new IReadOnlyCollection<ISceneNode>[] { new ISceneNode[] { carrier, fighter } };
+
+            SpaceCombatAutoResult result = CreateResolver(config)
+                .Resolve(
+                    new[] { attacker },
+                    new List<Starfighter>(),
+                    new[] { carrier },
+                    new[] { fighter },
+                    Array.Empty<IReadOnlyCollection<ISceneNode>>(),
+                    withdrawalGroups
+                );
+
+            Assert.IsTrue(GetShipOutcome(result, carrier).Withdrew);
+            Assert.IsTrue(GetFighterOutcome(result, fighter).Withdrew);
+            Assert.AreEqual(12, GetFighterOutcome(result, fighter).SquadronSizeAfter);
+        }
+
+        [Test]
+        public void Resolve_CarrierDestroyedWithoutRecoveryCapacity_DestroysNonHyperdriveFighter()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 1000, weaponStrength: 10);
+            CapitalShip carrier = CreateShip("carrier", hull: 1, weaponStrength: 1);
+            carrier.StarfighterCapacity = 1;
+            carrier.SublightSpeed = 10;
+            CapitalShip escapeShip = CreateShip("escape-ship", hull: 1000, weaponStrength: 1);
+            escapeShip.StarfighterCapacity = 0;
+            escapeShip.SublightSpeed = 10;
+            Starfighter fighter = CreateFighter("fighter", squadronSize: 12, weaponStrength: 0);
+            fighter.Hyperdrive = 0;
+            fighter.ShieldStrength = 100;
+            fighter.SublightSpeed = 10;
+            Fleet fleet = new Fleet();
+            fleet.AddChild(carrier);
+            fleet.AddChild(escapeShip);
+            carrier.AddChild(fighter);
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveRetreatStrengthRatio = 1.01;
+            config.AutoResolveStartingDistance = 0;
+            config.AutoResolveWithdrawalDistance = 20;
+            config.AutoResolveTargetScanDivisor = 1;
+            IReadOnlyList<IReadOnlyCollection<ISceneNode>> withdrawalGroups =
+                new IReadOnlyCollection<ISceneNode>[]
+                {
+                    new ISceneNode[] { carrier, escapeShip, fighter },
+                };
+
+            SpaceCombatAutoResult result = CreateResolver(config, new ArcDamageRNG())
+                .Resolve(
+                    new[] { attacker },
+                    new List<Starfighter>(),
+                    new[] { carrier, escapeShip },
+                    new[] { fighter },
+                    Array.Empty<IReadOnlyCollection<ISceneNode>>(),
+                    withdrawalGroups
+                );
+
+            Assert.IsTrue(GetShipOutcome(result, escapeShip).Withdrew);
+            Assert.IsFalse(GetFighterOutcome(result, fighter).Withdrew);
+            Assert.AreEqual(0, GetFighterOutcome(result, fighter).SquadronSizeAfter);
+        }
+
+        [Test]
+        public void Resolve_CarrierDestroyedWithSpareRecoveryCapacity_WithdrawsNonHyperdriveFighter()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 1000, weaponStrength: 10);
+            CapitalShip destroyedCarrier = CreateShip(
+                "destroyed-carrier",
+                hull: 1,
+                weaponStrength: 1
+            );
+            destroyedCarrier.StarfighterCapacity = 1;
+            destroyedCarrier.SublightSpeed = 10;
+            CapitalShip recoveryCarrier = CreateShip(
+                "recovery-carrier",
+                hull: 1000,
+                weaponStrength: 1
+            );
+            recoveryCarrier.StarfighterCapacity = 1;
+            recoveryCarrier.SublightSpeed = 10;
+            Starfighter fighter = CreateFighter("fighter", squadronSize: 12, weaponStrength: 0);
+            fighter.Hyperdrive = 0;
+            fighter.ShieldStrength = 100;
+            fighter.SublightSpeed = 10;
+            Fleet fleet = new Fleet();
+            fleet.AddChild(destroyedCarrier);
+            fleet.AddChild(recoveryCarrier);
+            destroyedCarrier.AddChild(fighter);
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveRetreatStrengthRatio = 1.01;
+            config.AutoResolveStartingDistance = 0;
+            config.AutoResolveWithdrawalDistance = 20;
+            config.AutoResolveTargetScanDivisor = 1;
+            IReadOnlyList<IReadOnlyCollection<ISceneNode>> withdrawalGroups =
+                new IReadOnlyCollection<ISceneNode>[]
+                {
+                    new ISceneNode[] { destroyedCarrier, recoveryCarrier, fighter },
+                };
+
+            SpaceCombatAutoResult result = CreateResolver(config, new ArcDamageRNG())
+                .Resolve(
+                    new[] { attacker },
+                    new List<Starfighter>(),
+                    new[] { destroyedCarrier, recoveryCarrier },
+                    new[] { fighter },
+                    Array.Empty<IReadOnlyCollection<ISceneNode>>(),
+                    withdrawalGroups
+                );
+
+            Assert.AreEqual(0, GetShipOutcome(result, destroyedCarrier).HullAfter);
+            Assert.IsTrue(GetShipOutcome(result, recoveryCarrier).Withdrew);
+            Assert.IsTrue(GetFighterOutcome(result, fighter).Withdrew);
+            Assert.AreEqual(12, GetFighterOutcome(result, fighter).SquadronSizeAfter);
+        }
+
+        [Test]
         public void Resolve_UnarmedForcesWithoutWithdrawal_DestroysBothForces()
         {
             CapitalShip attacker = CreateShip("attacker", hull: 100, weaponStrength: 0);
@@ -877,6 +1008,7 @@ namespace Rebellion.Tests.Game.Combat
                 InstanceID = instanceId,
                 MaxHullStrength = hull,
                 CurrentHullStrength = hull,
+                Hyperdrive = 1,
                 ManufacturingStatus = ManufacturingStatus.Complete,
                 WeaponRecharge = Math.Max(weaponStrength, 0),
             };
@@ -900,6 +1032,7 @@ namespace Rebellion.Tests.Game.Combat
                 MaxSquadronSize = squadronSize,
                 CurrentSquadronSize = squadronSize,
                 ShieldStrength = 1,
+                Hyperdrive = 1,
                 LaserCannon = weaponStrength,
                 LaserRange = weaponStrength > 0 ? 100 : 0,
                 ManufacturingStatus = ManufacturingStatus.Complete,

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -666,6 +666,86 @@ namespace Rebellion.Tests.Game.Combat
         }
 
         [Test]
+        public void Resolve_WithdrawalRequiredWithoutHyperdrive_ContinuesFighting()
+        {
+            CapitalShip attacker = CreatePassiveTarget("attacker", hull: 1);
+            CapitalShip defender = CreateShip("defender", hull: 100, weaponStrength: 100);
+            defender.Hyperdrive = 0;
+            defender.SublightSpeed = 10;
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveRetreatStrengthRatio = 1.01;
+            config.AutoResolveStartingDistance = 0;
+            config.AutoResolveWithdrawalDistance = 10;
+            config.AutoResolveTargetScanDivisor = 1;
+            IReadOnlyList<IReadOnlyCollection<ISceneNode>> defenderWithdrawalGroups =
+                new IReadOnlyCollection<ISceneNode>[] { new ISceneNode[] { defender } };
+
+            SpaceCombatAutoResult result = CreateResolver(config, new ArcDamageRNG())
+                .Resolve(
+                    new[] { attacker },
+                    new List<Starfighter>(),
+                    new[] { defender },
+                    new List<Starfighter>(),
+                    Array.Empty<IReadOnlyCollection<ISceneNode>>(),
+                    defenderWithdrawalGroups
+                );
+
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, result.AttackerOutcome);
+            Assert.AreEqual(SpaceCombatSideOutcome.Active, result.DefenderOutcome);
+            Assert.AreEqual(0, GetShipOutcome(result, attacker).HullAfter);
+            Assert.IsFalse(GetShipOutcome(result, defender).Withdrew);
+            Assert.Greater(GetShipOutcome(result, defender).HullAfter, 0);
+        }
+
+        [Test]
+        public void Resolve_ThreeCapitalShipsWithdrawWithOneWithoutHyperdrive_DestroysStrandedShip()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 1000, weaponStrength: 10);
+            CapitalShip firstWithdrawingShip = CreateShip(
+                "first-withdrawing-ship",
+                hull: 1000,
+                weaponStrength: 1
+            );
+            firstWithdrawingShip.SublightSpeed = 10;
+            CapitalShip secondWithdrawingShip = CreateShip(
+                "second-withdrawing-ship",
+                hull: 1000,
+                weaponStrength: 1
+            );
+            secondWithdrawingShip.SublightSpeed = 10;
+            CapitalShip strandedShip = CreateShip("stranded-ship", hull: 100, weaponStrength: 1);
+            strandedShip.Hyperdrive = 0;
+            strandedShip.SublightSpeed = 10;
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveRetreatStrengthRatio = 1.01;
+            config.AutoResolveStartingDistance = 0;
+            config.AutoResolveWithdrawalDistance = 10;
+            config.AutoResolveTargetScanDivisor = 1;
+            IReadOnlyList<IReadOnlyCollection<ISceneNode>> defenderWithdrawalGroups =
+                new IReadOnlyCollection<ISceneNode>[]
+                {
+                    new ISceneNode[] { firstWithdrawingShip, secondWithdrawingShip, strandedShip },
+                };
+
+            SpaceCombatAutoResult result = CreateResolver(config, new ArcDamageRNG())
+                .Resolve(
+                    new[] { attacker },
+                    new List<Starfighter>(),
+                    new[] { firstWithdrawingShip, secondWithdrawingShip, strandedShip },
+                    new List<Starfighter>(),
+                    Array.Empty<IReadOnlyCollection<ISceneNode>>(),
+                    defenderWithdrawalGroups
+                );
+
+            Assert.IsTrue(GetShipOutcome(result, firstWithdrawingShip).Withdrew);
+            Assert.IsTrue(GetShipOutcome(result, secondWithdrawingShip).Withdrew);
+            Assert.IsFalse(GetShipOutcome(result, strandedShip).Withdrew);
+            Assert.AreEqual(0, GetShipOutcome(result, strandedShip).HullAfter);
+            Assert.Less(GetShipOutcome(result, attacker).HullAfter, 1000);
+            Assert.AreEqual(SpaceCombatSideOutcome.Withdrawn, result.DefenderOutcome);
+        }
+
+        [Test]
         public void Resolve_FleetWithdrawalInterruptedByVictory_DoesNotWithdrawPartialFleet()
         {
             CapitalShip attacker = CreatePassiveTarget("attacker", hull: 1);
@@ -820,6 +900,70 @@ namespace Rebellion.Tests.Game.Combat
             Assert.IsTrue(GetShipOutcome(result, escapeShip).Withdrew);
             Assert.IsFalse(GetFighterOutcome(result, fighter).Withdrew);
             Assert.AreEqual(0, GetFighterOutcome(result, fighter).SquadronSizeAfter);
+        }
+
+        [Test]
+        public void Resolve_TwoCarriersDestroyedWithNonHyperdriveFighters_DestroysFightersAfterTheyFight()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 1000, weaponStrength: 100);
+            attacker.WeaponRecharge = 100;
+            CapitalShip firstCarrier = CreatePassiveTarget("first-carrier", hull: 1);
+            firstCarrier.StarfighterCapacity = 1;
+            firstCarrier.SublightSpeed = 1;
+            CapitalShip secondCarrier = CreatePassiveTarget("second-carrier", hull: 1);
+            secondCarrier.StarfighterCapacity = 1;
+            secondCarrier.SublightSpeed = 1;
+            Starfighter firstFighter = CreateFighter(
+                "first-fighter",
+                squadronSize: 12,
+                weaponStrength: 10
+            );
+            firstFighter.Hyperdrive = 0;
+            firstFighter.SublightSpeed = 10;
+            Starfighter secondFighter = CreateFighter(
+                "second-fighter",
+                squadronSize: 12,
+                weaponStrength: 10
+            );
+            secondFighter.Hyperdrive = 0;
+            secondFighter.SublightSpeed = 10;
+            Fleet fleet = new Fleet();
+            fleet.AddChild(firstCarrier);
+            firstCarrier.SetParent(fleet);
+            fleet.AddChild(secondCarrier);
+            secondCarrier.SetParent(fleet);
+            firstCarrier.AddChild(firstFighter);
+            firstFighter.SetParent(firstCarrier);
+            secondCarrier.AddChild(secondFighter);
+            secondFighter.SetParent(secondCarrier);
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveRetreatStrengthRatio = 1.01;
+            config.AutoResolveStartingDistance = 0;
+            config.AutoResolveWithdrawalDistance = 10;
+            config.AutoResolveTargetScanDivisor = 1;
+            IReadOnlyList<IReadOnlyCollection<ISceneNode>> defenderWithdrawalGroups =
+                new IReadOnlyCollection<ISceneNode>[]
+                {
+                    new ISceneNode[] { firstCarrier, secondCarrier, firstFighter, secondFighter },
+                };
+
+            SpaceCombatAutoResult result = CreateResolver(config, new ArcDamageRNG())
+                .Resolve(
+                    new[] { attacker },
+                    new List<Starfighter>(),
+                    new[] { firstCarrier, secondCarrier },
+                    new[] { firstFighter, secondFighter },
+                    Array.Empty<IReadOnlyCollection<ISceneNode>>(),
+                    defenderWithdrawalGroups
+                );
+
+            Assert.AreEqual(0, GetShipOutcome(result, firstCarrier).HullAfter);
+            Assert.AreEqual(0, GetShipOutcome(result, secondCarrier).HullAfter);
+            Assert.IsFalse(GetFighterOutcome(result, firstFighter).Withdrew);
+            Assert.IsFalse(GetFighterOutcome(result, secondFighter).Withdrew);
+            Assert.AreEqual(0, GetFighterOutcome(result, firstFighter).SquadronSizeAfter);
+            Assert.AreEqual(0, GetFighterOutcome(result, secondFighter).SquadronSizeAfter);
+            Assert.Less(GetShipOutcome(result, attacker).HullAfter, 1000);
         }
 
         [Test]
@@ -1035,6 +1179,37 @@ namespace Rebellion.Tests.Game.Combat
             Assert.AreEqual(0, GetShipOutcome(result, attacker).HullAfter);
             Assert.AreEqual(0, GetShipOutcome(result, defender).HullAfter);
             Assert.AreEqual(1200, result.IterationsCompleted);
+        }
+
+        [Test]
+        public void Resolve_DamagedShipsCannotRechargeWeaponsOrWithdraw_DestroysBothSides()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 100, weaponStrength: 10);
+            attacker.CurrentHullStrength = 10;
+            attacker.Hyperdrive = 0;
+            attacker.WeaponRecharge = 0;
+            CapitalShip defender = CreateShip("defender", hull: 100, weaponStrength: 10);
+            defender.CurrentHullStrength = 10;
+            defender.Hyperdrive = 0;
+            defender.WeaponRecharge = 0;
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveStartingDistance = 0;
+            config.AutoResolveStagnationIterations = 2;
+            config.AutoResolveTargetScanDivisor = 1;
+
+            SpaceCombatAutoResult result = Resolve(
+                config,
+                new[] { attacker },
+                new List<Starfighter>(),
+                new[] { defender },
+                new List<Starfighter>()
+            );
+
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, result.AttackerOutcome);
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, result.DefenderOutcome);
+            Assert.AreEqual(0, GetShipOutcome(result, attacker).HullAfter);
+            Assert.AreEqual(0, GetShipOutcome(result, defender).HullAfter);
+            Assert.AreEqual(3, result.IterationsCompleted);
         }
 
         private static SpaceCombatAutoResult ResolveSymmetricBattle()

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NUnit.Framework;
 using Rebellion.Game;
 using Rebellion.Game.Combat;
+using Rebellion.Game.Movement;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
@@ -750,7 +751,9 @@ namespace Rebellion.Tests.Game.Combat
             fighter.SublightSpeed = 10;
             Fleet fleet = new Fleet();
             fleet.AddChild(carrier);
+            carrier.SetParent(fleet);
             carrier.AddChild(fighter);
+            fighter.SetParent(carrier);
             GameConfig.SpaceCombatConfig config = CreateConfig();
             config.AutoResolveRetreatStrengthRatio = 1.01;
             config.AutoResolveStartingDistance = 0;
@@ -788,8 +791,11 @@ namespace Rebellion.Tests.Game.Combat
             fighter.SublightSpeed = 10;
             Fleet fleet = new Fleet();
             fleet.AddChild(carrier);
+            carrier.SetParent(fleet);
             fleet.AddChild(escapeShip);
+            escapeShip.SetParent(fleet);
             carrier.AddChild(fighter);
+            fighter.SetParent(carrier);
             GameConfig.SpaceCombatConfig config = CreateConfig();
             config.AutoResolveRetreatStrengthRatio = 1.01;
             config.AutoResolveStartingDistance = 0;
@@ -817,6 +823,74 @@ namespace Rebellion.Tests.Game.Combat
         }
 
         [Test]
+        public void Resolve_RecoveryCarrierBayOccupiedByInTransitFighter_DestroysNonHyperdriveFighter()
+        {
+            CapitalShip attacker = CreateShip("attacker", hull: 1000, weaponStrength: 10);
+            CapitalShip destroyedCarrier = CreateShip(
+                "destroyed-carrier",
+                hull: 1,
+                weaponStrength: 1
+            );
+            destroyedCarrier.StarfighterCapacity = 1;
+            destroyedCarrier.SublightSpeed = 10;
+            CapitalShip recoveryCarrier = CreateShip(
+                "recovery-carrier",
+                hull: 1000,
+                weaponStrength: 1
+            );
+            recoveryCarrier.StarfighterCapacity = 1;
+            recoveryCarrier.SublightSpeed = 10;
+            Starfighter strandedFighter = CreateFighter(
+                "stranded-fighter",
+                squadronSize: 12,
+                weaponStrength: 0
+            );
+            strandedFighter.Hyperdrive = 0;
+            strandedFighter.ShieldStrength = 100;
+            strandedFighter.SublightSpeed = 10;
+            Starfighter inTransitFighter = CreateFighter(
+                "in-transit-fighter",
+                squadronSize: 12,
+                weaponStrength: 0
+            );
+            inTransitFighter.Movement = new MovementState();
+            Fleet fleet = new Fleet();
+            fleet.AddChild(destroyedCarrier);
+            destroyedCarrier.SetParent(fleet);
+            fleet.AddChild(recoveryCarrier);
+            recoveryCarrier.SetParent(fleet);
+            destroyedCarrier.AddChild(strandedFighter);
+            strandedFighter.SetParent(destroyedCarrier);
+            recoveryCarrier.AddChild(inTransitFighter);
+            inTransitFighter.SetParent(recoveryCarrier);
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveRetreatStrengthRatio = 1.01;
+            config.AutoResolveStartingDistance = 0;
+            config.AutoResolveWithdrawalDistance = 20;
+            config.AutoResolveTargetScanDivisor = 1;
+            IReadOnlyList<IReadOnlyCollection<ISceneNode>> withdrawalGroups =
+                new IReadOnlyCollection<ISceneNode>[]
+                {
+                    new ISceneNode[] { destroyedCarrier, recoveryCarrier, strandedFighter },
+                };
+
+            SpaceCombatAutoResult result = CreateResolver(config, new ArcDamageRNG())
+                .Resolve(
+                    new[] { attacker },
+                    new List<Starfighter>(),
+                    new[] { destroyedCarrier, recoveryCarrier },
+                    new[] { strandedFighter },
+                    Array.Empty<IReadOnlyCollection<ISceneNode>>(),
+                    withdrawalGroups
+                );
+
+            Assert.AreEqual(0, GetShipOutcome(result, destroyedCarrier).HullAfter);
+            Assert.IsTrue(GetShipOutcome(result, recoveryCarrier).Withdrew);
+            Assert.IsFalse(GetFighterOutcome(result, strandedFighter).Withdrew);
+            Assert.AreEqual(0, GetFighterOutcome(result, strandedFighter).SquadronSizeAfter);
+        }
+
+        [Test]
         public void Resolve_CarrierDestroyedWithSpareRecoveryCapacity_WithdrawsNonHyperdriveFighter()
         {
             CapitalShip attacker = CreateShip("attacker", hull: 1000, weaponStrength: 10);
@@ -840,8 +914,11 @@ namespace Rebellion.Tests.Game.Combat
             fighter.SublightSpeed = 10;
             Fleet fleet = new Fleet();
             fleet.AddChild(destroyedCarrier);
+            destroyedCarrier.SetParent(fleet);
             fleet.AddChild(recoveryCarrier);
+            recoveryCarrier.SetParent(fleet);
             destroyedCarrier.AddChild(fighter);
+            fighter.SetParent(destroyedCarrier);
             GameConfig.SpaceCombatConfig config = CreateConfig();
             config.AutoResolveRetreatStrengthRatio = 1.01;
             config.AutoResolveStartingDistance = 0;
@@ -905,9 +982,13 @@ namespace Rebellion.Tests.Game.Combat
             nonHyperdriveFighter.SublightSpeed = 10;
             Fleet fleet = new Fleet();
             fleet.AddChild(destroyedCarrier);
+            destroyedCarrier.SetParent(fleet);
             fleet.AddChild(recoveryCarrier);
+            recoveryCarrier.SetParent(fleet);
             destroyedCarrier.AddChild(nonHyperdriveFighter);
+            nonHyperdriveFighter.SetParent(destroyedCarrier);
             recoveryCarrier.AddChild(hyperdriveFighter);
+            hyperdriveFighter.SetParent(recoveryCarrier);
             GameConfig.SpaceCombatConfig config = CreateConfig();
             config.AutoResolveRetreatStrengthRatio = 1.01;
             config.AutoResolveStartingDistance = 0;

--- a/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
@@ -22,7 +22,7 @@ namespace Rebellion.Tests.Sectors
     public class MovementSystemTests
     {
         [Test]
-        public void RelocateUnits_NoCompatibleShip_MovesStarfighterToFriendlyPlanet()
+        public void RelocateUnits_NoCompatibleShip_MovesHyperdriveStarfighterToFriendlyPlanet()
         {
             GameRoot game = new GameRoot(TestConfig.Create());
             Faction faction = new Faction { InstanceID = "alliance" };
@@ -58,6 +58,7 @@ namespace Rebellion.Tests.Sectors
             {
                 InstanceID = "fighter",
                 OwnerInstanceID = faction.InstanceID,
+                Hyperdrive = 1,
                 ManufacturingStatus = ManufacturingStatus.Complete,
             };
             game.AttachNode(fleet, combatPlanet);
@@ -73,6 +74,119 @@ namespace Rebellion.Tests.Sectors
             movement.RelocateUnits(new[] { starfighter });
 
             Assert.AreSame(friendlyPlanet, starfighter.GetParent());
+        }
+
+        [Test]
+        public void RelocateUnits_NoCompatibleShipAndNoHyperdrive_LeavesStarfighterWithCurrentShip()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            Faction faction = new Faction { InstanceID = "alliance" };
+            game.GetFactions().Add(faction);
+            PlanetSector sector = new PlanetSector { InstanceID = "sector" };
+            game.AttachNode(sector, game.Galaxy);
+            Planet combatPlanet = new Planet { InstanceID = "combat" };
+            Planet friendlyPlanet = new Planet
+            {
+                InstanceID = "friendly",
+                OwnerInstanceID = faction.InstanceID,
+                IsColonized = true,
+            };
+            game.AttachNode(combatPlanet, sector);
+            game.AttachNode(friendlyPlanet, sector);
+            Fleet fleet = new Fleet { InstanceID = "fleet", OwnerInstanceID = faction.InstanceID };
+            CapitalShip destroyedShip = new CapitalShip
+            {
+                InstanceID = "destroyed",
+                OwnerInstanceID = faction.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                StarfighterCapacity = 1,
+            };
+            Starfighter starfighter = new Starfighter
+            {
+                InstanceID = "fighter",
+                OwnerInstanceID = faction.InstanceID,
+                Hyperdrive = 0,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, combatPlanet);
+            game.AttachNode(destroyedShip, fleet);
+            game.AttachNode(starfighter, destroyedShip);
+            MovementSystem movement = new MovementSystem(
+                game,
+                new FogOfWarSystem(game),
+                new FleetSystem(game)
+            );
+
+            movement.RelocateUnits(new[] { starfighter });
+
+            Assert.AreSame(destroyedShip, starfighter.GetParent());
+            Assert.IsNull(starfighter.Movement);
+        }
+
+        [Test]
+        public void RelocateUnits_LimitedRecoveryCapacity_PrioritizesNonHyperdriveStarfighter()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            Faction faction = new Faction { InstanceID = "alliance" };
+            game.GetFactions().Add(faction);
+            PlanetSector sector = new PlanetSector { InstanceID = "sector" };
+            game.AttachNode(sector, game.Galaxy);
+            Planet combatPlanet = new Planet { InstanceID = "combat" };
+            Planet friendlyPlanet = new Planet
+            {
+                InstanceID = "friendly",
+                OwnerInstanceID = faction.InstanceID,
+                IsColonized = true,
+            };
+            game.AttachNode(combatPlanet, sector);
+            game.AttachNode(friendlyPlanet, sector);
+            Fleet fleet = new Fleet { InstanceID = "fleet", OwnerInstanceID = faction.InstanceID };
+            CapitalShip destroyedShip = new CapitalShip
+            {
+                InstanceID = "destroyed",
+                OwnerInstanceID = faction.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                StarfighterCapacity = 2,
+            };
+            CapitalShip recoveryCarrier = new CapitalShip
+            {
+                InstanceID = "recovery",
+                OwnerInstanceID = faction.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                CurrentHullStrength = 100,
+                StarfighterCapacity = 1,
+            };
+            Starfighter hyperdriveFighter = new Starfighter
+            {
+                InstanceID = "hyperdrive-fighter",
+                OwnerInstanceID = faction.InstanceID,
+                Hyperdrive = 1,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            Starfighter nonHyperdriveFighter = new Starfighter
+            {
+                InstanceID = "non-hyperdrive-fighter",
+                OwnerInstanceID = faction.InstanceID,
+                Hyperdrive = 0,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, combatPlanet);
+            game.AttachNode(destroyedShip, fleet);
+            game.AttachNode(recoveryCarrier, fleet);
+            game.AttachNode(hyperdriveFighter, destroyedShip);
+            game.AttachNode(nonHyperdriveFighter, destroyedShip);
+            MovementSystem movement = new MovementSystem(
+                game,
+                new FogOfWarSystem(game),
+                new FleetSystem(game)
+            );
+
+            movement.RelocateUnits(new IMovable[] { hyperdriveFighter, nonHyperdriveFighter });
+
+            Assert.AreSame(recoveryCarrier, nonHyperdriveFighter.GetParent());
+            Assert.IsNull(nonHyperdriveFighter.Movement);
+            Assert.AreSame(friendlyPlanet, hyperdriveFighter.GetParent());
+            Assert.IsNotNull(hyperdriveFighter.Movement);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/MovementSystemTests.cs
@@ -190,6 +190,72 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void RelocateUnits_HyperdriveFighterOccupiesRecoveryCapacity_EvacuatesHyperdriveFighterAndRecoversNonHyperdriveFighter()
+        {
+            GameRoot game = new GameRoot(TestConfig.Create());
+            Faction faction = new Faction { InstanceID = "alliance" };
+            game.GetFactions().Add(faction);
+            PlanetSector sector = new PlanetSector { InstanceID = "sector" };
+            game.AttachNode(sector, game.Galaxy);
+            Planet combatPlanet = new Planet { InstanceID = "combat" };
+            Planet friendlyPlanet = new Planet
+            {
+                InstanceID = "friendly",
+                OwnerInstanceID = faction.InstanceID,
+                IsColonized = true,
+            };
+            game.AttachNode(combatPlanet, sector);
+            game.AttachNode(friendlyPlanet, sector);
+            Fleet fleet = new Fleet { InstanceID = "fleet", OwnerInstanceID = faction.InstanceID };
+            CapitalShip destroyedShip = new CapitalShip
+            {
+                InstanceID = "destroyed",
+                OwnerInstanceID = faction.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                StarfighterCapacity = 1,
+            };
+            CapitalShip recoveryCarrier = new CapitalShip
+            {
+                InstanceID = "recovery",
+                OwnerInstanceID = faction.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                CurrentHullStrength = 100,
+                StarfighterCapacity = 1,
+            };
+            Starfighter hyperdriveFighter = new Starfighter
+            {
+                InstanceID = "hyperdrive-fighter",
+                OwnerInstanceID = faction.InstanceID,
+                Hyperdrive = 1,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            Starfighter nonHyperdriveFighter = new Starfighter
+            {
+                InstanceID = "non-hyperdrive-fighter",
+                OwnerInstanceID = faction.InstanceID,
+                Hyperdrive = 0,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, combatPlanet);
+            game.AttachNode(destroyedShip, fleet);
+            game.AttachNode(recoveryCarrier, fleet);
+            game.AttachNode(hyperdriveFighter, recoveryCarrier);
+            game.AttachNode(nonHyperdriveFighter, destroyedShip);
+            MovementSystem movement = new MovementSystem(
+                game,
+                new FogOfWarSystem(game),
+                new FleetSystem(game)
+            );
+
+            movement.RelocateUnits(new[] { nonHyperdriveFighter });
+
+            Assert.AreSame(recoveryCarrier, nonHyperdriveFighter.GetParent());
+            Assert.IsNull(nonHyperdriveFighter.Movement);
+            Assert.AreSame(friendlyPlanet, hyperdriveFighter.GetParent());
+            Assert.IsNotNull(hyperdriveFighter.Movement);
+        }
+
+        [Test]
         public void Constructor_WithNullGame_ThrowsArgumentNullException()
         {
             GameRoot dependencyGame = new GameRoot(TestConfig.Create());

--- a/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
@@ -2002,6 +2002,92 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ResolvePending_WithdrawingFleetCarriesNonHyperdriveFighter_PreservesFighter()
+        {
+            GameRoot game = CreateAutomaticCombatGame();
+            game.Config.Combat.SpaceCombat.AutoResolveRetreatStrengthRatio = 1.01;
+            game.Random = new SequenceRNG();
+            game.GetFactions().First(faction => faction.InstanceID == "empire").PlayerID =
+                "player1";
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat", owner: "alliance");
+            (Planet allianceFallback, _) = CreatePlanet(
+                game,
+                "alliance-fallback",
+                owner: "alliance"
+            );
+            CreatePlanet(game, "empire-fallback", owner: "empire");
+            Fleet attackerFleet = CreateFleet(
+                game,
+                "attacker",
+                "empire",
+                combatPlanet,
+                1,
+                1000,
+                76,
+                shieldRechargeRate: 0
+            );
+            Starfighter attackerFighter = new Starfighter
+            {
+                InstanceID = "attacker-fighter",
+                OwnerInstanceID = "empire",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                MaxSquadronSize = 9,
+                CurrentSquadronSize = 9,
+                ShieldStrength = 1,
+                LaserCannon = 1,
+            };
+            CapitalShip attackerShip = attackerFleet.GetChildren<CapitalShip>().Single();
+            attackerShip.StarfighterCapacity = 1;
+            game.AttachNode(attackerFighter, attackerShip);
+            Fleet defenderFleet = CreateFleet(
+                game,
+                "defender",
+                "alliance",
+                combatPlanet,
+                1,
+                1000,
+                100,
+                shieldRechargeRate: 0
+            );
+            CapitalShip defenderShip = defenderFleet.GetChildren<CapitalShip>().Single();
+            defenderShip.SublightSpeed = 10;
+            defenderShip.StarfighterCapacity = 1;
+            Starfighter defenderFighter = new Starfighter
+            {
+                InstanceID = "defender-fighter",
+                OwnerInstanceID = "alliance",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                MaxSquadronSize = 12,
+                CurrentSquadronSize = 12,
+                ShieldStrength = 1,
+                Hyperdrive = 0,
+                SublightSpeed = 10,
+                LaserCannon = 1,
+            };
+            game.AttachNode(defenderFighter, defenderShip);
+            SpaceCombatSystem manager = MakeSpaceCombat(game);
+
+            manager.ProcessTick();
+            SpaceCombatResult result = manager
+                .ResolvePending(autoResolve: true)
+                .OfType<SpaceCombatResult>()
+                .Single();
+            SpaceCombatSideOutcome allianceOutcome =
+                result.AttackerOwnerInstanceID == "alliance"
+                    ? result.AttackerOutcome
+                    : result.DefenderOutcome;
+
+            Assert.AreEqual(SpaceCombatSideOutcome.Withdrawn, allianceOutcome);
+            Assert.AreSame(allianceFallback, defenderFleet.GetParentOfType<Planet>());
+            Assert.IsNotNull(defenderFleet.Movement);
+            Assert.AreSame(
+                defenderFighter,
+                game.GetSceneNodeByInstanceID<Starfighter>(defenderFighter.InstanceID)
+            );
+            Assert.AreSame(defenderShip, defenderFighter.GetParent());
+        }
+
+        [Test]
         public void ResolvePending_CapitalShipAgainstPlanetaryFighter_DestroysFighter()
         {
             GameRoot game = CreateAutomaticCombatGame();
@@ -2090,6 +2176,35 @@ namespace Rebellion.Tests.Systems
                 SpaceCombatSideOutcome.Active,
                 empireWasAttacker ? combatResult.DefenderOutcome : combatResult.AttackerOutcome
             );
+        }
+
+        [Test]
+        public void ResolvePendingRetreat_FleetWithoutHyperdrive_DoesNotMoveFleet()
+        {
+            GameRoot game = CreateGame();
+            game.GetFactions().First(faction => faction.InstanceID == "empire").PlayerID =
+                "player1";
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat");
+            CreatePlanet(game, "empireHome", owner: "empire");
+            CreatePlanet(game, "allianceHome", owner: "alliance");
+            Fleet empireFleet = CreateFleet(game, "ef1", "empire", combatPlanet, 1, 100, 1);
+            empireFleet.GetChildren<CapitalShip>().Single().Hyperdrive = 0;
+            CreateFleet(game, "af1", "alliance", combatPlanet, 1, 1000, 100);
+            SpaceCombatSystem manager = MakeSpaceCombat(game);
+
+            PendingCombatResult pending = manager
+                .ProcessTick()
+                .OfType<PendingCombatResult>()
+                .Single();
+            bool empireCanRetreat = ReferenceEquals(pending.AttackerFleet, empireFleet)
+                ? pending.AttackerCanRetreat
+                : pending.DefenderCanRetreat;
+            List<GameResult> results = manager.ResolvePendingRetreat("empire");
+
+            Assert.IsFalse(empireCanRetreat);
+            Assert.IsNull(results);
+            Assert.AreSame(combatPlanet, empireFleet.GetParentOfType<Planet>());
+            Assert.IsNull(empireFleet.Movement);
         }
 
         [Test]
@@ -2391,6 +2506,7 @@ namespace Rebellion.Tests.Systems
                     MaxHullStrength = hullStrength,
                     CurrentHullStrength = hullStrength,
                     ShieldRechargeRate = shieldRechargeRate,
+                    Hyperdrive = 1,
                     ManufacturingStatus = ManufacturingStatus.Complete,
                     WeaponRecharge = 1,
                 };

--- a/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
@@ -2088,6 +2088,223 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ResolvePending_CarrierDestroyedWithRecoveryCapacity_ReparentsFighterAndWithdrawsFleet()
+        {
+            (
+                GameRoot game,
+                Fleet retreatingFleet,
+                CapitalShip destroyedCarrier,
+                CapitalShip recoveryCarrier,
+                List<Starfighter> displacedFighters,
+                _,
+                Planet fallbackPlanet,
+                SpaceCombatResult result
+            ) = ResolveCarrierDestructionWithdrawal(
+                recoveryCapacity: 1,
+                displacedFighterHyperdrives: new[] { 0 }
+            );
+            Starfighter fighter = displacedFighters.Single();
+            SpaceCombatSideOutcome retreatingOutcome =
+                result.AttackerOwnerInstanceID == retreatingFleet.OwnerInstanceID
+                    ? result.AttackerOutcome
+                    : result.DefenderOutcome;
+
+            Assert.AreEqual(SpaceCombatSideOutcome.Withdrawn, retreatingOutcome);
+            Assert.IsNull(game.GetSceneNodeByInstanceID<CapitalShip>(destroyedCarrier.InstanceID));
+            Assert.AreSame(
+                recoveryCarrier,
+                game.GetSceneNodeByInstanceID<CapitalShip>(recoveryCarrier.InstanceID)
+            );
+            Assert.AreSame(fallbackPlanet, retreatingFleet.GetParentOfType<Planet>());
+            Assert.IsNotNull(retreatingFleet.Movement);
+            Assert.AreSame(fighter, game.GetSceneNodeByInstanceID<Starfighter>(fighter.InstanceID));
+            Assert.AreSame(recoveryCarrier, fighter.GetParent());
+        }
+
+        [Test]
+        public void ResolvePending_CarrierDestroyedWithoutRecoveryCapacity_DeletesStrandedFighter()
+        {
+            (
+                GameRoot game,
+                Fleet retreatingFleet,
+                CapitalShip destroyedCarrier,
+                CapitalShip recoveryCarrier,
+                List<Starfighter> displacedFighters,
+                _,
+                Planet fallbackPlanet,
+                SpaceCombatResult result
+            ) = ResolveCarrierDestructionWithdrawal(
+                recoveryCapacity: 0,
+                displacedFighterHyperdrives: new[] { 0 }
+            );
+            Starfighter fighter = displacedFighters.Single();
+            SpaceCombatSideOutcome retreatingOutcome =
+                result.AttackerOwnerInstanceID == retreatingFleet.OwnerInstanceID
+                    ? result.AttackerOutcome
+                    : result.DefenderOutcome;
+
+            Assert.AreEqual(SpaceCombatSideOutcome.Withdrawn, retreatingOutcome);
+            Assert.IsNull(game.GetSceneNodeByInstanceID<CapitalShip>(destroyedCarrier.InstanceID));
+            Assert.AreSame(
+                recoveryCarrier,
+                game.GetSceneNodeByInstanceID<CapitalShip>(recoveryCarrier.InstanceID)
+            );
+            Assert.AreSame(fallbackPlanet, retreatingFleet.GetParentOfType<Planet>());
+            Assert.IsNotNull(retreatingFleet.Movement);
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Starfighter>(fighter.InstanceID));
+        }
+
+        [Test]
+        public void ResolvePending_CarrierDestroyedWithPartiallyOccupiedRecoveryCapacity_PreservesOnlyAvailableFighters()
+        {
+            (
+                GameRoot game,
+                Fleet retreatingFleet,
+                CapitalShip destroyedCarrier,
+                CapitalShip recoveryCarrier,
+                List<Starfighter> displacedFighters,
+                List<Starfighter> existingFighters,
+                Planet fallbackPlanet,
+                SpaceCombatResult result
+            ) = ResolveCarrierDestructionWithdrawal(
+                recoveryCapacity: 2,
+                displacedFighterHyperdrives: new[] { 0, 0 },
+                existingRecoveryFighterCount: 1
+            );
+            Starfighter existingFighter = existingFighters.Single();
+            Starfighter recoveredFighter = displacedFighters[0];
+            Starfighter strandedFighter = displacedFighters[1];
+            SpaceCombatSideOutcome retreatingOutcome =
+                result.AttackerOwnerInstanceID == retreatingFleet.OwnerInstanceID
+                    ? result.AttackerOutcome
+                    : result.DefenderOutcome;
+
+            Assert.AreEqual(SpaceCombatSideOutcome.Withdrawn, retreatingOutcome);
+            Assert.IsNull(game.GetSceneNodeByInstanceID<CapitalShip>(destroyedCarrier.InstanceID));
+            Assert.AreSame(fallbackPlanet, retreatingFleet.GetParentOfType<Planet>());
+            Assert.AreSame(recoveryCarrier, existingFighter.GetParent());
+            Assert.AreSame(recoveryCarrier, recoveredFighter.GetParent());
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Starfighter>(strandedFighter.InstanceID));
+        }
+
+        [Test]
+        public void ResolvePending_CarrierDestroyedWithLimitedCapacity_PrioritizesNonHyperdriveFighter()
+        {
+            (
+                GameRoot game,
+                _,
+                _,
+                CapitalShip recoveryCarrier,
+                List<Starfighter> displacedFighters,
+                _,
+                Planet fallbackPlanet,
+                _
+            ) = ResolveCarrierDestructionWithdrawal(
+                recoveryCapacity: 1,
+                displacedFighterHyperdrives: new[] { 1, 0 }
+            );
+            Starfighter hyperdriveFighter = displacedFighters[0];
+            Starfighter nonHyperdriveFighter = displacedFighters[1];
+
+            Assert.AreSame(
+                nonHyperdriveFighter,
+                game.GetSceneNodeByInstanceID<Starfighter>(nonHyperdriveFighter.InstanceID)
+            );
+            Assert.AreSame(recoveryCarrier, nonHyperdriveFighter.GetParent());
+            Assert.AreSame(
+                hyperdriveFighter,
+                game.GetSceneNodeByInstanceID<Starfighter>(hyperdriveFighter.InstanceID)
+            );
+            Assert.AreSame(fallbackPlanet, hyperdriveFighter.GetParentOfType<Planet>());
+            Assert.IsNotNull(hyperdriveFighter.Movement);
+        }
+
+        [Test]
+        public void ResolvePending_HyperdriveFighterOccupiesRecoveryCarrier_EvacuatesHyperdriveFighterAndRecoversNonHyperdriveFighter()
+        {
+            (
+                GameRoot game,
+                _,
+                _,
+                CapitalShip recoveryCarrier,
+                List<Starfighter> displacedFighters,
+                List<Starfighter> existingFighters,
+                Planet fallbackPlanet,
+                _
+            ) = ResolveCarrierDestructionWithdrawal(
+                recoveryCapacity: 1,
+                displacedFighterHyperdrives: new[] { 0 },
+                existingRecoveryFighterCount: 1,
+                existingRecoveryFighterHyperdrive: 1
+            );
+            Starfighter nonHyperdriveFighter = displacedFighters.Single();
+            Starfighter hyperdriveFighter = existingFighters.Single();
+
+            Assert.AreSame(
+                nonHyperdriveFighter,
+                game.GetSceneNodeByInstanceID<Starfighter>(nonHyperdriveFighter.InstanceID)
+            );
+            Assert.AreSame(recoveryCarrier, nonHyperdriveFighter.GetParent());
+            Assert.AreSame(
+                hyperdriveFighter,
+                game.GetSceneNodeByInstanceID<Starfighter>(hyperdriveFighter.InstanceID)
+            );
+            Assert.AreSame(fallbackPlanet, hyperdriveFighter.GetParentOfType<Planet>());
+            Assert.IsNotNull(hyperdriveFighter.Movement);
+        }
+
+        [Test]
+        public void ResolvePending_AutomaticWithdrawalFleetWithoutHyperdrive_DestroysFleet()
+        {
+            GameRoot game = CreateAutomaticCombatGame();
+            game.Config.Combat.SpaceCombat.AutoResolveRetreatStrengthRatio = 1.01;
+            game.Random = new SequenceRNG();
+            game.GetFactions().First(faction => faction.InstanceID == "empire").PlayerID =
+                "player1";
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat", owner: "alliance");
+            CreatePlanet(game, "alliance-fallback", owner: "alliance");
+            CreatePlanet(game, "empire-fallback", owner: "empire");
+            Fleet attackingFleet = CreateFleet(
+                game,
+                "attacker",
+                "empire",
+                combatPlanet,
+                1,
+                1000,
+                10
+            );
+            attackingFleet.GetChildren<CapitalShip>().Single().Hyperdrive = 0;
+            Fleet retreatingFleet = CreateFleet(
+                game,
+                "retreating",
+                "alliance",
+                combatPlanet,
+                1,
+                100,
+                1,
+                shieldRechargeRate: 0
+            );
+            CapitalShip retreatingShip = retreatingFleet.GetChildren<CapitalShip>().Single();
+            retreatingShip.Hyperdrive = 0;
+            retreatingShip.SublightSpeed = 10;
+            SpaceCombatSystem manager = MakeSpaceCombat(game);
+
+            manager.ProcessTick();
+            SpaceCombatResult result = manager
+                .ResolvePending(autoResolve: true)
+                .OfType<SpaceCombatResult>()
+                .Single();
+            SpaceCombatSideOutcome retreatingOutcome =
+                result.AttackerOwnerInstanceID == retreatingFleet.OwnerInstanceID
+                    ? result.AttackerOutcome
+                    : result.DefenderOutcome;
+
+            Assert.AreEqual(SpaceCombatSideOutcome.Destroyed, retreatingOutcome);
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Fleet>(retreatingFleet.InstanceID));
+            Assert.IsNull(game.GetSceneNodeByInstanceID<CapitalShip>(retreatingShip.InstanceID));
+        }
+
+        [Test]
         public void ResolvePending_CapitalShipAgainstPlanetaryFighter_DestroysFighter()
         {
             GameRoot game = CreateAutomaticCombatGame();
@@ -2435,6 +2652,114 @@ namespace Rebellion.Tests.Systems
         private static SpaceCombatResult GetCombatResult(List<GameResult> results)
         {
             return results.OfType<SpaceCombatResult>().Single();
+        }
+
+        private (
+            GameRoot game,
+            Fleet retreatingFleet,
+            CapitalShip destroyedCarrier,
+            CapitalShip recoveryCarrier,
+            List<Starfighter> displacedFighters,
+            List<Starfighter> existingFighters,
+            Planet fallbackPlanet,
+            SpaceCombatResult result
+        ) ResolveCarrierDestructionWithdrawal(
+            int recoveryCapacity,
+            IReadOnlyList<int> displacedFighterHyperdrives,
+            int existingRecoveryFighterCount = 0,
+            int existingRecoveryFighterHyperdrive = 0
+        )
+        {
+            GameRoot game = CreateAutomaticCombatGame();
+            game.Config.Combat.SpaceCombat.AutoResolveTargetScanDivisor = 1;
+            game.Config.Combat.SpaceCombat.AutoResolveStartingDistance = 0;
+            game.Config.Combat.SpaceCombat.AutoResolveWithdrawalDistance = 10;
+            game.Random = new SequenceRNG();
+            game.GetFactions().First(faction => faction.InstanceID == "empire").PlayerID =
+                "player1";
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat", owner: "alliance");
+            (Planet fallbackPlanet, _) = CreatePlanet(game, "alliance-fallback", owner: "alliance");
+            CreatePlanet(game, "empire-fallback", owner: "empire");
+            CreateFleet(game, "attacker", "empire", combatPlanet, 1, 1000, 10);
+            Fleet retreatingFleet = CreateFleet(
+                game,
+                "retreating",
+                "alliance",
+                combatPlanet,
+                2,
+                1000,
+                1,
+                shieldRechargeRate: 0
+            );
+            IReadOnlyList<CapitalShip> retreatingShips = retreatingFleet.GetChildren<CapitalShip>();
+            CapitalShip destroyedCarrier = retreatingShips[0];
+            destroyedCarrier.MaxHullStrength = 1;
+            destroyedCarrier.CurrentHullStrength = 1;
+            destroyedCarrier.StarfighterCapacity = displacedFighterHyperdrives.Count;
+            destroyedCarrier.SublightSpeed = 10;
+            destroyedCarrier.PrimaryWeapons[PrimaryWeaponType.Turbolaser] = new int[]
+            {
+                100,
+                0,
+                0,
+                0,
+                100,
+            };
+            CapitalShip recoveryCarrier = retreatingShips[1];
+            recoveryCarrier.StarfighterCapacity = recoveryCapacity;
+            recoveryCarrier.SublightSpeed = 10;
+            List<Starfighter> displacedFighters = new List<Starfighter>();
+            for (int index = 0; index < displacedFighterHyperdrives.Count; index++)
+            {
+                Starfighter fighter = new Starfighter
+                {
+                    InstanceID = $"displaced-fighter-{index}",
+                    OwnerInstanceID = "alliance",
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                    MaxSquadronSize = 12,
+                    CurrentSquadronSize = 12,
+                    ShieldStrength = 1,
+                    Hyperdrive = displacedFighterHyperdrives[index],
+                    SublightSpeed = 10,
+                };
+                game.AttachNode(fighter, destroyedCarrier);
+                displacedFighters.Add(fighter);
+            }
+            List<Starfighter> existingFighters = new List<Starfighter>();
+            for (int index = 0; index < existingRecoveryFighterCount; index++)
+            {
+                Starfighter fighter = new Starfighter
+                {
+                    InstanceID = $"existing-fighter-{index}",
+                    OwnerInstanceID = "alliance",
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                    MaxSquadronSize = 12,
+                    CurrentSquadronSize = 12,
+                    ShieldStrength = 1,
+                    Hyperdrive = existingRecoveryFighterHyperdrive,
+                    SublightSpeed = 10,
+                };
+                game.AttachNode(fighter, recoveryCarrier);
+                existingFighters.Add(fighter);
+            }
+            SpaceCombatSystem manager = MakeSpaceCombat(game);
+
+            manager.ProcessTick();
+            SpaceCombatResult result = manager
+                .ResolvePending(autoResolve: true)
+                .OfType<SpaceCombatResult>()
+                .Single();
+
+            return (
+                game,
+                retreatingFleet,
+                destroyedCarrier,
+                recoveryCarrier,
+                displacedFighters,
+                existingFighters,
+                fallbackPlanet,
+                result
+            );
         }
 
         private static GameRoot CreateAutomaticCombatGame()

--- a/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
@@ -2188,6 +2188,38 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ResolvePending_InTransitFighterOccupiesRecoveryCarrier_RecordsStrandedFighterLoss()
+        {
+            (
+                GameRoot game,
+                Fleet retreatingFleet,
+                _,
+                CapitalShip recoveryCarrier,
+                List<Starfighter> displacedFighters,
+                List<Starfighter> existingFighters,
+                Planet fallbackPlanet,
+                SpaceCombatResult result
+            ) = ResolveCarrierDestructionWithdrawal(
+                recoveryCapacity: 1,
+                displacedFighterHyperdrives: new[] { 0 },
+                existingRecoveryFighterCount: 1,
+                existingRecoveryFightersAreInTransit: true
+            );
+            Starfighter strandedFighter = displacedFighters.Single();
+            Starfighter inTransitFighter = existingFighters.Single();
+            FighterLossResult loss = result.FighterLosses.Single(candidate =>
+                candidate.Fighter == strandedFighter
+            );
+
+            Assert.AreSame(fallbackPlanet, retreatingFleet.GetParentOfType<Planet>());
+            Assert.AreSame(recoveryCarrier, inTransitFighter.GetParent());
+            Assert.IsNotNull(inTransitFighter.Movement);
+            Assert.IsNull(game.GetSceneNodeByInstanceID<Starfighter>(strandedFighter.InstanceID));
+            Assert.AreEqual(12, loss.SquadsBefore);
+            Assert.AreEqual(0, loss.SquadsAfter);
+        }
+
+        [Test]
         public void ResolvePending_CarrierDestroyedWithLimitedCapacity_PrioritizesNonHyperdriveFighter()
         {
             (
@@ -2667,7 +2699,8 @@ namespace Rebellion.Tests.Systems
             int recoveryCapacity,
             IReadOnlyList<int> displacedFighterHyperdrives,
             int existingRecoveryFighterCount = 0,
-            int existingRecoveryFighterHyperdrive = 0
+            int existingRecoveryFighterHyperdrive = 0,
+            bool existingRecoveryFightersAreInTransit = false
         )
         {
             GameRoot game = CreateAutomaticCombatGame();
@@ -2739,6 +2772,13 @@ namespace Rebellion.Tests.Systems
                     Hyperdrive = existingRecoveryFighterHyperdrive,
                     SublightSpeed = 10,
                 };
+                if (existingRecoveryFightersAreInTransit)
+                {
+                    fighter.Movement = new MovementState
+                    {
+                        CurrentPosition = combatPlanet.GetPosition(),
+                    };
+                }
                 game.AttachNode(fighter, recoveryCarrier);
                 existingFighters.Add(fighter);
             }


### PR DESCRIPTION
## Summary

- Requiring an operational hyperdrive-capable capital ship before a fleet can retreat.
- Letting hyperdrive-equipped fighters withdraw independently, while requiring fighters without hyperdrives to recover aboard a surviving withdrawing carrier with available capacity.
- Preserving existing non-hyperdrive carrier assignments when possible, reassign stranded fighters deterministically, and prioritize fighters that cannot leave independently when recovery capacity is limited.
- Calculating recovery space from actual occupied carrier capacity, including bays reserved by inactive or in-transit fighters and bays released by destroyed or independently withdrawing fighters.
- Evacuating a hyperdrive-capable fighter from an occupied recovery bay when that bay is required by a non-hyperdrive fighter.
- Preventing destroyed or already-withdrawn carriers from recovering fighters, and leave unrecoverable fighters in combat to be resolved as losses.
- Applying the same hyperdrive and carrier constraints when relocating units after a carrier is destroyed.

This restores the carrier-dependent recovery model and fixes non-hyperdrive fighter squadrons escaping after their carrier is destroyed.

## Scenario coverage

- Surviving assigned carrier preserves its non-hyperdrive fighter.
- Destroyed carrier with spare recovery capacity reparents the fighter and withdraws the fleet.
- Destroyed carrier without recovery capacity leaves the stranded fighter in combat until it is destroyed.
- Two destroyed carriers leave their non-hyperdrive fighters fighting until both squadrons are destroyed.
- Partially occupied recovery capacity preserves only the squadrons that fit.
- In-transit fighters continue reserving their carrier bays, and displaced fighters that cannot fit are recorded as losses.
- Limited recovery capacity prioritizes non-hyperdrive fighters; hyperdrive fighters leave independently.
- A hyperdrive fighter occupying the final recovery bay evacuates independently so a non-hyperdrive fighter can recover.
- Hyperdrive-capable planetary fighters withdraw independently.
- Non-hyperdrive planetary fighters cannot withdraw.
- Fleets without an operational hyperdrive cannot retreat manually or automatically.
- A ship ordered to withdraw without a working hyperdrive resumes fighting instead of disappearing.
- In a three-capital-ship withdrawal, the two hyperdrive-capable ships escape while the stranded ship fights to destruction.
- Equally damaged ships with no hyperdrive and no weapon recharge terminate as a mutual stalemate loss.
- Withdrawal groups remain vulnerable and do not partially disappear before reaching safety.

## Validation

- New occupied-bay regressions: 2/2 failed before the fix and 2/2 passed after it.
- Requested stranded-withdrawal scenarios: 4/4 passed.
- SpaceCombatAutoResolverTests: 38/38 passed.
- MovementSystemTests: 139/139 passed.
- SpaceCombatSystemTests: 66/66 passed.
- Combined affected suites: 243/243 passed across the final test-only addition and the preceding affected-suite run.
- Earlier full EditMode suite: 4,555 passed; 102 unrelated existing UI fixture failures caused by unavailable generated prefab and texture references. No combat or movement tests failed.
- Standalone Windows 64 player build completed successfully after the final changes.
- CSharpier check passed for the changed test fixture and all production files.
- Git diff whitespace check passed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (N/A: no UI builder changes.)
- [x] Content path or structure changes were also made in rebellion2-media. (N/A: no content path or structure changes.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (N/A: no public behavior documentation or setup changes required.)
