### PR TITLE
Fixing bug preventing hyperdrive-enabled starfighters from fleeing battle.

### DIFF
--- a/Assets/Scripts/Systems/SpaceCombatSystem.cs
+++ b/Assets/Scripts/Systems/SpaceCombatSystem.cs
@@ -254,7 +254,12 @@ namespace Rebellion.Systems
                     opposingFleets,
                     planet,
                     retreatingFactionInstanceId
-                ) || !TryRetreatFleets(retreatingFleets, opposingFleets, ignoreGravityWell: false)
+                )
+            )
+                return false;
+            if (
+                retreatingFleets.Count > 0
+                && !TryRetreatFleets(retreatingFleets, opposingFleets, ignoreGravityWell: false)
             )
                 return false;
 
@@ -267,6 +272,16 @@ namespace Rebellion.Systems
             );
             foreach (Starfighter fighter in retreatingFighters)
                 _movement.EvacuateToNearestFriendlyPlanet(fighter);
+            string retreatPlanetInstanceId = GetRetreatPlanetInstanceID(
+                retreatingFleets,
+                retreatingFighters,
+                planet,
+                SpaceCombatSideOutcome.Withdrawn
+            );
+            if (attackerRetreated)
+                result.AttackerRetreatPlanetInstanceID = retreatPlanetInstanceId;
+            else
+                result.DefenderRetreatPlanetInstanceID = retreatPlanetInstanceId;
 
             results.Add(result);
             ClearCombatFlags(decision);
@@ -274,7 +289,7 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Builds the combat result emitted after a successful fleet withdrawal.
+        /// Builds the combat result emitted after a successful force withdrawal.
         /// </summary>
         /// <param name="decision">The resolved combat decision.</param>
         /// <param name="attackerRetreated">Whether the attacking side withdrew.</param>
@@ -300,12 +315,6 @@ namespace Rebellion.Systems
                 DefenderOwnerInstanceID = decision.DefenderOwnerInstanceID,
                 Planet = planet,
                 PlanetOwnerInstanceID = planet.OwnerInstanceID,
-                AttackerRetreatPlanetInstanceID = attackerRetreated
-                    ? attacker.GetParentOfType<Planet>()?.InstanceID
-                    : null,
-                DefenderRetreatPlanetInstanceID = attackerRetreated
-                    ? null
-                    : defender.GetParentOfType<Planet>()?.InstanceID,
                 Winner = attackerRetreated ? CombatSide.Defender : CombatSide.Attacker,
                 AttackerOutcome = attackerRetreated
                     ? SpaceCombatSideOutcome.Withdrawn
@@ -689,17 +698,21 @@ namespace Rebellion.Systems
             string ownerInstanceId
         )
         {
-            return fleets?.Count > 0
-                && !IsRetreatBlockedByGravityWell(fleets, opponents)
-                && fleets.All(fleet =>
+            IReadOnlyList<Fleet> retreatingFleets = fleets ?? Array.Empty<Fleet>();
+            List<Starfighter> retreatingFighters = GetActivePlanetStarfighters(
+                    planet,
+                    ownerInstanceId
+                )
+                .ToList();
+            return (retreatingFleets.Count > 0 || retreatingFighters.Count > 0)
+                && !IsRetreatBlockedByGravityWell(planet, opponents)
+                && retreatingFleets.All(fleet =>
                     HasHyperdriveCapableShip(fleet)
                     && _movement.CanEvacuateToNearestFriendlyPlanet(fleet)
                 )
-                && GetActivePlanetStarfighters(planet, ownerInstanceId)
-                    .All(fighter =>
-                        fighter.Hyperdrive > 0
-                        && _movement.CanEvacuateToNearestFriendlyPlanet(fighter)
-                    );
+                && retreatingFighters.All(fighter =>
+                    fighter.Hyperdrive > 0 && _movement.CanEvacuateToNearestFriendlyPlanet(fighter)
+                );
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/SpaceCombatSystem.cs
+++ b/Assets/Scripts/Systems/SpaceCombatSystem.cs
@@ -154,6 +154,7 @@ namespace Rebellion.Systems
             List<Fleet> defenderFleets = GetFleets(decision.DefenderFleetInstanceIDs);
             Fleet attacker = GetRepresentativeFleet(attackerFleets);
             Fleet defender = GetRepresentativeFleet(defenderFleets);
+            Planet planet = ResolveCombatPlanet(decision);
 
             return new PendingCombatResult
             {
@@ -161,9 +162,19 @@ namespace Rebellion.Systems
                 DefenderFleet = defender,
                 AttackerOwnerInstanceID = decision.AttackerOwnerInstanceID,
                 DefenderOwnerInstanceID = decision.DefenderOwnerInstanceID,
-                Planet = ResolveCombatPlanet(decision),
-                AttackerCanRetreat = CanRetreatFleets(attackerFleets, defenderFleets),
-                DefenderCanRetreat = CanRetreatFleets(defenderFleets, attackerFleets),
+                Planet = planet,
+                AttackerCanRetreat = CanRetreatForces(
+                    attackerFleets,
+                    defenderFleets,
+                    planet,
+                    decision.AttackerOwnerInstanceID
+                ),
+                DefenderCanRetreat = CanRetreatForces(
+                    defenderFleets,
+                    attackerFleets,
+                    planet,
+                    decision.DefenderOwnerInstanceID
+                ),
                 Tick = _game.CurrentTick,
             };
         }
@@ -231,19 +242,33 @@ namespace Rebellion.Systems
                 retreatingFactionInstanceId == decision.AttackerOwnerInstanceID;
             List<Fleet> retreatingFleets = attackerRetreated ? attackerFleets : defenderFleets;
             List<Fleet> opposingFleets = attackerRetreated ? defenderFleets : attackerFleets;
+            List<Starfighter> retreatingFighters = GetActivePlanetStarfighters(
+                    planet,
+                    retreatingFactionInstanceId
+                )
+                .ToList();
 
-            if (!TryRetreatFleets(retreatingFleets, opposingFleets, ignoreGravityWell: false))
+            if (
+                !CanRetreatForces(
+                    retreatingFleets,
+                    opposingFleets,
+                    planet,
+                    retreatingFactionInstanceId
+                ) || !TryRetreatFleets(retreatingFleets, opposingFleets, ignoreGravityWell: false)
+            )
                 return false;
 
-            results.Add(
-                BuildRetreatResult(
-                    decision,
-                    attackerRetreated,
-                    attackerFleets,
-                    defenderFleets,
-                    planet
-                )
+            SpaceCombatResult result = BuildRetreatResult(
+                decision,
+                attackerRetreated,
+                attackerFleets,
+                defenderFleets,
+                planet
             );
+            foreach (Starfighter fighter in retreatingFighters)
+                _movement.EvacuateToNearestFriendlyPlanet(fighter);
+
+            results.Add(result);
             ClearCombatFlags(decision);
             return true;
         }
@@ -650,19 +675,31 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Reports whether a fleet can withdraw from its opponent.
+        /// Reports whether every force on one side can withdraw from its opponent.
         /// </summary>
         /// <param name="fleets">The fleets requesting withdrawal.</param>
         /// <param name="opponents">The opposing fleets.</param>
-        /// <returns>True when no opposing gravity well prevents withdrawal.</returns>
-        private bool CanRetreatFleets(IReadOnlyList<Fleet> fleets, IReadOnlyList<Fleet> opponents)
+        /// <param name="planet">The combat planet.</param>
+        /// <param name="ownerInstanceId">The withdrawing faction identifier.</param>
+        /// <returns>True when every fleet and directly deployed fighter can evacuate.</returns>
+        private bool CanRetreatForces(
+            IReadOnlyList<Fleet> fleets,
+            IReadOnlyList<Fleet> opponents,
+            Planet planet,
+            string ownerInstanceId
+        )
         {
             return fleets?.Count > 0
                 && !IsRetreatBlockedByGravityWell(fleets, opponents)
                 && fleets.All(fleet =>
                     HasHyperdriveCapableShip(fleet)
                     && _movement.CanEvacuateToNearestFriendlyPlanet(fleet)
-                );
+                )
+                && GetActivePlanetStarfighters(planet, ownerInstanceId)
+                    .All(fighter =>
+                        fighter.Hyperdrive > 0
+                        && _movement.CanEvacuateToNearestFriendlyPlanet(fighter)
+                    );
         }
 
         /// <summary>

--- a/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
@@ -2478,6 +2478,52 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ResolvePendingRetreat_PlanetaryHyperdriveFighterWithoutFleet_MovesFighterAndEndsCombat()
+        {
+            GameRoot game = CreateGame();
+            game.GetFactions().First(faction => faction.InstanceID == "alliance").PlayerID =
+                "player1";
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat", owner: "alliance");
+            (Planet allianceHome, _) = CreatePlanet(game, "allianceHome", owner: "alliance");
+            CreatePlanet(game, "empireHome", owner: "empire");
+            CreateFleet(game, "ef1", "empire", combatPlanet, 1, 1000, 100);
+            Starfighter fighter = new Starfighter
+            {
+                InstanceID = "planet-fighter",
+                OwnerInstanceID = "alliance",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                MaxSquadronSize = 12,
+                CurrentSquadronSize = 12,
+                Hyperdrive = 60,
+            };
+            game.AttachNode(fighter, combatPlanet);
+            SpaceCombatSystem manager = MakeSpaceCombat(game);
+
+            PendingCombatResult pending = manager
+                .ProcessTick()
+                .OfType<PendingCombatResult>()
+                .Single();
+            bool allianceCanRetreat =
+                pending.AttackerOwnerInstanceID == "alliance"
+                    ? pending.AttackerCanRetreat
+                    : pending.DefenderCanRetreat;
+            List<GameResult> results = manager.ResolvePendingRetreat("alliance");
+
+            Assert.IsTrue(allianceCanRetreat);
+            Assert.IsNotNull(results);
+            SpaceCombatResult combatResult = results.OfType<SpaceCombatResult>().Single();
+            string retreatPlanetInstanceId =
+                combatResult.AttackerOwnerInstanceID == "alliance"
+                    ? combatResult.AttackerRetreatPlanetInstanceID
+                    : combatResult.DefenderRetreatPlanetInstanceID;
+            Assert.AreEqual(allianceHome.InstanceID, retreatPlanetInstanceId);
+            Assert.AreSame(allianceHome, fighter.GetParentOfType<Planet>());
+            Assert.IsNotNull(fighter.Movement);
+            Assert.IsEmpty(manager.ProcessTick());
+            Assert.IsFalse(manager.HasPendingDecision);
+        }
+
+        [Test]
         public void ResolvePendingRetreat_PlanetaryNonHyperdriveFighter_DoesNotMoveAnyForces()
         {
             GameRoot game = CreateGame();

--- a/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
@@ -2428,6 +2428,97 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ResolvePendingRetreat_PlanetaryHyperdriveFighter_MovesFighterAndDoesNotRestartCombat()
+        {
+            GameRoot game = CreateGame();
+            game.GetFactions().First(faction => faction.InstanceID == "empire").PlayerID =
+                "player1";
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat", owner: "empire");
+            (Planet empireHome, _) = CreatePlanet(game, "empireHome", owner: "empire");
+            CreatePlanet(game, "allianceHome", owner: "alliance");
+            CreateFleet(game, "ef1", "empire", combatPlanet, 1, 100, 1);
+            CreateFleet(game, "af1", "alliance", combatPlanet, 1, 1000, 100);
+            Starfighter fighter = new Starfighter
+            {
+                InstanceID = "planet-fighter",
+                OwnerInstanceID = "empire",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                MaxSquadronSize = 12,
+                CurrentSquadronSize = 12,
+                Hyperdrive = 1,
+            };
+            game.AttachNode(fighter, combatPlanet);
+            SpaceCombatSystem manager = MakeSpaceCombat(game);
+
+            PendingCombatResult pending = manager
+                .ProcessTick()
+                .OfType<PendingCombatResult>()
+                .Single();
+            bool empireCanRetreat =
+                pending.AttackerOwnerInstanceID == "empire"
+                    ? pending.AttackerCanRetreat
+                    : pending.DefenderCanRetreat;
+            List<GameResult> results = manager.ResolvePendingRetreat("empire");
+
+            Assert.IsTrue(empireCanRetreat);
+            Assert.IsNotNull(results);
+            SpaceCombatResult combatResult = results.OfType<SpaceCombatResult>().Single();
+            IEnumerable<CombatUnitSnapshot> retreatingUnits =
+                combatResult.AttackerOwnerInstanceID == "empire"
+                    ? combatResult.AttackingUnits
+                    : combatResult.DefendingUnits;
+            CollectionAssert.Contains(
+                retreatingUnits.Select(unit => unit.Unit.GetInstanceID()),
+                fighter.InstanceID
+            );
+            Assert.AreSame(empireHome, fighter.GetParentOfType<Planet>());
+            Assert.IsNotNull(fighter.Movement);
+            Assert.IsEmpty(manager.ProcessTick());
+            Assert.IsFalse(manager.HasPendingDecision);
+        }
+
+        [Test]
+        public void ResolvePendingRetreat_PlanetaryNonHyperdriveFighter_DoesNotMoveAnyForces()
+        {
+            GameRoot game = CreateGame();
+            game.GetFactions().First(faction => faction.InstanceID == "empire").PlayerID =
+                "player1";
+            (Planet combatPlanet, _) = CreatePlanet(game, "combat", owner: "empire");
+            CreatePlanet(game, "empireHome", owner: "empire");
+            CreatePlanet(game, "allianceHome", owner: "alliance");
+            Fleet empireFleet = CreateFleet(game, "ef1", "empire", combatPlanet, 1, 100, 1);
+            CreateFleet(game, "af1", "alliance", combatPlanet, 1, 1000, 100);
+            Starfighter fighter = new Starfighter
+            {
+                InstanceID = "planet-fighter",
+                OwnerInstanceID = "empire",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                MaxSquadronSize = 12,
+                CurrentSquadronSize = 12,
+                Hyperdrive = 0,
+            };
+            game.AttachNode(fighter, combatPlanet);
+            SpaceCombatSystem manager = MakeSpaceCombat(game);
+
+            PendingCombatResult pending = manager
+                .ProcessTick()
+                .OfType<PendingCombatResult>()
+                .Single();
+            bool empireCanRetreat =
+                pending.AttackerOwnerInstanceID == "empire"
+                    ? pending.AttackerCanRetreat
+                    : pending.DefenderCanRetreat;
+            List<GameResult> results = manager.ResolvePendingRetreat("empire");
+
+            Assert.IsFalse(empireCanRetreat);
+            Assert.IsNull(results);
+            Assert.AreSame(combatPlanet, empireFleet.GetParentOfType<Planet>());
+            Assert.IsNull(empireFleet.Movement);
+            Assert.AreSame(combatPlanet, fighter.GetParentOfType<Planet>());
+            Assert.IsNull(fighter.Movement);
+        }
+
+        [Test]
         public void ResolvePendingRetreat_FleetWithoutHyperdrive_DoesNotMoveFleet()
         {
             GameRoot game = CreateGame();


### PR DESCRIPTION
## Summary

- Moving directly deployed, hyperdrive-capable planetary starfighters when their side manually retreats from fleet combat.
- Allowing a hyperdrive-capable fighter to retreat when it is the only unit on its side, with no fleet container.
- Preventing a side-wide retreat when one of its directly deployed starfighters lacks a working hyperdrive.
- Applying opposing gravity-well interdiction to fleet and fighter-only withdrawals alike.
- Preserving evacuated fighters and their destination in the completed combat report, preventing the same-tick combat scan from starting a second fighter-only battle.
- Adding synthetic regression coverage for fleet-plus-fighter, fighter-only, and non-hyperdrive fighter retreat behavior.

## Validation

- The fleet-plus-fighter repeat-combat regression failed before the production fix and passes afterward.
- The fighter-only Y-wing-equivalent regression failed before the production fix and passes afterward.
- `SpaceCombatSystemTests`: 69/69 passed.
- Full Unity EditMode suite after updating to current `master`: 4,692/4,692 passed.
- `dotnet build GameAssembly.csproj --nologo`: passed with 0 warnings and 0 errors.
- Windows Standalone player build: passed (`build/repeat-fighter-fix/rebellion2.exe`).
- `dotnet csharpier check` passed for both changed files.
- `git diff --check`: passed.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable: no UI changes.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable: no content changes.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable: internal combat correction covered by regression tests.)

