### PR TITLE
Fixing bug allowing fighters to fire continuously in battle resolver.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -69,3 +69,4 @@ dotnet_diagnostic.RCS1213.severity = none
 # is therefore incomplete during lint even though Unity requires this import to compile the file.
 [Assets/Editor/Capture/GameRecordingSession.cs]
 dotnet_diagnostic.IDE0005.severity = none
+dotnet_diagnostic.CS8019.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -64,3 +64,8 @@ dotnet_naming_rule.private_fields_underscore.severity = none
 
 [Assets/Scripts/Managers/InputManager.cs]
 dotnet_diagnostic.RCS1213.severity = none
+
+# CI stages Unity's managed assemblies without compiling package source. The Recorder namespace
+# is therefore incomplete during lint even though Unity requires this import to compile the file.
+[Assets/Editor/Capture/GameRecordingSession.cs]
+dotnet_diagnostic.IDE0005.severity = none

--- a/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
+++ b/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
@@ -455,10 +455,7 @@ namespace Rebellion.Game.Combat
                     .ToList();
                 Fighters = (fighters ?? Array.Empty<Starfighter>())
                     .Where(fighter => fighter != null)
-                    .Select(fighter => new StarfighterState(
-                        fighter,
-                        config.AutoResolveMinimumManeuverRatio
-                    ))
+                    .Select(fighter => new StarfighterState(fighter, config))
                     .ToList();
                 Units = new List<TacticalUnit>(Ships.Count + Fighters.Count);
                 Units.AddRange(Ships);
@@ -1546,9 +1543,12 @@ namespace Rebellion.Game.Combat
             internal readonly Starfighter Fighter;
             internal readonly int InitialSquadronSize;
             private readonly double _durabilityPerFighter;
+            private readonly double _maximumWeaponCharge;
+            private readonly double _weaponRecharge;
             private readonly double[] _weaponTargetDamage = new double[3];
             private readonly TacticalUnit[] _weaponTargets = new TacticalUnit[3];
             private double _currentDurability;
+            private double _currentWeaponCharge;
 
             internal int CurrentSquadronSize =>
                 IsAlive
@@ -1563,11 +1563,7 @@ namespace Rebellion.Game.Combat
             internal override bool IsStarfighter => true;
             internal override double RemainingDurability => _currentDurability;
             internal override bool CanScanForTargets =>
-                GetCombinedWeaponStrength(
-                    targetsFighters: false,
-                    engagementDistance: 0,
-                    requireRange: true
-                ) > 0;
+                _maximumWeaponCharge > 0 && _currentWeaponCharge >= _maximumWeaponCharge;
             internal override double ClosingSpeed => Math.Max(Fighter.SublightSpeed, 0);
             internal override double ManeuverRate =>
                 Math.Max(Fighter.SublightSpeed + Fighter.Agility, MinimumManeuverRatio);
@@ -1576,14 +1572,22 @@ namespace Rebellion.Game.Combat
             /// Creates tactical state from a fighter squadron's current strategic state.
             /// </summary>
             /// <param name="fighter">The fighter squadron entering combat.</param>
-            /// <param name="minimumManeuverRatio">The minimum maneuver value and multiplier.</param>
-            internal StarfighterState(Starfighter fighter, double minimumManeuverRatio)
-                : base(minimumManeuverRatio)
+            /// <param name="config">The automatic combat parameters.</param>
+            internal StarfighterState(Starfighter fighter, GameConfig.SpaceCombatConfig config)
+                : base(config.AutoResolveMinimumManeuverRatio)
             {
                 Fighter = fighter;
                 InitialSquadronSize = Math.Max(fighter.CurrentSquadronSize, 0);
                 _durabilityPerFighter = Math.Max(fighter.ShieldStrength, 1);
                 _currentDurability = InitialSquadronSize * _durabilityPerFighter;
+                _maximumWeaponCharge =
+                    Math.Max(fighter.LaserCannon, 0)
+                    + Math.Max(fighter.IonCannon, 0)
+                    + Math.Max(fighter.Torpedoes, 0);
+                _currentWeaponCharge = _maximumWeaponCharge;
+                _weaponRecharge =
+                    Math.Max(fighter.ShieldStrength, 0)
+                    * Math.Max(config.AutoResolveFighterWeaponRechargeMultiplier, 0);
             }
 
             /// <inheritdoc />
@@ -1594,10 +1598,14 @@ namespace Rebellion.Game.Combat
                 IDictionary<TacticalUnit, PendingDamage> pendingDamage
             )
             {
+                if (_currentWeaponCharge < _maximumWeaponCharge)
+                    return;
+
                 if (scansForTarget)
                     ScanForWeaponTargets(targets, engagementDistance);
 
                 double squadronStrength = GetRemainingSquadronStrength();
+                double consumedCharge = 0;
                 for (int weaponIndex = 0; weaponIndex < _weaponTargets.Length; weaponIndex++)
                 {
                     TacticalUnit target = _weaponTargets[weaponIndex];
@@ -1614,8 +1622,12 @@ namespace Rebellion.Game.Combat
                     if (damage > 0)
                     {
                         AddPendingDamage(pendingDamage, target, damage, weaponIndex == 2);
+                        consumedCharge += weaponStrength;
                     }
                 }
+
+                if (consumedCharge > 0)
+                    _currentWeaponCharge = Math.Max(_currentWeaponCharge - consumedCharge, 0);
             }
 
             /// <summary>
@@ -1685,7 +1697,13 @@ namespace Rebellion.Game.Combat
             protected override void AdvanceUnitState(
                 GameConfig.SpaceCombatConfig config,
                 IRandomNumberProvider random
-            ) { }
+            )
+            {
+                _currentWeaponCharge = Math.Min(
+                    _maximumWeaponCharge,
+                    _currentWeaponCharge + _weaponRecharge
+                );
+            }
 
             /// <inheritdoc />
             internal override void Destroy()

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -577,6 +577,8 @@ namespace Rebellion.Game
         {
             public double CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier { get; set; }
 
+            public double AutoResolveFighterWeaponRechargeMultiplier { get; set; }
+
             public int AutoResolveMaximumIterations { get; set; }
 
             public int AutoResolveStagnationIterations { get; set; }

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -336,6 +336,29 @@ namespace Rebellion.Tests.Game.Combat
         }
 
         [Test]
+        public void Resolve_FighterWeaponCharge_MustRechargeBeforeFiringAgain()
+        {
+            Starfighter attacker = CreateFighter("attacker", squadronSize: 1, weaponStrength: 10);
+            attacker.ShieldStrength = 1;
+            CapitalShip defender = CreatePassiveTarget("defender", hull: 100);
+            GameConfig.SpaceCombatConfig config = CreateConfig();
+            config.AutoResolveMaximumIterations = 2;
+            config.AutoResolveTargetScanDivisor = 1;
+            config.AutoResolveStartingDistance = 0;
+
+            SpaceCombatAutoResult result = Resolve(
+                config,
+                new List<CapitalShip>(),
+                new[] { attacker },
+                new[] { defender },
+                new List<Starfighter>(),
+                defenderCanWithdraw: true
+            );
+
+            Assert.AreEqual(90, GetShipOutcome(result, defender).HullAfter);
+        }
+
+        [Test]
         public void Resolve_IonDamageWithoutShields_DoesNotDamageCapitalShipHull()
         {
             Starfighter attacker = CreateFighter("attacker", squadronSize: 1, weaponStrength: 0);
@@ -1410,6 +1433,7 @@ namespace Rebellion.Tests.Game.Combat
             return new GameConfig.SpaceCombatConfig
             {
                 CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 1.0 / 6.0,
+                AutoResolveFighterWeaponRechargeMultiplier = 3.751,
                 AutoResolveMaximumIterations = 4096,
                 AutoResolveStagnationIterations = 1200,
                 AutoResolveRetreatStrengthRatio = 0.33,

--- a/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/SpaceCombatSystemTests.cs
@@ -2954,6 +2954,7 @@ namespace Rebellion.Tests.Systems
                 {
                     SpaceCombat = new GameConfig.SpaceCombatConfig
                     {
+                        AutoResolveFighterWeaponRechargeMultiplier = 3.751,
                         AutoResolveMaximumIterations = 4096,
                         AutoResolveStagnationIterations = 1200,
                         AutoResolveRetreatStrengthRatio = 0.33,


### PR DESCRIPTION
## Summary

- Tracking a shared weapon-charge pool for each starfighter squadron in space autoresolve
- Requiring fighter weapons to recharge fully before another firing pass
- Consuming charge only for weapon lanes that fire, then recharge from shield strength and the configured multiplier
- Adding a regression test proving a fighter cannot fire again until its weapon charge is restored

This implements the missing fighter recharge behavior without applying it to capital ships. The tuning value lives in game config rather than resolver code.

Companion media/config PR (merge first): https://github.com/adasgames/rebellion2-media/pull/86

## Validation

- `bash build.sh test`: 4,700/4,700 Unity EditMode tests passed
- `Resolve_FighterWeaponCharge_MustRechargeBeforeFiringAgain`: passed in the repository test run
- `bash build.sh`: formatting, analyzer build/tests (6 passed), and production GameAssembly compilation passed; the local generated GameTests project then stopped on pre-existing missing `InputTestFixture` and `LogAssert` references
- `git diff --check`: passed

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [ ] UI builder changes were verified by rebuilding the affected UI.
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.