### PR TITLE
Enabling idle bar by default.

### DIFF
--- a/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/OptionsMenu/OptionsMenuPrefabBuilder.cs
@@ -311,7 +311,7 @@ public static class OptionsMenuPrefabBuilder
         {
             "Pause After Enemy Bombardment",
             "Pause on Space Battles",
-            "[Experimental] Show Idle Bar",
+            "Show Idle Bar",
         };
         OptionsToggleRowView[] rows = new OptionsToggleRowView[options.Length + 1];
         rows[0] = autosaveRow;

--- a/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/ContextMenus/StrategyMenuCommand.cs
@@ -246,7 +246,7 @@ public static class StrategyContextMenuAvailability
     /// </summary>
     /// <param name="item">The context-targeted scene node.</param>
     /// <param name="playerFactionId">The player faction identifier.</param>
-    /// <param name="idleBarEnabled">Whether the experimental idle bar is enabled.</param>
+    /// <param name="idleBarEnabled">Whether the idle bar is enabled.</param>
     /// <returns><see langword="true"/> when tracking can be changed for the item.</returns>
     public static bool CanToggleIdleBarTracking(
         ISceneNode item,

--- a/Assets/Scripts/UserSettings/UserGameplaySettings.cs
+++ b/Assets/Scripts/UserSettings/UserGameplaySettings.cs
@@ -28,7 +28,7 @@ public sealed class UserGameplaySettings
     public int AutosavesToKeep = DefaultAutosavesToKeep;
     public bool PauseAfterEnemyBombardment = true;
     public bool PauseWhenSpaceBattleBegins = true;
-    public bool ShowIdleBar;
+    public bool ShowIdleBar = true;
     public bool ShowMissionOdds = true;
 
     /// <summary>
@@ -116,7 +116,7 @@ public sealed class UserGameplaySettings
         AutosavesToKeep = DefaultAutosavesToKeep;
         PauseAfterEnemyBombardment = true;
         PauseWhenSpaceBattleBegins = true;
-        ShowIdleBar = false;
+        ShowIdleBar = true;
         ShowMissionOdds = true;
     }
 }

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsMenuViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/OptionsMenu/OptionsMenuViewTests.cs
@@ -333,7 +333,7 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 .ToArray();
 
             CollectionAssert.Contains(labels, "GALACTIC MODE");
-            CollectionAssert.Contains(labels, "[Experimental] Show Idle Bar");
+            CollectionAssert.Contains(labels, "Show Idle Bar");
             CollectionAssert.Contains(labels, "RETURN TO GAME");
             CollectionAssert.Contains(labels, "RETURN TO MAIN MENU");
         }

--- a/Assets/Tests/EditMode/GameTests/UserSettings/UserGameplaySettingsTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UserSettings/UserGameplaySettingsTests.cs
@@ -32,7 +32,7 @@ namespace Rebellion.Tests.UserSettings
 
             Assert.IsTrue(settings.PauseAfterEnemyBombardment);
             Assert.IsTrue(settings.PauseWhenSpaceBattleBegins);
-            Assert.IsFalse(settings.ShowIdleBar);
+            Assert.IsTrue(settings.ShowIdleBar);
             Assert.IsTrue(settings.ShowMissionOdds);
 
             settings.PauseAfterEnemyBombardment = false;
@@ -43,7 +43,7 @@ namespace Rebellion.Tests.UserSettings
 
             Assert.IsTrue(settings.PauseAfterEnemyBombardment);
             Assert.IsTrue(settings.PauseWhenSpaceBattleBegins);
-            Assert.IsFalse(settings.ShowIdleBar);
+            Assert.IsTrue(settings.ShowIdleBar);
             Assert.IsTrue(settings.ShowMissionOdds);
         }
 
@@ -56,11 +56,11 @@ namespace Rebellion.Tests.UserSettings
         }
 
         [Test]
-        public void JsonUtility_OmittedIdleBarPreference_DefaultsDisabled()
+        public void JsonUtility_OmittedIdleBarPreference_DefaultsEnabled()
         {
             UserGameplaySettings settings = JsonUtility.FromJson<UserGameplaySettings>("{}");
 
-            Assert.IsFalse(settings.ShowIdleBar);
+            Assert.IsTrue(settings.ShowIdleBar);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

- Enabling the idle bar by default for new or omitted gameplay settings.
- Restoring the enabled idle-bar state when gameplay settings are reset to defaults.
- Removing the `[Experimental]` qualifier from the gameplay option and its remaining documentation.
- Updating persistence and generated-options-view expectations for the production label and default.

## Validation

- `bash build.sh`
  - Formatting passed.
  - Static analysis and compilation passed.
  - 4,774/4,774 EditMode tests passed with zero failures or skips.
  - Line coverage: 81.1% (79.0% required).
  - Method coverage: 91.0% (87.8% required).
- Rebuilt the authored options UI through `UIBuilderMenu.BuildAll` as part of the Unity test run.
- Confirmed no remaining idle-bar `Experimental` references under `Assets`.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [x] No content path or structure changes were required in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] No documentation changes were required for this gameplay-default and label update.