### PR TITLE
Renaming poorly named configs.

### DIFF
--- a/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
+++ b/Assets/Scripts/AI/Planners/AIProductionPlanner.cs
@@ -1229,8 +1229,7 @@ namespace Rebellion.AI.Planners
                 double effectiveStrength =
                     turbolasers
                     + ionCannons
-                    + laserCannons
-                        * Math.Max(combatConfig.LaserCannonDamageAgainstCapitalShipsMultiplier, 0);
+                    + laserCannons * Math.Max(combatConfig.LaserCannonCapitalDamageMultiplier, 0);
                 if (effectiveStrength <= maximumEffectiveStrength)
                     continue;
 

--- a/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
+++ b/Assets/Scripts/Game/Combat/SpaceCombatAutoResolver.cs
@@ -971,7 +971,7 @@ namespace Rebellion.Game.Combat
             ];
             private readonly int[] _ionCannons;
             private readonly int[] _laserCannons;
-            private readonly double _laserCannonDamageAgainstCapitalShipsMultiplier;
+            private readonly double _laserCannonCapitalDamageMultiplier;
             private readonly double _maximumHull;
             private readonly double _maximumShields;
             private readonly double[] _maximumArcCharge = new double[
@@ -1028,8 +1028,8 @@ namespace Rebellion.Game.Combat
                 _turbolasers = GetWeaponValues(ship, PrimaryWeaponType.Turbolaser);
                 _laserCannons = GetWeaponValues(ship, PrimaryWeaponType.LaserCannon);
                 _ionCannons = GetWeaponValues(ship, PrimaryWeaponType.IonCannon);
-                _laserCannonDamageAgainstCapitalShipsMultiplier = Math.Max(
-                    config.LaserCannonDamageAgainstCapitalShipsMultiplier,
+                _laserCannonCapitalDamageMultiplier = Math.Max(
+                    config.LaserCannonCapitalDamageMultiplier,
                     0
                 );
                 CurrentHull = InitialHull;
@@ -1480,7 +1480,7 @@ namespace Rebellion.Game.Combat
                 if (type == PrimaryWeaponType.IonCannon && targetsFighters)
                     return 0;
                 if (type == PrimaryWeaponType.LaserCannon && !targetsFighters)
-                    return _laserCannonDamageAgainstCapitalShipsMultiplier;
+                    return _laserCannonCapitalDamageMultiplier;
                 return 1;
             }
 

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -575,7 +575,7 @@ namespace Rebellion.Game
         [PersistableObject]
         public class SpaceCombatConfig
         {
-            public double LaserCannonDamageAgainstCapitalShipsMultiplier { get; set; }
+            public double LaserCannonCapitalDamageMultiplier { get; set; }
 
             public double AutoResolveFighterWeaponRechargeMultiplier { get; set; }
 

--- a/Assets/Tests/EditMode/GameTests/AI/Planners/AIProductionPlannerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/AI/Planners/AIProductionPlannerTests.cs
@@ -835,7 +835,7 @@ namespace Rebellion.Tests.AI.Planners
         public void Plan_WithFleetDeficit_UsesConfiguredLaserCannonDamageMultiplier()
         {
             GameRoot game = AITestSceneBuilder.CreateGame(out Faction empire, out Faction _);
-            game.Config.Combat.SpaceCombat.LaserCannonDamageAgainstCapitalShipsMultiplier = 0.75;
+            game.Config.Combat.SpaceCombat.LaserCannonCapitalDamageMultiplier = 0.75;
             PlanetSector system = AITestSceneBuilder.AddSector(game, "sys1");
             Planet planet = AITestSceneBuilder.AddPlanet(
                 game,

--- a/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Game/Combat/SpaceCombatAutoResolverTests.cs
@@ -64,7 +64,7 @@ namespace Rebellion.Tests.Game.Combat
             attacker.PrimaryWeapons[PrimaryWeaponType.LaserCannon][4] = 100;
             CapitalShip defender = CreatePassiveTarget("defender", hull: 100);
             GameConfig.SpaceCombatConfig config = CreateConfig();
-            config.LaserCannonDamageAgainstCapitalShipsMultiplier = 0.25;
+            config.LaserCannonCapitalDamageMultiplier = 0.25;
             config.AutoResolveMaximumIterations = 1;
             config.AutoResolveTargetScanDivisor = 1;
 
@@ -119,7 +119,7 @@ namespace Rebellion.Tests.Game.Combat
             );
             defenderFighter.Agility = 10;
             GameConfig.SpaceCombatConfig config = CreateConfig();
-            config.LaserCannonDamageAgainstCapitalShipsMultiplier = 0.01;
+            config.LaserCannonCapitalDamageMultiplier = 0.01;
             config.AutoResolveMaximumIterations = 1;
             config.AutoResolveTargetScanDivisor = 1;
             config.AutoResolveStartingDistance = 0;
@@ -149,7 +149,7 @@ namespace Rebellion.Tests.Game.Combat
                 weaponStrength: 20
             );
             GameConfig.SpaceCombatConfig config = CreateConfig();
-            config.LaserCannonDamageAgainstCapitalShipsMultiplier = 0.25;
+            config.LaserCannonCapitalDamageMultiplier = 0.25;
             config.AutoResolveMaximumIterations = 0;
 
             SpaceCombatAutoResult result = Resolve(
@@ -1432,7 +1432,7 @@ namespace Rebellion.Tests.Game.Combat
         {
             return new GameConfig.SpaceCombatConfig
             {
-                LaserCannonDamageAgainstCapitalShipsMultiplier = 1.0 / 6.0,
+                LaserCannonCapitalDamageMultiplier = 1.0 / 6.0,
                 AutoResolveFighterWeaponRechargeMultiplier = 3.751,
                 AutoResolveMaximumIterations = 4096,
                 AutoResolveStagnationIterations = 1200,


### PR DESCRIPTION
## Summary

- Renaming `LaserCannonDamageAgainstCapitalShipsMultiplier` to the shorter `LaserCannonCapitalDamageMultiplier`.
- Updating combat resolution, AI production scoring, and their tests without changing the multiplier's behavior or value.
- Pairing with adasgames/rebellion2-media#93, which updates the rules XML and schema contract.

## Validation

- `bash build.sh`
  - Formatting passed.
  - Static analysis and compilation passed.
  - 4,774/4,774 EditMode tests passed with zero failures or skips.
  - Line coverage: 81.1% (79.0% required).
  - Method coverage: 91.0% (87.8% required).
- Confirmed no references to either previous long-form name remain in tracked code or media content.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] No UI builder changes were made.
- [x] The matching content contract change is included in adasgames/rebellion2-media#93.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] No documentation changes were required for this internal configuration rename.