### PR TITLE
Rename laser cannon damage multiplier

### DIFF
--- a/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
+++ b/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
@@ -1230,10 +1230,7 @@ namespace Rebellion.AI.Planners
                     turbolasers
                     + ionCannons
                     + laserCannons
-                        * Math.Max(
-                            combatConfig.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier,
-                            0
-                        );
+                        * Math.Max(combatConfig.LaserCannonDamageAgainstCapitalShipsMultiplier, 0);
                 if (effectiveStrength <= maximumEffectiveStrength)
                     continue;
 

--- a/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
+++ b/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
@@ -1029,7 +1029,7 @@ namespace Rebellion.Game.Combat
                 _laserCannons = GetWeaponValues(ship, PrimaryWeaponType.LaserCannon);
                 _ionCannons = GetWeaponValues(ship, PrimaryWeaponType.IonCannon);
                 _laserCannonDamageAgainstCapitalShipsMultiplier = Math.Max(
-                    config.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier,
+                    config.LaserCannonDamageAgainstCapitalShipsMultiplier,
                     0
                 );
                 CurrentHull = InitialHull;

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -575,7 +575,7 @@ namespace Rebellion.Game
         [PersistableObject]
         public class SpaceCombatConfig
         {
-            public double CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier { get; set; }
+            public double LaserCannonDamageAgainstCapitalShipsMultiplier { get; set; }
 
             public double AutoResolveFighterWeaponRechargeMultiplier { get; set; }
 

--- a/Assets/Tests/EditMode/GameTests/AI/Planners/AIProductionPlannerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/AI/Planners/AIProductionPlannerTests.cs
@@ -835,10 +835,7 @@ namespace Rebellion.Tests.AI.Planners
         public void Plan_WithFleetDeficit_UsesConfiguredLaserCannonDamageMultiplier()
         {
             GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction _);
-            game.Config
-                .Combat
-                .SpaceCombat
-                .CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 0.75;
+            game.Config.Combat.SpaceCombat.LaserCannonDamageAgainstCapitalShipsMultiplier = 0.75;
             PlanetSector system = AITestSceneBuilder.AddSector(game, "sys1");
             Planet planet = AITestSceneBuilder.AddPlanet(
                 game,

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -64,7 +64,7 @@ namespace Rebellion.Tests.Game.Combat
             attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][4] = 100;
             CapitalShip defender = CreatePassiveTarget("defender", hull: 100);
             GameConfig.SpaceCombatConfig config = CreateConfig();
-            config.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 0.25;
+            config.LaserCannonDamageAgainstCapitalShipsMultiplier = 0.25;
             config.AutoResolveMaximumIterations = 1;
             config.AutoResolveTargetScanDivisor = 1;
 
@@ -119,7 +119,7 @@ namespace Rebellion.Tests.Game.Combat
             );
             defenderFighter.Agility = 10;
             GameConfig.SpaceCombatConfig config = CreateConfig();
-            config.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 0.01;
+            config.LaserCannonDamageAgainstCapitalShipsMultiplier = 0.01;
             config.AutoResolveMaximumIterations = 1;
             config.AutoResolveTargetScanDivisor = 1;
             config.AutoResolveStartingDistance = 0;
@@ -149,7 +149,7 @@ namespace Rebellion.Tests.Game.Combat
                 weaponStrength: 20
             );
             GameConfig.SpaceCombatConfig config = CreateConfig();
-            config.CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 0.25;
+            config.LaserCannonDamageAgainstCapitalShipsMultiplier = 0.25;
             config.AutoResolveMaximumIterations = 0;
 
             SpaceCombatAutoResult result = Resolve(
@@ -1432,7 +1432,7 @@ namespace Rebellion.Tests.Game.Combat
         {
             return new GameConfig.SpaceCombatConfig
             {
-                CapitalShipLaserCannonDamageAgainstCapitalShipsMultiplier = 1.0 / 6.0,
+                LaserCannonDamageAgainstCapitalShipsMultiplier = 1.0 / 6.0,
                 AutoResolveFighterWeaponRechargeMultiplier = 3.751,
                 AutoResolveMaximumIterations = 4096,
                 AutoResolveStagnationIterations = 1200,


### PR DESCRIPTION
## Summary

- Renaming the space-combat setting to `LaserCannonDamageAgainstCapitalShipsMultiplier`.
- Updating auto-resolution, AI strength evaluation, and their tests to use the clearer name.
- Pairing this with the corresponding XML and XSD rename in rebellion2-media.

## Validation

- `bash build.sh format`
- `bash build.sh lint`
- `bash build.sh test` — 4,723 passed, 0 failed
- `bash build.sh build` — StandaloneWindows64 build succeeded
- Headless player boot with the matching media content — no config deserialization or AppBootstrap errors

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI. (No UI builder changes; the test/build pipeline rebuilt generated UI successfully.)
- [x] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed. (No documentation change was required.)