### PR TITLE
Fixing post battle icon mapping.

### DIFF
--- a/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjector.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjector.cs
@@ -162,7 +162,12 @@ internal sealed class BattleAlertWindowProjector
         bool detail = panel is BattleResultPanel.FirstForces or BattleResultPanel.SecondForces;
         bool direct = panel == BattleResultPanel.Direct;
         bool planetaryResult = result.UsesPlanetaryLayout;
-        string ownerInstanceId = result.GetOwnerInstanceID(panel);
+        string ownerInstanceId = GetForcesOwnerInstanceID(
+            uiContext,
+            result.AttackerOwnerInstanceID,
+            result.DefenderOwnerInstanceID,
+            panel == BattleResultPanel.SecondForces
+        );
         BattleResultTableRenderData table = detail
             ? resultTableProjector.Project(uiContext, result, ownerInstanceId, category)
             : null;
@@ -434,10 +439,13 @@ internal sealed class BattleAlertWindowProjector
         switch (panel)
         {
             case BattleAlertPanel.FirstForces:
-                AddFleetRows(rows, pending, GetPendingOwnerInstanceID(pending, panel), uiContext);
-                break;
             case BattleAlertPanel.SecondForces:
-                AddFleetRows(rows, pending, GetPendingOwnerInstanceID(pending, panel), uiContext);
+                AddFleetRows(
+                    rows,
+                    pending,
+                    GetPendingOwnerInstanceID(uiContext, pending, panel),
+                    uiContext
+                );
                 break;
             case BattleAlertPanel.SystemAssets:
                 AddSystemRows(rows, pending?.Planet, uiContext);
@@ -646,7 +654,7 @@ internal sealed class BattleAlertWindowProjector
         {
             BattleAlertPanel.FirstForces or BattleAlertPanel.SecondForces => GetForcesHeader(
                 uiContext,
-                GetPendingOwnerInstanceID(pending, panel)
+                GetPendingOwnerInstanceID(uiContext, pending, panel)
             ),
             BattleAlertPanel.SystemAssets => "System Assets",
             _ => "Battle Summary",
@@ -656,23 +664,59 @@ internal sealed class BattleAlertWindowProjector
     /// <summary>
     /// Returns the owner represented by a pending-combat force panel.
     /// </summary>
+    /// <param name="uiContext">The current strategy UI context.</param>
     /// <param name="pending">The pending encounter.</param>
     /// <param name="panel">The selected pending panel.</param>
     /// <returns>The represented owner identifier.</returns>
     private static string GetPendingOwnerInstanceID(
+        UIContext uiContext,
         PendingCombatResult pending,
         BattleAlertPanel panel
     )
     {
-        return panel == BattleAlertPanel.SecondForces
-            ? BattleResultPresentation.FirstNonBlank(
-                pending?.DefenderOwnerInstanceID,
-                pending?.DefenderFleet?.GetOwnerInstanceID()
+        string attackerOwnerInstanceId = BattleResultPresentation.FirstNonBlank(
+            pending?.AttackerOwnerInstanceID,
+            pending?.AttackerFleet?.GetOwnerInstanceID()
+        );
+        string defenderOwnerInstanceId = BattleResultPresentation.FirstNonBlank(
+            pending?.DefenderOwnerInstanceID,
+            pending?.DefenderFleet?.GetOwnerInstanceID()
+        );
+        return GetForcesOwnerInstanceID(
+            uiContext,
+            attackerOwnerInstanceId,
+            defenderOwnerInstanceId,
+            panel == BattleAlertPanel.SecondForces
+        );
+    }
+
+    /// <summary>
+    /// Resolves a faction-icon slot independently of which faction attacked.
+    /// </summary>
+    /// <param name="uiContext">The current strategy UI context.</param>
+    /// <param name="attackerOwnerInstanceId">The attacking faction identifier.</param>
+    /// <param name="defenderOwnerInstanceId">The defending faction identifier.</param>
+    /// <param name="secondForces">Whether to resolve the second faction-icon slot.</param>
+    /// <returns>The owner represented by the requested faction-icon slot.</returns>
+    private static string GetForcesOwnerInstanceID(
+        UIContext uiContext,
+        string attackerOwnerInstanceId,
+        string defenderOwnerInstanceId,
+        bool secondForces
+    )
+    {
+        string[] participants = { attackerOwnerInstanceId, defenderOwnerInstanceId };
+        IEnumerable<string> configuredFactionOrder =
+            uiContext?.Game?.GetFactions()?.Select(faction => faction?.InstanceID)
+            ?? Enumerable.Empty<string>();
+        List<string> orderedParticipants = configuredFactionOrder
+            .Concat(participants)
+            .Where(ownerInstanceId =>
+                !string.IsNullOrEmpty(ownerInstanceId) && participants.Contains(ownerInstanceId)
             )
-            : BattleResultPresentation.FirstNonBlank(
-                pending?.AttackerOwnerInstanceID,
-                pending?.AttackerFleet?.GetOwnerInstanceID()
-            );
+            .Distinct()
+            .ToList();
+        return orderedParticipants.ElementAtOrDefault(secondForces ? 1 : 0);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleResultPresentation.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Combat/BattleResultPresentation.cs
@@ -251,18 +251,6 @@ internal abstract class BattleResultPresentation
     }
 
     /// <summary>
-    /// Gets the owner identifier represented by a result-window force panel.
-    /// </summary>
-    /// <param name="panel">The selected result-window panel.</param>
-    /// <returns>The represented attacker or defender owner identifier.</returns>
-    internal string GetOwnerInstanceID(BattleResultPanel panel)
-    {
-        return panel == BattleResultPanel.SecondForces
-            ? DefenderOwnerInstanceID
-            : AttackerOwnerInstanceID;
-    }
-
-    /// <summary>
     /// Returns the owner identifier represented by one combat side.
     /// </summary>
     /// <param name="result">The completed combat result.</param>

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjectorTests.cs
@@ -134,7 +134,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Combat
         }
 
         [Test]
-        public void Project_PendingForces_WhenEmpireAttacks_IconsStillOpenMatchingFactions()
+        public void Project_PendingForces_WhenSecondFactionAttacks_IconsStillMatchFactionOrder()
         {
             (
                 GameRoot Game,
@@ -660,7 +660,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Combat
         }
 
         [Test]
-        public void Project_ResultForces_WhenEmpireAttacks_IconsStillOpenMatchingFactions()
+        public void Project_ResultForces_WhenSecondFactionAttacks_IconsStillMatchFactionOrder()
         {
             (
                 GameRoot Game,

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjectorTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Combat/BattleAlertWindowProjectorTests.cs
@@ -134,6 +134,63 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Combat
         }
 
         [Test]
+        public void Project_PendingForces_WhenEmpireAttacks_IconsStillOpenMatchingFactions()
+        {
+            (
+                GameRoot Game,
+                UIContext Context,
+                Planet Planet,
+                GameFleet PlayerFleet,
+                GameFleet OpponentFleet
+            ) scene = CreateScene();
+            PendingCombatResult pending = new PendingCombatResult
+            {
+                Planet = scene.Planet,
+                AttackerFleet = scene.OpponentFleet,
+                DefenderFleet = scene.PlayerFleet,
+                AttackerOwnerInstanceID = _opponentFactionId,
+                DefenderOwnerInstanceID = _playerFactionId,
+            };
+            BattleAlertWindowProjector projector = new BattleAlertWindowProjector();
+
+            BattleAlertWindowRenderData alliance = projector.Project(
+                BattleAlertWindowMode.Pending,
+                BattleAlertPanel.FirstForces,
+                BattleResultPanel.Summary,
+                BattleResultCategory.CapitalShips,
+                pending,
+                null,
+                _playerFactionId,
+                0,
+                0,
+                scene.Context
+            );
+            BattleAlertWindowRenderData empire = projector.Project(
+                BattleAlertWindowMode.Pending,
+                BattleAlertPanel.SecondForces,
+                BattleResultPanel.Summary,
+                BattleResultCategory.CapitalShips,
+                pending,
+                null,
+                _playerFactionId,
+                0,
+                0,
+                scene.Context
+            );
+
+            Assert.AreEqual("Alliance Forces", alliance.Pending.Header);
+            CollectionAssert.AreEqual(
+                new[] { "Player Fleet", "Player Ship" },
+                alliance.Pending.Rows.Select(row => row.Text)
+            );
+            Assert.AreEqual("Imperial Forces", empire.Pending.Header);
+            CollectionAssert.AreEqual(
+                new[] { "Opponent Fleet", "Opponent Ship" },
+                empire.Pending.Rows.Select(row => row.Text)
+            );
+        }
+
+        [Test]
         public void Project_PendingSecondForces_ExcludesUnitsUnderConstruction()
         {
             (
@@ -600,6 +657,67 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Combat
             Assert.IsTrue(data.Result.UsesPersonnelColumns);
             Assert.AreEqual("Field Officer", data.Result.ResultTable.Operational[0].Text);
             Assert.AreEqual("No Casualties", data.Result.ResultTable.Destroyed[0].Text);
+        }
+
+        [Test]
+        public void Project_ResultForces_WhenEmpireAttacks_IconsStillOpenMatchingFactions()
+        {
+            (
+                GameRoot Game,
+                UIContext Context,
+                Planet Planet,
+                GameFleet PlayerFleet,
+                GameFleet OpponentFleet
+            ) scene = CreateScene();
+            SpaceCombatResult result = new SpaceCombatResult
+            {
+                Planet = scene.Planet,
+                AttackerFleet = scene.OpponentFleet,
+                DefenderFleet = scene.PlayerFleet,
+                AttackerOwnerInstanceID = _opponentFactionId,
+                DefenderOwnerInstanceID = _playerFactionId,
+                Winner = CombatSide.Attacker,
+                AttackerOutcome = SpaceCombatSideOutcome.Active,
+                DefenderOutcome = SpaceCombatSideOutcome.Destroyed,
+            };
+            result.AttackingUnits.AddRange(
+                CombatUnitSnapshot.CaptureFleetUnits(new[] { scene.OpponentFleet })
+            );
+            result.DefendingUnits.AddRange(
+                CombatUnitSnapshot.CaptureFleetUnits(new[] { scene.PlayerFleet })
+            );
+            BattleAlertWindowProjector projector = new BattleAlertWindowProjector();
+            BattleResultPresentation presentation = BattleResultPresentation.Create(result);
+
+            BattleAlertWindowRenderData alliance = projector.Project(
+                BattleAlertWindowMode.Result,
+                BattleAlertPanel.Summary,
+                BattleResultPanel.FirstForces,
+                BattleResultCategory.CapitalShips,
+                null,
+                presentation,
+                _playerFactionId,
+                0,
+                0,
+                scene.Context
+            );
+            BattleAlertWindowRenderData empire = projector.Project(
+                BattleAlertWindowMode.Result,
+                BattleAlertPanel.Summary,
+                BattleResultPanel.SecondForces,
+                BattleResultCategory.CapitalShips,
+                null,
+                presentation,
+                _playerFactionId,
+                0,
+                0,
+                scene.Context
+            );
+
+            Assert.AreEqual("Alliance Forces", alliance.Result.ResultForceHeader);
+            Assert.AreEqual("Player Ship", alliance.Result.ResultTable.Operational[0].Text);
+            Assert.AreEqual("Imperial Forces", empire.Result.ResultForceHeader);
+            Assert.AreEqual("Opponent Ship", empire.Result.ResultTable.Operational[0].Text);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

- Keeping the Rebel and Imperial force icons bound to their configured faction order instead of treating the first icon as the attacker and the second as the defender
- Applying the corrected mapping to both pending-battle rosters and completed battle-result tables
- Preserving current filtering of unfinished and in-transit enemy units after updating the branch to latest `master`
- Removing the obsolete attacker/defender panel mapping from the result presentation
- Adding regression coverage for encounters where the second configured faction attacks the first, before and after combat resolution

## Validation

- `bash ./build.sh` passed
- Unity EditMode tests passed: 4,776/4,776
- formatting, analyzers, naming rules, compilation, Windows standalone build, and coverage thresholds passed
- `git diff --check` passed

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI through the full build.
- [x] Content path or structure changes were also made in `rebellion2-media`. (Not applicable: no content paths or structures changed.)
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (Not applicable: this corrects existing battle-panel behavior.)