### PR TITLE
Fixing bug that set default research level to 1 instead of 0.

### DIFF
--- a/Assets/Scripts/Game/GameSummary.cs
+++ b/Assets/Scripts/Game/GameSummary.cs
@@ -42,7 +42,7 @@ namespace Rebellion.Game
         public GameVictoryCondition VictoryCondition = GameVictoryCondition.Conquest;
         public GameResourceAvailability ResourceAvailability = GameResourceAvailability.Normal;
         public string[] StartingFactionIDs = Array.Empty<string>();
-        public int StartingResearchLevel = 1;
+        public int StartingResearchLevel;
         public string PlayerFactionID;
         public string PackID;
         public string PackVersion;

--- a/Assets/Scripts/UI/SceneUI/GameLaunchContext.cs
+++ b/Assets/Scripts/UI/SceneUI/GameLaunchContext.cs
@@ -46,7 +46,7 @@ public static class GameLaunchContext
             GalaxySize = GameSize.Large,
             VictoryCondition = GameVictoryCondition.Conquest,
             ResourceAvailability = GameResourceAvailability.Normal,
-            StartingResearchLevel = 1,
+            StartingResearchLevel = 0,
             PlayerFactionID = contentPack.Scenario.DefaultPlayerFactionID,
             StartingFactionIDs = startingFactionIds,
             PackID = contentPack.Definition.ID,

--- a/Assets/Tests/EditMode/GameTests/Game/GameSummaryTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/GameSummaryTests.cs
@@ -35,7 +35,7 @@ namespace Rebellion.Tests.Game
                 summary.StartingFactionIDs,
                 "StartingFactionIDs should be empty by default"
             );
-            Assert.AreEqual(1, summary.StartingResearchLevel, "StartingResearchLevel should be 1");
+            Assert.AreEqual(0, summary.StartingResearchLevel, "StartingResearchLevel should be 0");
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/GameLaunchContextTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/GameLaunchContextTests.cs
@@ -40,7 +40,7 @@ namespace Rebellion.Tests.UI.SceneUI
                 GameResourceAvailability.Normal,
                 GameLaunchContext.Summary.ResourceAvailability
             );
-            Assert.AreEqual(1, GameLaunchContext.Summary.StartingResearchLevel);
+            Assert.AreEqual(0, GameLaunchContext.Summary.StartingResearchLevel);
             Assert.AreEqual("FNALL1", GameLaunchContext.Summary.PlayerFactionID);
             Assert.IsNull(GameLaunchContext.SaveFileName);
             Assert.IsFalse(GameLaunchContext.IsLoadGame);


### PR DESCRIPTION
## Summary

Restoring the default starting research level to **0** (it had become `1`).

With `StartingResearchLevel = 1`, `FactionSeeder` sets every faction's highest unlocked research order to 1 across all three disciplines. Since a technology unlocks when `Order <= highestUnlockedOrder`, that made **all Order-1 tech available from tick 0** — Advanced Training Facility (BDFA06), Nebulon-B Frigate / TIE Bomber Squadron, and the Sullustan / War Droid regiments. The AI then upgraded basic facilities to advanced within the first few ticks (players saw Advanced Training Facilities by ~tick 3). This was unintended: the field previously defaulted to `0`, and the `= 1` slipped in via two unrelated bulk commits (`58272357`, `cfc853a6`).

Setting the default back to `0` leaves only Order-0 (basic) tech available at start; the Order-1 items now require actually researching the relevant discipline. New games only — loaded saves keep their seeded state.

## Validation

- `build.sh lint` run locally: clean — Roslynator `0 diagnostics`, Format / Naming / Member-Order `0`, analyzer tests `6/6 Passed`.
- CI: **Lint, Build, and Test all green** (4,640 EditMode tests).
- Updated the two tests that pin the default value: `GameSummaryTests` and `GameLaunchContextTests`.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. — N/A, no UI builder changes.
- [x] Content path or structure changes were also made in `rebellion2-media`. — N/A, code-only change (`Assets/Scripts` + EditMode tests).
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. — N/A, no docs cover this internal default.