### PR TITLE
Fixing bug which left stale orders on planet when manufacturing was destroyed.

### DIFF
--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -545,6 +545,9 @@ public sealed class GameManager
         _resultProcessor.Subscribe<OfficerCaptureStateResult>(_missionSystem);
         _resultProcessor.Subscribe<OfficerCaptureStateResult>(_captiveSystem);
         _resultProcessor.Subscribe<IntelligenceRevealedResult>(_fogOfWarSystem);
+        _resultProcessor.Subscribe<GameObjectDestroyedResult>(_manufacturingSystem);
+        _resultProcessor.Subscribe<BombardmentResult>(_manufacturingSystem);
+        _resultProcessor.Subscribe<PlanetaryAssaultResult>(_manufacturingSystem);
         _resultProcessor.Observe<GameObjectSabotagedResult>(_fogOfWarSystem.ProcessResults);
 
         _movementSystem.ResultsProduced += HandleSystemResultsProduced;

--- a/Assets/Scripts/Systems/ManufacturingSystem.cs
+++ b/Assets/Scripts/Systems/ManufacturingSystem.cs
@@ -16,6 +16,9 @@ namespace Rebellion.Systems
     /// Manages unit and facility production during each game tick.
     /// </summary>
     public class ManufacturingSystem
+        : IGameResultHandler<GameObjectDestroyedResult>,
+            IGameResultHandler<BombardmentResult>,
+            IGameResultHandler<PlanetaryAssaultResult>
     {
         private const int _productionRateScale = 100;
 
@@ -55,6 +58,68 @@ namespace Rebellion.Systems
                 results.AddRange(ProcessPlanetManufacturing(planet));
             }
             return results;
+        }
+
+        /// <summary>
+        /// Cancels affected production lanes after individually reported buildings are destroyed.
+        /// </summary>
+        /// <param name="results">The destruction results to inspect.</param>
+        /// <returns>No additional results.</returns>
+        public List<GameResult> HandleResults(IReadOnlyList<GameObjectDestroyedResult> results)
+        {
+            if (results == null)
+                return new List<GameResult>();
+
+            foreach (
+                IGrouping<Planet, GameObjectDestroyedResult> planetResults in results
+                    .Where(result =>
+                        result?.DestroyedObject is Building && result.Context is Planet
+                    )
+                    .GroupBy(result => (Planet)result.Context)
+            )
+            {
+                CancelUnsupportedProduction(
+                    planetResults.Key,
+                    planetResults.Select(result => (Building)result.DestroyedObject)
+                );
+            }
+
+            return new List<GameResult>();
+        }
+
+        /// <summary>
+        /// Cancels affected production lanes after orbital bombardment destroys buildings.
+        /// </summary>
+        /// <param name="results">The bombardment results to inspect.</param>
+        /// <returns>No additional results.</returns>
+        public List<GameResult> HandleResults(IReadOnlyList<BombardmentResult> results)
+        {
+            if (results != null)
+            {
+                foreach (BombardmentResult result in results)
+                    CancelUnsupportedProduction(result?.Planet, result?.DestroyedBuildings);
+            }
+
+            return new List<GameResult>();
+        }
+
+        /// <summary>
+        /// Cancels affected production lanes after a planetary assault destroys buildings.
+        /// </summary>
+        /// <param name="results">The assault results to inspect.</param>
+        /// <returns>No additional results.</returns>
+        public List<GameResult> HandleResults(IReadOnlyList<PlanetaryAssaultResult> results)
+        {
+            if (results != null)
+            {
+                foreach (PlanetaryAssaultResult result in results)
+                    CancelUnsupportedProduction(
+                        result?.Planet,
+                        result?.CollateralDestroyedBuildings
+                    );
+            }
+
+            return new List<GameResult>();
         }
 
         /// <summary>
@@ -1525,6 +1590,56 @@ namespace Rebellion.Systems
             }
 
             items.Clear();
+        }
+
+        /// <summary>
+        /// Cancels queued work for each destroyed production type that no surviving facility can
+        /// manufacture on the same planet.
+        /// </summary>
+        /// <param name="planet">The planet where the facilities were destroyed.</param>
+        /// <param name="destroyedBuildings">The buildings destroyed by the completed action.</param>
+        private void CancelUnsupportedProduction(
+            Planet planet,
+            IEnumerable<Building> destroyedBuildings
+        )
+        {
+            if (planet == null || destroyedBuildings == null)
+                return;
+
+            Dictionary<ManufacturingType, List<IManufacturable>> queues =
+                planet.GetManufacturingQueue();
+            foreach (
+                ManufacturingType type in destroyedBuildings
+                    .Where(building =>
+                        building != null
+                        && building.ManufacturingStatus == ManufacturingStatus.Complete
+                        && building.Movement == null
+                        && building.ProcessRate > 0
+                    )
+                    .Select(building => building.ProductionType)
+                    .Where(type => type != ManufacturingType.None)
+                    .Distinct()
+                    .ToList()
+            )
+            {
+                bool hasProducer = planet
+                    .GetChildren<Building>()
+                    .Any(facility =>
+                        facility.ProductionType == type
+                        && facility.ManufacturingStatus == ManufacturingStatus.Complete
+                        && facility.Movement == null
+                        && facility.ProcessRate > 0
+                    );
+                if (
+                    hasProducer
+                    || !queues.TryGetValue(type, out List<IManufacturable> items)
+                    || items == null
+                )
+                    continue;
+
+                ClearQueueItems(planet, items);
+                queues.Remove(type);
+            }
         }
 
         /// <summary>

--- a/Assets/Tests/EditMode/GameTests/Systems/ManufacturingSystemTests.cs
+++ b/Assets/Tests/EditMode/GameTests/Systems/ManufacturingSystemTests.cs
@@ -550,6 +550,110 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void HandleResults_LastProductionBuildingDestroyed_CancelsQueuedWork()
+        {
+            Building mine = new Building
+            {
+                InstanceID = "MINE1",
+                OwnerInstanceID = "EMPIRE",
+                ConstructionCost = 100,
+                BaseBuildSpeed = 10,
+                BuildingType = BuildingType.Mine,
+            };
+            _manager.Enqueue(_coruscant, mine, _coruscant, ignoreCost: true);
+            _game.DetachNode(_shipyard);
+
+            _manager.HandleResults(
+                new List<GameObjectDestroyedResult>
+                {
+                    new GameObjectDestroyedResult
+                    {
+                        DestroyedObject = _shipyard,
+                        Context = _coruscant,
+                    },
+                }
+            );
+
+            Assert.IsFalse(
+                _coruscant.GetManufacturingQueue().ContainsKey(ManufacturingType.Building)
+            );
+            Assert.IsNull(mine.GetParent());
+        }
+
+        [Test]
+        public void HandleResults_AnotherProductionBuildingSurvives_RetainsQueuedWork()
+        {
+            Building secondShipyard = new Building
+            {
+                InstanceID = "SHIPYARD2",
+                OwnerInstanceID = "EMPIRE",
+                BuildingType = BuildingType.ConstructionFacility,
+                ProductionType = ManufacturingType.Building,
+                ProcessRate = 4,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            _game.AttachNode(secondShipyard, _coruscant);
+            Building mine = new Building
+            {
+                InstanceID = "MINE1",
+                OwnerInstanceID = "EMPIRE",
+                ConstructionCost = 100,
+                BaseBuildSpeed = 10,
+                BuildingType = BuildingType.Mine,
+            };
+            _manager.Enqueue(_coruscant, mine, _coruscant, ignoreCost: true);
+            _game.DetachNode(_shipyard);
+
+            _manager.HandleResults(
+                new List<GameObjectDestroyedResult>
+                {
+                    new GameObjectDestroyedResult
+                    {
+                        DestroyedObject = _shipyard,
+                        Context = _coruscant,
+                    },
+                }
+            );
+
+            CollectionAssert.Contains(
+                _coruscant.GetManufacturingQueue()[ManufacturingType.Building],
+                mine
+            );
+            Assert.AreSame(_coruscant, mine.GetParent());
+        }
+
+        [Test]
+        public void HandleResults_BombardmentDestroysLastProducer_CancelsQueuedWork()
+        {
+            Building mine = new Building
+            {
+                InstanceID = "MINE1",
+                OwnerInstanceID = "EMPIRE",
+                ConstructionCost = 100,
+                BaseBuildSpeed = 10,
+                BuildingType = BuildingType.Mine,
+            };
+            _manager.Enqueue(_coruscant, mine, _coruscant, ignoreCost: true);
+            _game.DetachNode(_shipyard);
+
+            _manager.HandleResults(
+                new List<BombardmentResult>
+                {
+                    new BombardmentResult
+                    {
+                        Planet = _coruscant,
+                        DestroyedBuildings = new List<Building> { _shipyard },
+                    },
+                }
+            );
+
+            Assert.IsFalse(
+                _coruscant.GetManufacturingQueue().ContainsKey(ManufacturingType.Building)
+            );
+            Assert.IsNull(mine.GetParent());
+        }
+
+        [Test]
         public void ProcessTick_MultipleProductionSources_StackCorrectly()
         {
             _shipyard.ProcessRate = 4;
@@ -3473,6 +3577,32 @@ namespace Rebellion.Tests.Systems
             Assert.IsFalse(_shipyard.ProductionInputReserved);
             Assert.IsFalse(_shipyard.ProductionPointReady);
             Assert.IsNull(_game.GetSceneNodeByInstanceID<Building>(mine.InstanceID));
+        }
+
+        [Test]
+        public void CancelManufacturing_QueuedItem_RestoresMaintenanceHeadroom()
+        {
+            const int maintenanceCost = 12;
+            int initialHeadroom = _empire.ProjectedMaintenanceHeadroom;
+            Building mine = new Building
+            {
+                InstanceID = "MINE1",
+                OwnerInstanceID = "EMPIRE",
+                ConstructionCost = 100,
+                MaintenanceCost = maintenanceCost,
+                BaseBuildSpeed = 10,
+                BuildingType = BuildingType.Mine,
+            };
+            _manager.Enqueue(_coruscant, mine, _coruscant, ignoreCost: true);
+            Assert.AreEqual(
+                initialHeadroom - maintenanceCost,
+                _empire.ProjectedMaintenanceHeadroom
+            );
+
+            bool cancelled = _manager.CancelManufacturing(mine, _empire.InstanceID);
+
+            Assert.IsTrue(cancelled);
+            Assert.AreEqual(initialHeadroom, _empire.ProjectedMaintenanceHeadroom);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

- Canceling a planet’s manufacturing lane when its last compatible production facility is destroyed
- Handling individual destruction, bombardment, and planetary-assault collateral results
- Retaining queued work when another compatible producer survives
- Verifying canceled work restores projected maintenance headroom

## Validation

- `bash build.sh`
- Unity EditMode tests: 4,778 passed, 0 failed

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [ ] UI builder changes were verified by rebuilding the affected UI.
- [ ] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [ ] Documentation was updated when behavior or setup changed.