### PR TITLE
Fixing bug allowing manufacturing on captured enemy planets.

### DIFF
--- a/Assets/Scripts/Systems/ManufacturingSystem.cs
+++ b/Assets/Scripts/Systems/ManufacturingSystem.cs
@@ -966,10 +966,9 @@ namespace Rebellion.Systems
             if (producer == null || items == null || items.Count == 0)
                 return;
 
-            string producerOwnerId = producer.GetOwnerInstanceID();
             foreach (IManufacturable item in items.ToList())
             {
-                if (!HasInvalidPlanetDestination(item, producerOwnerId))
+                if (!HasInvalidPlanetDestination(item))
                     continue;
 
                 item.ManufacturingQueueSequence = 0;
@@ -982,10 +981,7 @@ namespace Rebellion.Systems
         /// Returns whether an unfinished building or troop has a directly assigned planet that
         /// is not controlled by its producer. Fleet and capital-ship destinations are excluded.
         /// </summary>
-        private static bool HasInvalidPlanetDestination(
-            IManufacturable item,
-            string producerOwnerId
-        )
+        private static bool HasInvalidPlanetDestination(IManufacturable item)
         {
             if (
                 item is not ISceneNode sceneNode
@@ -999,7 +995,7 @@ namespace Rebellion.Systems
 
             return !string.Equals(
                 destination.GetOwnerInstanceID(),
-                producerOwnerId,
+                item.ProducerOwnerID,
                 StringComparison.Ordinal
             );
         }

--- a/Assets/Scripts/Systems/ManufacturingSystem.cs
+++ b/Assets/Scripts/Systems/ManufacturingSystem.cs
@@ -878,6 +878,7 @@ namespace Rebellion.Systems
                 bool hadQueuedItems = items?.Count > 0;
 
                 items?.RemoveAll(item => !IsQueuedItemActive(item));
+                RemoveInvalidPlanetDestinationItems(planet, items);
                 bool hasQueuedItems = items?.Count > 0;
                 List<Building> readyFacilities = AdvanceProductionFacilities(
                     planet,
@@ -949,6 +950,58 @@ namespace Rebellion.Systems
         {
             return item != null
                 && _game.GetSceneNodeByInstanceID<ISceneNode>(item.InstanceID) == item;
+        }
+
+        /// <summary>
+        /// Cancels unfinished building and troop orders whose planet destination is no longer
+        /// controlled by the producing faction.
+        /// </summary>
+        /// <param name="producer">The planet performing the manufacturing.</param>
+        /// <param name="items">The production lane to validate.</param>
+        private void RemoveInvalidPlanetDestinationItems(
+            Planet producer,
+            List<IManufacturable> items
+        )
+        {
+            if (producer == null || items == null || items.Count == 0)
+                return;
+
+            string producerOwnerId = producer.GetOwnerInstanceID();
+            foreach (IManufacturable item in items.ToList())
+            {
+                if (!HasInvalidPlanetDestination(item, producerOwnerId))
+                    continue;
+
+                item.ManufacturingQueueSequence = 0;
+                DetachQueuedItem(item);
+                items.Remove(item);
+            }
+        }
+
+        /// <summary>
+        /// Returns whether an unfinished building or troop has a directly assigned planet that
+        /// is not controlled by its producer. Fleet and capital-ship destinations are excluded.
+        /// </summary>
+        private static bool HasInvalidPlanetDestination(
+            IManufacturable item,
+            string producerOwnerId
+        )
+        {
+            if (
+                item is not ISceneNode sceneNode
+                || item is CapitalShip
+                || item is Starfighter
+                || sceneNode.GetParent() is not Planet destination
+            )
+            {
+                return false;
+            }
+
+            return !string.Equals(
+                destination.GetOwnerInstanceID(),
+                producerOwnerId,
+                StringComparison.Ordinal
+            );
         }
 
         /// <summary>
@@ -1524,6 +1577,58 @@ namespace Rebellion.Systems
 
                 ClearQueueItems(planet, items);
                 queue.Remove(type);
+            }
+        }
+
+        /// <summary>
+        /// Cancels unfinished building and troop orders assigned directly to a planet that is
+        /// changing to an incompatible owner. Orders assigned to fleets or capital ships remain.
+        /// </summary>
+        /// <param name="destination">The planet whose ownership is changing.</param>
+        /// <param name="newOwnerInstanceId">The planet's incoming owner.</param>
+        public void InvalidatePlanetDestinationOrders(Planet destination, string newOwnerInstanceId)
+        {
+            if (destination == null)
+                return;
+
+            foreach (Planet producer in _game.GetSceneNodesByType<Planet>())
+            {
+                string producerOwnerId = producer.GetOwnerInstanceID();
+                Dictionary<ManufacturingType, List<IManufacturable>> queues =
+                    producer.GetManufacturingQueue();
+                foreach (
+                    KeyValuePair<ManufacturingType, List<IManufacturable>> entry in queues.ToList()
+                )
+                {
+                    List<IManufacturable> items = entry.Value;
+                    if (items == null)
+                        continue;
+
+                    foreach (IManufacturable item in items.ToList())
+                    {
+                        if (
+                            item is not ISceneNode sceneNode
+                            || item is CapitalShip
+                            || item is Starfighter
+                            || !ReferenceEquals(sceneNode.GetParent(), destination)
+                            || string.Equals(
+                                producerOwnerId,
+                                newOwnerInstanceId,
+                                StringComparison.Ordinal
+                            )
+                        )
+                        {
+                            continue;
+                        }
+
+                        item.ManufacturingQueueSequence = 0;
+                        DetachQueuedItem(item);
+                        items.Remove(item);
+                    }
+
+                    if (items.Count == 0)
+                        queues.Remove(entry.Key);
+                }
             }
         }
 

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -416,6 +416,8 @@ namespace Rebellion.Systems
                     newOwner
                 );
 
+                _manufacturingSystem.InvalidatePlanetDestinationOrders(planet, newOwnerId);
+
                 if (newOwner != null)
                     TransferBuildings(planet, newOwner);
 

--- a/Assets/Tests/EditMode/GameTests/Systems/ManufacturingSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/ManufacturingSystemTests.cs
@@ -2240,6 +2240,83 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_SixInvalidOrdersBeforeValidOrder_CancelsInvalidAndAdvancesValid()
+        {
+            _game.GetFactions().Add(new Faction { InstanceID = "REBELS" });
+            Planet captured = CreateOrderTestPlanet(_game, "CAPTURED", _empire.InstanceID);
+            List<Building> invalidOrders = Enumerable
+                .Range(1, 6)
+                .Select(index =>
+                {
+                    Building building = CreateOrderTestBuildingTemplate($"INVALID_{index}");
+                    building.InstanceID = $"INVALID_{index}";
+                    building.OwnerInstanceID = _empire.InstanceID;
+                    building.ConstructionCost = 100;
+                    return building;
+                })
+                .ToList();
+            foreach (Building invalidOrder in invalidOrders)
+                Assert.IsTrue(
+                    _manager.Enqueue(_coruscant, invalidOrder, captured, ignoreCost: true)
+                );
+
+            Building validOrder = CreateOrderTestBuildingTemplate("VALID");
+            validOrder.InstanceID = "VALID";
+            validOrder.OwnerInstanceID = _empire.InstanceID;
+            validOrder.ConstructionCost = 100;
+            Assert.IsTrue(_manager.Enqueue(_coruscant, validOrder, _coruscant, ignoreCost: true));
+            captured.OwnerInstanceID = "REBELS";
+
+            _manager.ProcessTick();
+
+            Assert.IsTrue(invalidOrders.All(order => order.GetParent() == null));
+            List<IManufacturable> queue = _coruscant.GetManufacturingQueue()[
+                ManufacturingType.Building
+            ];
+            CollectionAssert.AreEqual(new[] { validOrder }, queue);
+            Assert.Greater(validOrder.ManufacturingProgress, 0);
+        }
+
+        [Test]
+        public void ProcessTick_OrdersForTwoCapturedPlanets_CancelsEntireLane()
+        {
+            _game.GetFactions().Add(new Faction { InstanceID = "REBELS" });
+            Planet firstCaptured = CreateOrderTestPlanet(
+                _game,
+                "FIRST_CAPTURED",
+                _empire.InstanceID
+            );
+            Planet secondCaptured = CreateOrderTestPlanet(
+                _game,
+                "SECOND_CAPTURED",
+                _empire.InstanceID
+            );
+            Planet[] destinations = { firstCaptured, secondCaptured, firstCaptured };
+            List<Building> orders = new List<Building>();
+            for (int index = 0; index < destinations.Length; index++)
+            {
+                Building order = CreateOrderTestBuildingTemplate($"ORDER_{index}");
+                order.InstanceID = $"ORDER_{index}";
+                order.OwnerInstanceID = _empire.InstanceID;
+                order.ConstructionCost = 100;
+                Assert.IsTrue(
+                    _manager.Enqueue(_coruscant, order, destinations[index], ignoreCost: true)
+                );
+                orders.Add(order);
+            }
+
+            firstCaptured.OwnerInstanceID = "REBELS";
+            secondCaptured.OwnerInstanceID = "REBELS";
+
+            _manager.ProcessTick();
+
+            Assert.IsTrue(orders.All(order => order.GetParent() == null));
+            Assert.IsFalse(
+                _coruscant.GetManufacturingQueue().ContainsKey(ManufacturingType.Building)
+            );
+        }
+
+        [Test]
         public void ProcessTick_BuildingBatchDestinationChangedSides_CancelsAllTargetedOrders()
         {
             // 3 mines queued from production planet A to destination planet B.

--- a/Assets/Tests/EditMode/GameTests/Systems/ManufacturingSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/ManufacturingSystemTests.cs
@@ -1405,10 +1405,10 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_BuildingCompleteDestinationChangedSides_RedirectsToProductionPlanet()
+        public void ProcessTick_BuildingDestinationChangedSides_CancelsOrder()
         {
             // Mine queued from planetA to planetB. planetB captured before completion.
-            // planetA has capacity — mine should redirect there and be in transit.
+            // The order should be cancelled instead of redirecting to planetA.
             GameConfig config = TestConfig.Create();
             GameRoot _game = new GameRoot(config);
             Faction empire = new Faction { InstanceID = "empire", RefinedMaterialStockpile = 1 };
@@ -1480,23 +1480,16 @@ namespace Rebellion.Tests.Systems
 
             mfg.ProcessTick();
 
-            Assert.AreEqual(ManufacturingStatus.Delivering, mine.ManufacturingStatus);
-            Assert.AreEqual(
-                planetA,
-                mine.GetParent(),
-                "Mine should redirect to production planet."
-            );
-            Assert.IsNotNull(
-                mine.Movement,
-                "Mine should be in visual transit to production planet."
-            );
+            Assert.IsNull(mine.GetParent());
+            Assert.IsNull(_game.GetSceneNodeByInstanceID<Building>(mine.InstanceID));
+            Assert.IsEmpty(planetA.GetManufacturingQueue());
         }
 
         [Test]
-        public void ProcessTick_BuildingCompleteDestinationChangedNoCapacity_StaysAtHostile()
+        public void ProcessTick_BuildingDestinationChangedSides_CancelsRegardlessOfProducerCapacity()
         {
             // Mine queued from full planetA to planetB. planetB captured before completion.
-            // planetA has no remaining capacity — mine stays at hostile planetB.
+            // Cancellation should not depend on planetA having fallback capacity.
             GameConfig config = TestConfig.Create();
             GameRoot _game = new GameRoot(config);
             Faction empire = new Faction { InstanceID = "empire", RefinedMaterialStockpile = 1 };
@@ -1577,12 +1570,9 @@ namespace Rebellion.Tests.Systems
 
             mfg.ProcessTick();
 
-            Assert.AreEqual(ManufacturingStatus.Complete, mine.ManufacturingStatus);
-            Assert.IsNotNull(
-                _game.GetSceneNodeByInstanceID<Building>("mine1"),
-                "Mine should remain in the scene — not destroyed."
-            );
-            Assert.IsNull(mine.Movement, "No transit state when no valid planet found.");
+            Assert.IsNull(mine.GetParent());
+            Assert.IsNull(_game.GetSceneNodeByInstanceID<Building>(mine.InstanceID));
+            Assert.IsEmpty(planetA.GetManufacturingQueue());
         }
 
         [Test]
@@ -2221,11 +2211,40 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_BuildingBatchDestinationChangedSidesWithCapacity_RedirectsAll()
+        public void ProcessTick_RegimentDestinationChangedSides_CancelsOrder()
+        {
+            _game.GetFactions().Add(new Faction { InstanceID = "REBELS" });
+            Planet destination = new Planet
+            {
+                InstanceID = "DESTINATION",
+                OwnerInstanceID = _empire.InstanceID,
+                IsColonized = true,
+                EnergyCapacity = 10,
+            };
+            _game.AttachNode(destination, _coruscant.GetParent());
+            Regiment regiment = new Regiment
+            {
+                InstanceID = "REGIMENT",
+                OwnerInstanceID = _empire.InstanceID,
+                ConstructionCost = 100,
+            };
+
+            Assert.IsTrue(_manager.Enqueue(_coruscant, regiment, destination, ignoreCost: true));
+            destination.OwnerInstanceID = "REBELS";
+
+            _manager.ProcessTick();
+
+            Assert.IsNull(regiment.GetParent());
+            Assert.IsNull(_game.GetSceneNodeByInstanceID<Regiment>(regiment.InstanceID));
+            Assert.IsFalse(_coruscant.GetManufacturingQueue().ContainsKey(ManufacturingType.Troop));
+        }
+
+        [Test]
+        public void ProcessTick_BuildingBatchDestinationChangedSides_CancelsAllTargetedOrders()
         {
             // 3 mines queued from production planet A to destination planet B.
             // B changes sides. A has enough ground slots for all 3.
-            // Expected: all 3 mines redirect to A and are marked complete.
+            // Every order assigned to B should be cancelled.
             GameConfig config = TestConfig.Create();
             GameRoot _game = new GameRoot(config);
             Faction empire = new Faction { InstanceID = "empire", RefinedMaterialStockpile = 3 };
@@ -2325,33 +2344,17 @@ namespace Rebellion.Tests.Systems
 
             mfg.ProcessTick();
 
-            Assert.AreEqual(ManufacturingStatus.Delivering, mine1.ManufacturingStatus);
-            Assert.AreEqual(ManufacturingStatus.Delivering, mine2.ManufacturingStatus);
-            Assert.AreEqual(ManufacturingStatus.Delivering, mine3.ManufacturingStatus);
-            Assert.AreEqual(
-                planetA,
-                mine1.GetParent(),
-                "Mine 1 should redirect to production planet."
-            );
-            Assert.AreEqual(
-                planetA,
-                mine2.GetParent(),
-                "Mine 2 should redirect to production planet."
-            );
-            Assert.AreEqual(
-                planetA,
-                mine3.GetParent(),
-                "Mine 3 should redirect to production planet."
-            );
+            Assert.IsNull(mine1.GetParent());
+            Assert.IsNull(mine2.GetParent());
+            Assert.IsNull(mine3.GetParent());
+            Assert.IsEmpty(planetA.GetManufacturingQueue());
         }
 
         [Test]
-        public void ProcessTick_BuildingBatchDestinationChangedSidesNoCapacity_StaysAtCurrentLocation()
+        public void ProcessTick_BuildingBatchDestinationChangedSides_CancelsWithoutFallbackCapacity()
         {
             // 3 mines queued from production planet A to destination planet B.
-            // B changes sides. A has no capacity for redirected mines.
-            // Expected: MovementSystem cannot find a valid placement; mines remain in the scene
-            // at their current location (planetB) rather than being destroyed.
+            // B changes sides. Cancellation does not depend on fallback capacity at A.
             GameConfig config = TestConfig.Create();
             GameRoot _game = new GameRoot(config);
             Faction empire = new Faction { InstanceID = "empire", RefinedMaterialStockpile = 3 };
@@ -2467,21 +2470,10 @@ namespace Rebellion.Tests.Systems
 
             mfg.ProcessTick();
 
-            Assert.AreEqual(ManufacturingStatus.Complete, mine1.ManufacturingStatus);
-            Assert.AreEqual(ManufacturingStatus.Complete, mine2.ManufacturingStatus);
-            Assert.AreEqual(ManufacturingStatus.Complete, mine3.ManufacturingStatus);
-            Assert.IsNotNull(
-                _game.GetSceneNodeByInstanceID<Building>("m1"),
-                "Mine 1 should remain in the scene when no valid placement is found."
-            );
-            Assert.IsNotNull(
-                _game.GetSceneNodeByInstanceID<Building>("m2"),
-                "Mine 2 should remain in the scene when no valid placement is found."
-            );
-            Assert.IsNotNull(
-                _game.GetSceneNodeByInstanceID<Building>("m3"),
-                "Mine 3 should remain in the scene when no valid placement is found."
-            );
+            Assert.IsNull(mine1.GetParent());
+            Assert.IsNull(mine2.GetParent());
+            Assert.IsNull(mine3.GetParent());
+            Assert.IsEmpty(planetA.GetManufacturingQueue());
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GameTests/Systems/ManufacturingSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/ManufacturingSystemTests.cs
@@ -2240,6 +2240,27 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_LocalBuildingOrderProducerChangedSides_CancelsOrder()
+        {
+            _game.GetFactions().Add(new Faction { InstanceID = "REBELS" });
+            Building mine = CreateOrderTestBuildingTemplate("LOCAL_MINE");
+            mine.InstanceID = "LOCAL_MINE";
+            mine.OwnerInstanceID = _empire.InstanceID;
+            mine.ConstructionCost = 100;
+            Assert.IsTrue(_manager.Enqueue(_coruscant, mine, _coruscant, ignoreCost: true));
+
+            _coruscant.OwnerInstanceID = "REBELS";
+
+            _manager.ProcessTick();
+
+            Assert.IsNull(mine.GetParent());
+            Assert.IsNull(_game.GetSceneNodeByInstanceID<Building>(mine.InstanceID));
+            Assert.IsFalse(
+                _coruscant.GetManufacturingQueue().ContainsKey(ManufacturingType.Building)
+            );
+        }
+
+        [Test]
         public void ProcessTick_SixInvalidOrdersBeforeValidOrder_CancelsInvalidAndAdvancesValid()
         {
             _game.GetFactions().Add(new Faction { InstanceID = "REBELS" });

--- a/Assets/Tests/EditMode/GameTests/Systems/PlanetaryControlSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/PlanetaryControlSystemTests.cs
@@ -600,6 +600,87 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void TransferPlanet_CancelsRemoteOrdersForDestinationAndPreservesOtherOrders()
+        {
+            _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
+            _targetPlanet.EnergyCapacity = 2;
+            _empirePlanet.IsColonized = true;
+            _empirePlanet.EnergyCapacity = 3;
+
+            ManufacturingSystem manufacturing = new ManufacturingSystem(
+                _game,
+                new FleetSystem(_game)
+            );
+            Building remoteMine = new Building
+            {
+                InstanceID = "remote-mine",
+                OwnerInstanceID = _empire.InstanceID,
+                BuildingType = BuildingType.Mine,
+                ConstructionCost = 100,
+            };
+            Building localMine = new Building
+            {
+                InstanceID = "local-mine",
+                OwnerInstanceID = _empire.InstanceID,
+                BuildingType = BuildingType.Mine,
+                ConstructionCost = 100,
+            };
+            Assert.IsTrue(
+                manufacturing.Enqueue(_empirePlanet, remoteMine, _targetPlanet, ignoreCost: true)
+            );
+            Assert.IsTrue(
+                manufacturing.Enqueue(_empirePlanet, localMine, _empirePlanet, ignoreCost: true)
+            );
+
+            _ownershipSystem.TransferPlanet(_targetPlanet, _rebels);
+
+            List<IManufacturable> queue = _empirePlanet.GetManufacturingQueue()[
+                ManufacturingType.Building
+            ];
+            Assert.AreEqual(1, queue.Count);
+            Assert.AreSame(localMine, queue[0]);
+            Assert.IsNull(remoteMine.GetParent());
+            Assert.IsNull(_game.GetSceneNodeByInstanceID<Building>(remoteMine.InstanceID));
+        }
+
+        [Test]
+        public void TransferPlanet_PreservesRegimentOrderAssignedToFriendlyFleet()
+        {
+            _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
+            Fleet fleet = new Fleet(_empire.InstanceID, "Empire Fleet");
+            CapitalShip transport = new CapitalShip
+            {
+                InstanceID = "transport",
+                OwnerInstanceID = _empire.InstanceID,
+                RegimentCapacity = 1,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            _game.AttachNode(fleet, _targetPlanet);
+            _game.AttachNode(transport, fleet);
+
+            ManufacturingSystem manufacturing = new ManufacturingSystem(
+                _game,
+                new FleetSystem(_game)
+            );
+            Regiment regiment = new Regiment
+            {
+                InstanceID = "fleet-regiment",
+                OwnerInstanceID = _empire.InstanceID,
+                ConstructionCost = 100,
+            };
+            Assert.IsTrue(manufacturing.Enqueue(_empirePlanet, regiment, fleet, ignoreCost: true));
+
+            _ownershipSystem.TransferPlanet(_targetPlanet, _rebels);
+
+            CollectionAssert.Contains(
+                _empirePlanet.GetManufacturingQueue()[ManufacturingType.Troop],
+                regiment
+            );
+            Assert.AreSame(fleet, regiment.GetParentOfType<Fleet>());
+            Assert.AreSame(regiment, _game.GetSceneNodeByInstanceID<Regiment>(regiment.InstanceID));
+        }
+
+        [Test]
         public void ClearPlanetOwnership_ActiveDiplomacyMission_PreservesMission()
         {
             _game.ChangeOwnership(_targetPlanet, _rebels.InstanceID);


### PR DESCRIPTION
## Summary

- Canceling unfinished building and ground-unit orders immediately when their directly assigned destination planet changes to an incompatible owner
- Revalidating planet-bound orders against their recorded producer owner before manufacturing progress advances, covering ownership mutations that bypass the normal transfer path
- Leaving ship-class orders outside this invalidation and preserve ground-unit orders assigned to friendly fleets orbiting hostile planets
- Superseding #177 with ground-unit coverage and the per-tick safety net

## Validation

- `./build.sh format`
- `./build.sh lint`
- `./build.sh test` — 4,649 passed, 0 failed before the test-only follow-up
- focused ManufacturingSystemTests after review changes — 118 passed, 0 failed
- `./build.sh build` — StandaloneOSX build succeeded
- regression coverage includes local orders after direct ownership mutation, six invalid orders ahead of a valid order, and three orders split across two captured destinations

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [ ] UI builder changes were verified by rebuilding the affected UI.
- [ ] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [ ] Documentation was updated when behavior or setup changed.