### PR TITLE
Documenting upcoming ownership requirement change.

### DIFF
--- a/Docs/Development.md
+++ b/Docs/Development.md
@@ -5,7 +5,7 @@
 - Unity 6000.4.0f1
 - .NET SDK
 - A Bash-compatible shell
-- A copy of *Star Wars: Rebellion* owned through GOG or Steam
+- Ownership of *Star Wars: Rebellion* or *Star Wars: Empire at War: Gold Pack* through GOG or Steam
 - Access to the separate `rebellion2-media` repository
 
 Access to development content does not grant redistribution rights. **NEVER share, upload, commit,

--- a/Docs/Modding/Index.md
+++ b/Docs/Modding/Index.md
@@ -10,8 +10,9 @@ sparse overlays, base-pack fallback, or a separate `Mods` directory.
 
 **Only distribute files you have the right to distribute.** For mods based on the classic pack,
 distribute your changes rather than the modified pack, and have players apply them to their installed
-content. Players and mod developers must own the original game and obtain its content through the
-ownership-verifying installer.
+content. Players and mod developers must own *Star Wars: Rebellion* or
+*Star Wars: Empire at War: Gold Pack* and obtain the content through the ownership-verifying
+installer.
 
 ## Create a private development workspace
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Rebellion 2 is currently available through an early-access installer. Join the
 [Star Wars Rebellion Discord](https://discord.com/invite/rWP4vzw8Gg) and ask **@DavidAdas** for
 access.
 
-The installer verifies ownership automatically. A copy of *Star Wars: Rebellion* from either
-**GOG** or **Steam** is required.
+The installer verifies ownership automatically. You must own either *Star Wars: Rebellion* or
+*Star Wars: Empire at War: Gold Pack* on **GOG** or **Steam**.
 
 **NOTE: Installed game data and copyrighted assets must NEVER be redistributed, uploaded, or
 shared under any circumstances.**


### PR DESCRIPTION
## Summary

- Documenting that either Star Wars: Rebellion or Star Wars: Empire at War: Gold Pack satisfies the ownership requirement
- Keeping player, developer, and modding guidance consistent with the updated launcher and content gate

## Validation

- Documentation-only change
- `git diff --check`

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (Not applicable: no UI builder changes.)
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable: no content changes.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.

## Dependencies

Depends on davidadas/rebellion2-infrastructure#22 for Empire at War ownership verification.