### PR TITLE
Adding support for MacOS.

### DIFF
--- a/Assets/Editor/Build/StandalonePlayerBuild.cs
+++ b/Assets/Editor/Build/StandalonePlayerBuild.cs
@@ -95,16 +95,49 @@ public static class StandalonePlayerBuild
             GetRequiredArgument(_buildPlayerPathArgument, _gameCIBuildPathArgument)
         );
         string originalVersion = UnityEditor.PlayerSettings.bundleVersion;
+#if UNITY_STANDALONE_OSX
+        UnityEditor.Build.OSArchitecture originalMacArchitecture = default;
+        if (target == UnityEditor.BuildTarget.StandaloneOSX)
+        {
+            originalMacArchitecture = UnityEditor.OSXStandalone.UserBuildSettings.architecture;
+        }
+#endif
         try
         {
             ApplyBuildVersion();
+#if UNITY_STANDALONE_OSX
+            ApplyBuildArchitecture(target);
+#endif
             BuildPlayer(target, outputPath);
         }
         finally
         {
             UnityEditor.PlayerSettings.bundleVersion = originalVersion;
+#if UNITY_STANDALONE_OSX
+            if (target == UnityEditor.BuildTarget.StandaloneOSX)
+            {
+                UnityEditor.OSXStandalone.UserBuildSettings.architecture = originalMacArchitecture;
+            }
+#endif
         }
     }
+
+#if UNITY_STANDALONE_OSX
+    /// <summary>
+    /// Builds macOS releases for both Intel and Apple Silicon.
+    /// </summary>
+    /// <param name="target">The desktop platform being built.</param>
+    private static void ApplyBuildArchitecture(UnityEditor.BuildTarget target)
+    {
+        if (target == UnityEditor.BuildTarget.StandaloneOSX)
+        {
+            UnityEditor.OSXStandalone.UserBuildSettings.architecture = UnityEditor
+                .Build
+                .OSArchitecture
+                .x64ARM64;
+        }
+    }
+#endif
 
     /// <summary>
     /// Applies the release version supplied by the build environment, when present.


### PR DESCRIPTION
## Summary

- Building StandaloneOSX releases as universal Intel and Apple Silicon players.
- Restoring Unity's previous macOS architecture setting after the command-line build so the build does not leave persistent editor state behind.
- Supplying the macOS player consumed by adasgames/rebellion2-installers#27.

## Validation

- `bash build.sh all`: 4,699 Unity tests passed and coverage thresholds passed.
- [Installer validation](https://github.com/adasgames/rebellion2-installers/actions/runs/33973450279): Windows and macOS asset-free players built successfully, and both platform packages completed successfully.
- Release and content-publishing jobs were correctly skipped for the branch validation run.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable: this PR does not change UI builders.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable: this PR does not change content paths or structure.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (The related installer behavior and setup are documented in adasgames/rebellion2-installers#27; this PR does not change the game build command interface.)