### PR TITLE
Restoring upgraded strategy HUD buttons

### DIFF
--- a/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
+++ b/Assets/Editor/PrefabBuilders/StrategyView/StrategyViewPrefabBuilder.cs
@@ -365,6 +365,34 @@ public static class StrategyViewPrefabBuilder
     }
 
     /// <summary>
+    /// Authors the themed HUD command-button image slots in their configured order.
+    /// </summary>
+    /// <param name="parent">The HUD button-image container.</param>
+    /// <returns>The authored HUD button images.</returns>
+    private static List<RawImage> CreateHudButtonImages(Transform parent)
+    {
+        List<RawImage> images = new List<RawImage>();
+        List<StrategyHudButtonTheme> buttons = PreviewTheme?.TacticalHUDLayout?.Buttons;
+        if (buttons == null)
+            return images;
+
+        for (int i = 0; i < buttons.Count; i++)
+        {
+            StrategyHudButtonTheme button = buttons[i];
+            RawImage image = CreateRawImage(
+                $"{button.Action}ButtonImage",
+                parent,
+                button.UpImagePath,
+                button.PressedImageLayout ?? button.HitArea
+            );
+            image.raycastTarget = false;
+            images.Add(image);
+        }
+
+        return images;
+    }
+
+    /// <summary>
     /// Authors the themed HUD message-notification image slots.
     /// </summary>
     /// <param name="parent">The HUD notification container.</param>
@@ -789,6 +817,7 @@ public static class StrategyViewPrefabBuilder
             hud.transform
         );
         List<Button> messageNotificationButtons = CreateButtons(messageNotificationImages);
+        List<RawImage> mainButtonImages = CreateHudButtonImages(hud.transform);
         List<UIRaycastArea> hudButtonViews = CreateHudButtonViews(hud.transform);
         UIRaycastArea speedContextView = CreateHudButtonView(
             "GameSpeedButton",
@@ -902,6 +931,7 @@ public static class StrategyViewPrefabBuilder
             galacticInformationDisplayImage
         );
         AssignReference(hudView, "pressedMainButtonImage", pressedMainButtonImage);
+        AssignReferenceArray(hudView, "mainButtonImages", mainButtonImages);
         AssignReferenceArray(hudView, "messageNotificationImages", messageNotificationImages);
         AssignReferenceArray(hudView, "messageNotificationButtons", messageNotificationButtons);
         AssignReferenceArray(hudView, "buttonViews", hudButtonViews);

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudController.cs
@@ -369,6 +369,7 @@ public sealed class StrategyHudController : IContextMenuReceiver
                 new StrategyHudButtonViewData(
                     theme.Action,
                     ToRequiredRect(theme.HitArea),
+                    ResolveTexture(theme.UpImagePath),
                     ResolveTexture(theme.PressedImagePath),
                     ToRequiredRect(theme.PressedImageLayout ?? theme.HitArea)
                 )

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudView.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudView.cs
@@ -36,6 +36,9 @@ public sealed class StrategyHudView : MonoBehaviour
     private RawImage pressedMainButtonImage;
 
     [SerializeField]
+    private RawImage[] mainButtonImages = Array.Empty<RawImage>();
+
+    [SerializeField]
     private UIRaycastArea[] buttonViews = Array.Empty<UIRaycastArea>();
 
     [SerializeField]
@@ -258,11 +261,15 @@ public sealed class StrategyHudView : MonoBehaviour
         {
             StrategyHudButtonViewData button = buttons[i];
             renderedButtons.Add(button);
+            SetImageAtSourceRect(mainButtonImages[i], button.UpTexture, button.ImageBounds);
             buttonViews[i].Render(button.HitArea);
         }
 
         for (int i = renderedCount; i < buttonViews.Length; i++)
+        {
+            SetImageAtSourceRect(mainButtonImages[i], null, null);
             buttonViews[i].gameObject.SetActive(false);
+        }
 
         speedContextView.Render(speedContextBounds);
     }
@@ -302,7 +309,7 @@ public sealed class StrategyHudView : MonoBehaviour
             return;
         }
 
-        SetImageAtSourceRect(pressedMainButtonImage, button.PressedTexture, button.PressedBounds);
+        SetImageAtSourceRect(pressedMainButtonImage, button.PressedTexture, button.ImageBounds);
     }
 
     /// <summary>
@@ -483,6 +490,18 @@ public sealed class StrategyHudView : MonoBehaviour
         if (pressedMainButtonImage == null)
             throw new MissingReferenceException($"{name}/PressedMainButtonImage is missing.");
         if (
+            mainButtonImages == null
+            || buttonViews == null
+            || mainButtonImages.Length == 0
+            || mainButtonImages.Length != buttonViews.Length
+        )
+            throw new MissingReferenceException($"{name}/HUD button image slots are missing.");
+        for (int i = 0; i < mainButtonImages.Length; i++)
+        {
+            if (mainButtonImages[i] == null)
+                throw new MissingReferenceException($"{name}/MainButtonImage{i} is missing.");
+        }
+        if (
             messageNotificationImages == null
             || messageNotificationButtons == null
             || messageNotificationImages.Length == 0
@@ -501,7 +520,7 @@ public sealed class StrategyHudView : MonoBehaviour
                 );
         }
 
-        if (buttonViews == null || buttonViews.Length == 0)
+        if (buttonViews.Length == 0)
             throw new MissingReferenceException($"{name}/HUD button views are missing.");
         for (int i = 0; i < buttonViews.Length; i++)
         {

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudViewData.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Hud/StrategyHudViewData.cs
@@ -87,7 +87,7 @@ public sealed class StrategyHudCounterViewData
 }
 
 /// <summary>
-/// Defines the action, hit area, and pressed presentation for one HUD button slot.
+/// Defines the action, hit area, and artwork for one HUD button slot.
 /// </summary>
 public sealed class StrategyHudButtonViewData
 {
@@ -95,28 +95,33 @@ public sealed class StrategyHudButtonViewData
 
     public RectInt HitArea { get; }
 
+    public Texture2D UpTexture { get; }
+
     public Texture2D PressedTexture { get; }
 
-    public RectInt PressedBounds { get; }
+    public RectInt ImageBounds { get; }
 
     /// <summary>
     /// Creates immutable HUD button presentation data.
     /// </summary>
     /// <param name="action">The semantic action assigned to the button.</param>
     /// <param name="hitArea">The source-space button hit area.</param>
+    /// <param name="upTexture">The texture displayed while released.</param>
     /// <param name="pressedTexture">The texture displayed while pressed.</param>
-    /// <param name="pressedBounds">The source-space pressed-art bounds.</param>
+    /// <param name="imageBounds">The source-space artwork bounds.</param>
     public StrategyHudButtonViewData(
         StrategyHudAction action,
         RectInt hitArea,
+        Texture2D upTexture,
         Texture2D pressedTexture,
-        RectInt pressedBounds
+        RectInt imageBounds
     )
     {
         Action = action;
         HitArea = hitArea;
+        UpTexture = upTexture;
         PressedTexture = pressedTexture;
-        PressedBounds = pressedBounds;
+        ImageBounds = imageBounds;
     }
 }
 

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyHudControllerTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyHudControllerTests.cs
@@ -114,6 +114,65 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         }
 
         [Test]
+        public void CreateViewData_ConfiguredButton_ResolvesReleasedAndPressedArtwork()
+        {
+            Texture2D upTexture = new Texture2D(2, 2);
+            Texture2D pressedTexture = new Texture2D(2, 2);
+            try
+            {
+                StrategyHudController controller = new StrategyHudController(
+                    () => new Faction(),
+                    () => new FactionTheme(),
+                    path => path == "up" ? upTexture : pressedTexture,
+                    _ => { }
+                );
+                FactionTheme theme = new FactionTheme
+                {
+                    TacticalHUDLayout = new TacticalHUDLayout
+                    {
+                        Buttons = new List<StrategyHudButtonTheme>
+                        {
+                            new StrategyHudButtonTheme
+                            {
+                                Action = StrategyHudAction.SystemFinder,
+                                UpImagePath = "up",
+                                PressedImagePath = "pressed",
+                                PressedImageLayout = new SourceRectLayout
+                                {
+                                    X = 10,
+                                    Y = 20,
+                                    Width = 30,
+                                    Height = 40,
+                                },
+                                HitArea = new SourceRectLayout
+                                {
+                                    X = 10,
+                                    Y = 20,
+                                    Width = 30,
+                                    Height = 40,
+                                },
+                            },
+                        },
+                    },
+                };
+
+                StrategyHudViewData data = controller.CreateViewData(
+                    new StrategyHudRenderData("42", "100", "200", "300", TickSpeed.Medium, null),
+                    theme
+                );
+
+                Assert.AreSame(upTexture, data.Buttons[0].UpTexture);
+                Assert.AreSame(pressedTexture, data.Buttons[0].PressedTexture);
+                Assert.AreEqual(new RectInt(10, 20, 30, 40), data.Buttons[0].ImageBounds);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(upTexture);
+                UnityEngine.Object.DestroyImmediate(pressedTexture);
+            }
+        }
+
+        [Test]
         public void BuildSpeedMenuCommands_DefaultCatalog_ReturnsOrderedEnabledCommands()
         {
             IReadOnlyList<StrategyMenuCommand> commands =

--- a/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyHudViewTests.cs
+++ b/Assets/Tests/EditMode/GameTests/UI/SceneUI/StrategyView/Hud/StrategyHudViewTests.cs
@@ -20,6 +20,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         private Texture2D _pressedTexture;
         private GameObject _rootObject;
         private Texture2D _speedTexture;
+        private Texture2D _upTexture;
         private StrategyHudView _view;
 
         [SetUp]
@@ -32,6 +33,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             _notificationTexture = new Texture2D(24, 24);
             _pressedTexture = new Texture2D(40, 40);
             _speedTexture = new Texture2D(50, 16);
+            _upTexture = new Texture2D(40, 40);
             UIComponentTestHelper.InvokeLifecycle(_view, "Awake");
             Canvas.ForceUpdateCanvases();
         }
@@ -41,6 +43,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
         {
             UnityEngine.Object.DestroyImmediate(_speedTexture);
             UnityEngine.Object.DestroyImmediate(_pressedTexture);
+            UnityEngine.Object.DestroyImmediate(_upTexture);
             UnityEngine.Object.DestroyImmediate(_notificationTexture);
             UnityEngine.Object.DestroyImmediate(_displayTexture);
             UnityEngine.Object.DestroyImmediate(_backgroundTexture);
@@ -84,9 +87,17 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 GetField<RawImage>("galacticInformationDisplayImage").texture
             );
             UIRaycastArea[] buttons = GetField<UIRaycastArea[]>("buttonViews");
+            RawImage[] buttonImages = GetField<RawImage[]>("mainButtonImages");
+            Assert.AreSame(_upTexture, buttonImages[0].texture);
+            Assert.AreSame(_upTexture, buttonImages[1].texture);
+            Assert.AreEqual(
+                new RectInt(30, 410, 40, 40),
+                UILayout.GetSourceRect(buttonImages[0].rectTransform)
+            );
             Assert.AreEqual(new RectInt(20, 400, 30, 30), GetSourceRect(buttons[0]));
             Assert.AreEqual(new RectInt(60, 400, 30, 30), GetSourceRect(buttons[1]));
             Assert.IsFalse(buttons[2].gameObject.activeSelf);
+            Assert.IsFalse(buttonImages[2].gameObject.activeSelf);
             Assert.AreEqual(
                 new RectInt(700, 10, 80, 20),
                 GetSourceRect(GetField<UIRaycastArea>("speedContextView"))
@@ -135,6 +146,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                 GetField<RawImage>("galacticInformationDisplayImage").gameObject.activeSelf
             );
             Assert.IsFalse(GetField<RawImage>("pressedMainButtonImage").gameObject.activeSelf);
+            Assert.IsFalse(GetField<RawImage[]>("mainButtonImages")[0].gameObject.activeSelf);
             Assert.IsFalse(GetField<UIRaycastArea[]>("buttonViews")[0].gameObject.activeSelf);
             Assert.IsFalse(GetField<UIRaycastArea>("speedContextView").gameObject.activeSelf);
             Assert.IsFalse(
@@ -250,6 +262,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
             StrategyHudButtonViewData noneButton = new StrategyHudButtonViewData(
                 StrategyHudAction.None,
                 new RectInt(20, 400, 30, 30),
+                _upTexture,
                 _pressedTexture,
                 new RectInt(30, 410, 40, 40)
             );
@@ -343,6 +356,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
                         new StrategyHudButtonViewData(
                             action,
                             new RectInt(20 + index * 40, 400, 30, 30),
+                            _upTexture,
                             _pressedTexture,
                             new RectInt(30 + index * 40, 410, 40, 40)
                         )


### PR DESCRIPTION
## Summary

- Restoring themed released-state artwork for strategy HUD command buttons
- Applying the shared HUD rendering path to both Alliance and Empire consoles
- Extending the strategy HUD prefab and controller builders with explicit normal-state image slots
- Adding controller and view coverage for released and pressed artwork, placement, and inactive slots

## Validation

- Passing 4,777 Unity EditMode tests with 0 failures
- Passing `bash build.sh lint` with 0 diagnostics
- Passing `bash build.sh format` across 753 files
- Rebuilding the affected strategy UI through `UIBuilderMenu.BuildAll`
- Inspecting the updated HUD in Unity

## Checklist

- [x] Passing relevant automated tests
- [x] Reviewing AI-assisted code
- [x] Verifying affected UI through the UI builder
- [x] Confirming no content path or structure changes are required
- [x] Excluding generated UI prefabs, generated scenes, and copyrighted game assets
- [x] Confirming no documentation changes are required
