### PR TITLE
Adding support for placing officers on randomized capitals.

### DIFF
--- a/Assets/Scripts/Generation/OfficerSeeder.cs
+++ b/Assets/Scripts/Generation/OfficerSeeder.cs
@@ -342,6 +342,9 @@ namespace Rebellion.Generation
         {
             if (rule?.DestinationTypeID != null)
             {
+                if (rule.DestinationTypeID == GameGenerationConfig.FactionHqSentinel)
+                    return factionDests.First(n => n is Planet planet && planet.IsHeadquarters);
+
                 return factionDests.First(n =>
                     n is Planet planet && planet.TypeID == rule.DestinationTypeID
                 );

--- a/Assets/Tests/EditMode/GameTests/Generation/OfficerSeederTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Generation/OfficerSeederTests.cs
@@ -424,6 +424,41 @@ namespace Rebellion.Tests.Generation
             Assert.IsEmpty(other.GetChildren<Officer>());
         }
 
+        [Test]
+        public void Seed_WithFactionHqDestination_OfficerAddedToFactionHeadquarters()
+        {
+            Planet other = new Planet
+            {
+                InstanceID = "p1",
+                OwnerInstanceID = "FNALL1",
+                IsColonized = true,
+            };
+            Planet headquarters = new Planet
+            {
+                InstanceID = "hq",
+                OwnerInstanceID = "FNALL1",
+                IsColonized = true,
+                IsHeadquarters = true,
+            };
+            PlanetSector sector = new PlanetSector { InstanceID = "sector1" };
+            sector.AddChild(other);
+            sector.AddChild(headquarters);
+
+            Officer officer = MakeOfficer("MON_MOTHMA", "FNALL1");
+            _rules.Officers.StartingOfficers.Add(
+                new StartingOfficerRule
+                {
+                    OfficerInstanceID = officer.InstanceID,
+                    DestinationTypeID = GameGenerationConfig.FactionHqSentinel,
+                }
+            );
+
+            Deploy(new[] { officer }, new[] { sector }, _rules, _summary, new StubRNG());
+
+            Assert.Contains(officer, headquarters.GetChildren<Officer>().ToList());
+            Assert.IsEmpty(other.GetChildren<Officer>());
+        }
+
         private static (Officer[] Deployed, Officer[] Unrecruited) Deploy(
             Officer[] officers,
             PlanetSector[] sectors,


### PR DESCRIPTION
## Summary

- Resolving `FACTION_HQ` starting-officer destinations to the officer faction’s generated headquarters planet
- Adding regression coverage for placing a fixed officer at a dynamically selected headquarters
- Enabling Mon Mothma’s configured starting placement through the paired media change: https://github.com/adasgames/rebellion2-media/pull/83

## Validation

- `OfficerSeederTests`: 18 passed, 0 failed
- focused `Seed_WithFactionHqDestination_OfficerAddedToFactionHeadquarters`: passed
- `git diff --check`: passed in both repositories

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.

No UI builder or documentation changes are required for this generation-only behavior fix.