### PR TITLE
Applying Blockade and Recovery Rules

### DIFF
--- a/Assets/Scripts/Game/Factions/FactionSettings.cs
+++ b/Assets/Scripts/Game/Factions/FactionSettings.cs
@@ -94,7 +94,7 @@ namespace Rebellion.Game.Factions
         /// </summary>
         public SupportChange SupportResistance { get; set; } = SupportChange.Increase;
 
-        public int PeacefulGarrisonSupportShift { get; set; }
+        public int GarrisonSupportShift { get; set; }
 
         public HeadquartersSettings Headquarters
         {

--- a/Assets/Scripts/Game/Factions/FactionSettings.cs
+++ b/Assets/Scripts/Game/Factions/FactionSettings.cs
@@ -94,6 +94,11 @@ namespace Rebellion.Game.Factions
         /// </summary>
         public SupportChange SupportResistance { get; set; } = SupportChange.Increase;
 
+        /// <summary>
+        /// Periodic popular-support shift caused by this faction's peaceful troop garrisons.
+        /// </summary>
+        public int GarrisonSupportShift { get; set; }
+
         public HeadquartersSettings Headquarters
         {
             get => _headquarters ??= new HeadquartersSettings();

--- a/Assets/Scripts/Game/Factions/FactionSettings.cs
+++ b/Assets/Scripts/Game/Factions/FactionSettings.cs
@@ -94,8 +94,6 @@ namespace Rebellion.Game.Factions
         /// </summary>
         public SupportChange SupportResistance { get; set; } = SupportChange.Increase;
 
-        public int GarrisonSupportShift { get; set; }
-
         public HeadquartersSettings Headquarters
         {
             get => _headquarters ??= new HeadquartersSettings();

--- a/Assets/Scripts/Game/Factions/FactionSettings.cs
+++ b/Assets/Scripts/Game/Factions/FactionSettings.cs
@@ -94,10 +94,7 @@ namespace Rebellion.Game.Factions
         /// </summary>
         public SupportChange SupportResistance { get; set; } = SupportChange.Increase;
 
-        /// <summary>
-        /// Periodic popular-support shift caused by this faction's peaceful troop garrisons.
-        /// </summary>
-        public int GarrisonSupportShift { get; set; }
+        public int PeacefulGarrisonSupportShift { get; set; }
 
         public HeadquartersSettings Headquarters
         {

--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -47,6 +47,7 @@ namespace Rebellion.Game.Galaxy
     public class Planet : ContainerNode
     {
         private const int _maximumPopularSupport = 100;
+        private const int _maximumProductionModifier = 100;
 
         // Planet Properties.
         public bool IsColonized { get; set; }
@@ -79,7 +80,6 @@ namespace Rebellion.Game.Galaxy
         // Periodic Support Status.
         public int NextBlockadeSupportShiftTick { get; set; }
         public int BlockadeSupportShiftIntervalTicks { get; set; }
-        public int NextGarrisonSupportShiftTick { get; set; }
 
         // Popular Support.
         public Dictionary<string, int> PopularSupport = new Dictionary<string, int>();
@@ -160,7 +160,6 @@ namespace Rebellion.Game.Galaxy
             copy.NextUprisingTimerOrder = NextUprisingTimerOrder;
             copy.NextBlockadeSupportShiftTick = NextBlockadeSupportShiftTick;
             copy.BlockadeSupportShiftIntervalTicks = BlockadeSupportShiftIntervalTicks;
-            copy.NextGarrisonSupportShiftTick = NextGarrisonSupportShiftTick;
             copy.PopularSupport = new Dictionary<string, int>(PopularSupport);
             copy._reservedManufacturingTypes = new List<ManufacturingType>(
                 _reservedManufacturingTypes
@@ -816,6 +815,49 @@ namespace Rebellion.Game.Galaxy
             return _buildings
                 .Where(building => building.GetProductionType() == productionType)
                 .ToList();
+        }
+
+        /// <summary>
+        /// Gets the manufacturing output percentage available during a blockade.
+        /// An operational KDY-150 ion cannon prevents the blockade penalty.
+        /// </summary>
+        /// <param name="capitalShipPenalty">The percentage removed per capital ship.</param>
+        /// <param name="fighterPenalty">The percentage removed per fighter squadron.</param>
+        /// <returns>The available manufacturing percentage from zero through one hundred.</returns>
+        public int GetBlockadeProductionModifier(int capitalShipPenalty, int fighterPenalty)
+        {
+            if (!IsBlockaded() || HasOperationalIonCannon())
+                return _maximumProductionModifier;
+
+            List<CapitalShip> capitalShips = _fleets
+                .Where(fleet => fleet.Movement == null)
+                .SelectMany(fleet => fleet.GetChildren<CapitalShip>())
+                .Where(IsEntityActive)
+                .ToList();
+            int fighterCount = capitalShips.Sum(capitalShip =>
+                capitalShip.GetChildren<Starfighter>().Count(IsEntityActive)
+            );
+            fighterCount += GetChildren<Starfighter>().Count(IsEntityActive);
+
+            return Math.Clamp(
+                _maximumProductionModifier
+                    - capitalShips.Count * capitalShipPenalty
+                    - fighterCount * fighterPenalty,
+                0,
+                _maximumProductionModifier
+            );
+        }
+
+        /// <summary>
+        /// Returns whether the planet has a completed, operational KDY-150 ion cannon.
+        /// </summary>
+        public bool HasOperationalIonCannon()
+        {
+            return _buildings.Any(building =>
+                building.BuildingType == BuildingType.Weapon
+                && building.DefenseWeaponEffect == DefenseWeaponEffect.ShieldDamage
+                && IsEntityActive(building)
+            );
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -47,7 +47,6 @@ namespace Rebellion.Game.Galaxy
     public class Planet : ContainerNode
     {
         private const int _maximumPopularSupport = 100;
-        private const int _maximumProductionModifier = 100;
 
         // Planet Properties.
         public bool IsColonized { get; set; }
@@ -196,20 +195,20 @@ namespace Rebellion.Game.Galaxy
 
         /// <summary>
         /// Checks if the planet is blockaded.
-        /// A planet is blockaded only when a stationary hostile fleet has an operational capital
-        /// ship and no equivalent defending fleet is present.
+        /// An owned planet is blockaded when a stationary hostile fleet has an operational
+        /// capital ship and no equivalent defending fleet is present. A neutral planet is
+        /// blockaded by any such fleet in orbit.
         /// </summary>
         /// <returns>True if the planet is blockaded, false otherwise.</returns>
         public bool IsBlockaded()
         {
-            // Neutral planets cannot be blockaded.
-            if (string.IsNullOrEmpty(OwnerInstanceID))
-                return false;
-
             bool hasHostile = GetChildren<Fleet>()
                 .Any(f =>
                     f.Movement == null
-                    && f.OwnerInstanceID != OwnerInstanceID
+                    && (
+                        string.IsNullOrEmpty(OwnerInstanceID)
+                        || f.OwnerInstanceID != OwnerInstanceID
+                    )
                     && f.HasOperationalCapitalShips()
                 );
             bool hasDefender = GetChildren<Fleet>()
@@ -809,47 +808,6 @@ namespace Rebellion.Game.Galaxy
             return _buildings
                 .Where(building => building.GetProductionType() == productionType)
                 .ToList();
-        }
-
-        /// <summary>
-        /// Gets the manufacturing output percentage available during a blockade.
-        /// An active shield-disrupting defense prevents the blockade penalty.
-        /// </summary>
-        /// <param name="capitalShipPenalty">The percentage removed per active capital ship.</param>
-        /// <param name="fighterPenalty">The percentage removed per active fighter squadron.</param>
-        /// <returns>The available manufacturing percentage from zero through one hundred.</returns>
-        public int GetBlockadeModifier(int capitalShipPenalty, int fighterPenalty)
-        {
-            if (!IsBlockaded() || HasActiveShieldDisruptingDefense())
-                return _maximumProductionModifier;
-
-            List<CapitalShip> activeCapitalShips = _fleets
-                .Where(fleet => fleet.Movement == null)
-                .SelectMany(fleet => fleet.GetChildren<CapitalShip>())
-                .Where(IsEntityActive)
-                .ToList();
-            int activeFighterCount = activeCapitalShips.Sum(capitalShip =>
-                capitalShip.GetChildren<Starfighter>().Count(IsEntityActive)
-            );
-
-            int modifier =
-                _maximumProductionModifier
-                - activeCapitalShips.Count * capitalShipPenalty
-                - activeFighterCount * fighterPenalty;
-            return Math.Clamp(modifier, 0, _maximumProductionModifier);
-        }
-
-        /// <summary>
-        /// Returns whether a complete, stationary shield-disrupting defense is active.
-        /// </summary>
-        /// <returns>True when an active shield-disrupting defense is present.</returns>
-        private bool HasActiveShieldDisruptingDefense()
-        {
-            return _buildings.Any(building =>
-                building.BuildingType == BuildingType.Weapon
-                && building.DefenseWeaponEffect == DefenseWeaponEffect.ShieldDamage
-                && IsEntityActive(building)
-            );
         }
 
         /// <summary>

--- a/Assets/Scripts/Game/Galaxy/Planet.cs
+++ b/Assets/Scripts/Game/Galaxy/Planet.cs
@@ -76,6 +76,11 @@ namespace Rebellion.Game.Galaxy
         public int UprisingClearTimerOrder { get; set; }
         public int NextUprisingTimerOrder { get; set; }
 
+        // Periodic Support Status.
+        public int NextBlockadeSupportShiftTick { get; set; }
+        public int BlockadeSupportShiftIntervalTicks { get; set; }
+        public int NextGarrisonSupportShiftTick { get; set; }
+
         // Popular Support.
         public Dictionary<string, int> PopularSupport = new Dictionary<string, int>();
 
@@ -153,6 +158,9 @@ namespace Rebellion.Game.Galaxy
             copy.UprisingIncidentTimerOrder = UprisingIncidentTimerOrder;
             copy.UprisingClearTimerOrder = UprisingClearTimerOrder;
             copy.NextUprisingTimerOrder = NextUprisingTimerOrder;
+            copy.NextBlockadeSupportShiftTick = NextBlockadeSupportShiftTick;
+            copy.BlockadeSupportShiftIntervalTicks = BlockadeSupportShiftIntervalTicks;
+            copy.NextGarrisonSupportShiftTick = NextGarrisonSupportShiftTick;
             copy.PopularSupport = new Dictionary<string, int>(PopularSupport);
             copy._reservedManufacturingTypes = new List<ManufacturingType>(
                 _reservedManufacturingTypes

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -447,6 +447,12 @@ namespace Rebellion.Game
 
             public int BlockadeOpposeShift { get; set; }
 
+            public int BlockadeMatchShiftIntervalTicks { get; set; }
+
+            public int BlockadeOpposeShiftIntervalTicks { get; set; }
+
+            public int ImperialGarrisonSupportShiftIntervalTicks { get; set; }
+
             public int DiplomacyOwnedPlanetSupportBase { get; set; }
 
             public int DiplomacyOwnedPlanetSupportRange { get; set; }

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -451,7 +451,7 @@ namespace Rebellion.Game
 
             public int BlockadeOpposeShiftIntervalTicks { get; set; }
 
-            public int ImperialGarrisonSupportShiftIntervalTicks { get; set; }
+            public int PeacefulGarrisonSupportShiftIntervalTicks { get; set; }
 
             public int DiplomacyOwnedPlanetSupportBase { get; set; }
 

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -610,10 +610,6 @@ namespace Rebellion.Game
         [PersistableObject]
         public class BlockadeConfig
         {
-            public int CapitalShipProductionPenaltyPercent { get; set; }
-
-            public int FighterProductionPenaltyPercent { get; set; }
-
             public int EvacuationLossPercent { get; set; }
         }
 

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -451,7 +451,7 @@ namespace Rebellion.Game
 
             public int BlockadeOpposeShiftIntervalTicks { get; set; }
 
-            public int PeacefulGarrisonSupportShiftIntervalTicks { get; set; }
+            public int GarrisonSupportShiftIntervalTicks { get; set; }
 
             public int DiplomacyOwnedPlanetSupportBase { get; set; }
 

--- a/Assets/Scripts/Game/GameConfig.cs
+++ b/Assets/Scripts/Game/GameConfig.cs
@@ -451,8 +451,6 @@ namespace Rebellion.Game
 
             public int BlockadeOpposeShiftIntervalTicks { get; set; }
 
-            public int GarrisonSupportShiftIntervalTicks { get; set; }
-
             public int DiplomacyOwnedPlanetSupportBase { get; set; }
 
             public int DiplomacyOwnedPlanetSupportRange { get; set; }
@@ -616,6 +614,10 @@ namespace Rebellion.Game
         [PersistableObject]
         public class BlockadeConfig
         {
+            public int CapitalShipProductionPenaltyPercent { get; set; }
+
+            public int FighterProductionPenaltyPercent { get; set; }
+
             public int EvacuationLossPercent { get; set; }
         }
 

--- a/Assets/Scripts/Game/Missions/DiplomacyMission.cs
+++ b/Assets/Scripts/Game/Missions/DiplomacyMission.cs
@@ -149,7 +149,7 @@ namespace Rebellion.Game.Missions
             GameConfig.SupportShiftConfig config = game.Config.SupportShift;
             int supportShift = GetFactionSupportShift(planet, config, provider);
             Faction faction = game.GetFactionByOwnerInstanceID(OwnerInstanceID);
-            supportShift = PlanetaryControlSystem.ApplyCoreWeakSupportPenalty(
+            supportShift = PlanetaryControlSystem.ApplyCoreSupportResistance(
                 planet,
                 faction,
                 supportShift,

--- a/Assets/Scripts/Systems/BlockadeSystem.cs
+++ b/Assets/Scripts/Systems/BlockadeSystem.cs
@@ -59,16 +59,15 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Applies evacuation losses when a unit departs a blockaded planet.
-        /// Only regiments are subject to losses — a friendly fleet at a planet
-        /// breaks the blockade, so fleets never evacuate through one.
+        /// Applies evacuation losses when a unit departs through an opposing blockade.
+        /// Only regiments are currently subject to losses.
         /// </summary>
         /// <param name="unit">The unit attempting to leave.</param>
         /// <param name="originPlanet">The planet the unit is departing from.</param>
         /// <returns>Result describing the loss, or null if the unit survived.</returns>
         public EvacuationLossesResult ApplyEvacuationLosses(IMovable unit, Planet originPlanet)
         {
-            if (!originPlanet.IsBlockaded())
+            if (!originPlanet.IsBlockadedFor(unit.GetOwnerInstanceID()))
                 return null;
 
             if (unit is Regiment regiment && RollEvacuationLoss())

--- a/Assets/Scripts/Systems/BlockadeSystem.cs
+++ b/Assets/Scripts/Systems/BlockadeSystem.cs
@@ -67,7 +67,10 @@ namespace Rebellion.Systems
         /// <returns>Result describing the loss, or null if the unit survived.</returns>
         public EvacuationLossesResult ApplyEvacuationLosses(IMovable unit, Planet originPlanet)
         {
-            if (!originPlanet.IsBlockadedFor(unit.GetOwnerInstanceID()))
+            if (
+                !originPlanet.IsBlockadedFor(unit.GetOwnerInstanceID())
+                || HasOperationalIonCannon(originPlanet, unit.GetOwnerInstanceID())
+            )
                 return null;
 
             if (unit is Regiment regiment && RollEvacuationLoss())
@@ -89,6 +92,22 @@ namespace Rebellion.Systems
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns whether the departing faction has an operational ion cannon protecting the system.
+        /// </summary>
+        private static bool HasOperationalIonCannon(Planet planet, string ownerInstanceId)
+        {
+            return planet
+                .GetChildren<Building>()
+                .Any(building =>
+                    building.OwnerInstanceID == ownerInstanceId
+                    && building.IsActive()
+                    && building.ManufacturingStatus == ManufacturingStatus.Complete
+                    && building.BuildingType == BuildingType.Weapon
+                    && building.DefenseWeaponEffect == DefenseWeaponEffect.ShieldDamage
+                );
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/BlockadeSystem.cs
+++ b/Assets/Scripts/Systems/BlockadeSystem.cs
@@ -69,7 +69,7 @@ namespace Rebellion.Systems
         {
             if (
                 !originPlanet.IsBlockadedFor(unit.GetOwnerInstanceID())
-                || HasOperationalIonCannon(originPlanet, unit.GetOwnerInstanceID())
+                || originPlanet.HasOperationalIonCannon()
             )
                 return null;
 
@@ -92,22 +92,6 @@ namespace Rebellion.Systems
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Returns whether the departing faction has an operational ion cannon protecting the system.
-        /// </summary>
-        private static bool HasOperationalIonCannon(Planet planet, string ownerInstanceId)
-        {
-            return planet
-                .GetChildren<Building>()
-                .Any(building =>
-                    building.OwnerInstanceID == ownerInstanceId
-                    && building.IsActive()
-                    && building.ManufacturingStatus == ManufacturingStatus.Complete
-                    && building.BuildingType == BuildingType.Weapon
-                    && building.DefenseWeaponEffect == DefenseWeaponEffect.ShieldDamage
-                );
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/BombardmentSystem.cs
+++ b/Assets/Scripts/Systems/BombardmentSystem.cs
@@ -1008,7 +1008,7 @@ namespace Rebellion.Systems
         )
         {
             int shift = _game.Config.Combat.Bombardment.CivilianSupportPenalty;
-            shift = PlanetaryControlSystem.ApplyCoreWeakSupportPenalty(
+            shift = PlanetaryControlSystem.ApplyCoreSupportResistance(
                 planet,
                 attacker,
                 shift,

--- a/Assets/Scripts/Systems/FactionAutomationSystem.cs
+++ b/Assets/Scripts/Systems/FactionAutomationSystem.cs
@@ -157,7 +157,22 @@ namespace Rebellion.Systems
                     out Planet destination
                 )
             )
-                return false;
+            {
+                nextType =
+                    nextType == BuildingType.Mine ? BuildingType.Refinery : BuildingType.Mine;
+                if (
+                    !HasActiveBuildingProject(ownedPlanets, nextType)
+                    || !TryFindResourceFacilityOrder(
+                        ownedPlanets,
+                        nextType,
+                        out producer,
+                        out destination
+                    )
+                )
+                {
+                    return false;
+                }
+            }
 
             Building template = GetAvailableBuilding(faction, nextType);
             return template != null
@@ -287,6 +302,7 @@ namespace Rebellion.Systems
                 .Where(planet =>
                     !planet.IsManufacturingReserved(ManufacturingType.Building)
                     && planet.GetAvailableManufacturingCapacity(ManufacturingType.Building) > 0
+                    && IsCompatibleBuildingProject(planet, buildingType)
                 )
                 .ToList();
             IEnumerable<Planet> destinations = planets.Where(planet =>
@@ -313,6 +329,49 @@ namespace Rebellion.Systems
             producer = order?.Producer;
             destination = order?.Destination;
             return producer != null && destination != null;
+        }
+
+        /// <summary>
+        /// Returns whether any available construction lane is already committed to a building type.
+        /// </summary>
+        /// <param name="planets">The faction's candidate producer planets.</param>
+        /// <param name="buildingType">The building project to locate.</param>
+        /// <returns>True when an active lane can accept another copy without replacement.</returns>
+        private static bool HasActiveBuildingProject(
+            IEnumerable<Planet> planets,
+            BuildingType buildingType
+        )
+        {
+            return planets.Any(planet =>
+                planet.GetAvailableManufacturingCapacity(ManufacturingType.Building) > 0
+                && planet
+                    .GetManufacturingQueue()
+                    .TryGetValue(ManufacturingType.Building, out List<IManufacturable> queue)
+                && queue?.OfType<Building>().Any(building => building.BuildingType == buildingType)
+                    == true
+            );
+        }
+
+        /// <summary>
+        /// Returns whether a construction lane is idle or already producing the requested project.
+        /// </summary>
+        /// <param name="producer">The planet containing the construction lane.</param>
+        /// <param name="buildingType">The requested building project.</param>
+        /// <returns>True when adding the project would not replace active automated work.</returns>
+        private static bool IsCompatibleBuildingProject(Planet producer, BuildingType buildingType)
+        {
+            if (
+                !producer
+                    .GetManufacturingQueue()
+                    .TryGetValue(ManufacturingType.Building, out List<IManufacturable> queue)
+                || queue == null
+                || queue.Count == 0
+            )
+            {
+                return true;
+            }
+
+            return queue.OfType<Building>().All(building => building.BuildingType == buildingType);
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/ManufacturingSystem.cs
+++ b/Assets/Scripts/Systems/ManufacturingSystem.cs
@@ -140,6 +140,8 @@ namespace Rebellion.Systems
             if (!CanStartManufacturing(producer, template, destination, count, ownerInstanceId))
                 return false;
 
+            ReplaceDifferentProject(producer, template);
+
             bool started = false;
             Fleet capitalShipDestination = null;
             Planet destinationPlanet = destination as Planet;
@@ -274,7 +276,60 @@ namespace Rebellion.Systems
                 return false;
 
             Faction faction = _game.GetFactionByOwnerInstanceID(ownerInstanceId);
-            return HasMaintenanceHeadroom(faction, template, count);
+            return HasMaintenanceHeadroom(
+                faction,
+                template,
+                count,
+                GetReleasedMaintenanceForReplacement(producer, template)
+            );
+        }
+
+        /// <summary>
+        /// Returns maintenance reserved by the active lane when the requested template would replace it.
+        /// </summary>
+        private static int GetReleasedMaintenanceForReplacement(
+            Planet producer,
+            IManufacturable template
+        )
+        {
+            if (
+                producer
+                    ?.GetManufacturingQueue()
+                    .TryGetValue(
+                        template.GetManufacturingType(),
+                        out List<IManufacturable> activeProject
+                    ) != true
+                || activeProject == null
+                || activeProject.Count == 0
+                || activeProject.All(item => item.GetTypeID() == template.GetTypeID())
+            )
+            {
+                return 0;
+            }
+
+            return activeProject.Sum(item => Math.Max(0, item.GetMaintenanceCost()));
+        }
+
+        /// <summary>
+        /// Cancels the active project in a production lane when a different unit type is ordered.
+        /// </summary>
+        private void ReplaceDifferentProject(Planet producer, IManufacturable template)
+        {
+            ManufacturingType type = template.GetManufacturingType();
+            if (
+                producer
+                    .GetManufacturingQueue()
+                    .TryGetValue(type, out List<IManufacturable> activeProject) != true
+                || activeProject == null
+                || activeProject.Count == 0
+                || activeProject.All(item => item.GetTypeID() == template.GetTypeID())
+            )
+            {
+                return;
+            }
+
+            ClearQueueItems(producer, activeProject);
+            producer.GetManufacturingQueue().Remove(type);
         }
 
         /// <summary>
@@ -879,8 +934,14 @@ namespace Rebellion.Systems
         /// <param name="faction">The faction committing the order.</param>
         /// <param name="item">The item template being manufactured.</param>
         /// <param name="count">The number of copies to queue.</param>
+        /// <param name="releasedMaintenance">Maintenance released by a replaced project.</param>
         /// <returns>True when the complete order remains within maintenance capacity.</returns>
-        private bool HasMaintenanceHeadroom(Faction faction, IManufacturable item, int count)
+        private bool HasMaintenanceHeadroom(
+            Faction faction,
+            IManufacturable item,
+            int count,
+            int releasedMaintenance = 0
+        )
         {
             if (faction == null)
                 return false;
@@ -889,7 +950,10 @@ namespace Rebellion.Systems
             if (maintenanceCost <= 0)
                 return true;
 
-            return faction.ProjectedMaintenanceHeadroom - maintenanceCost * count >= 0;
+            return faction.ProjectedMaintenanceHeadroom
+                    + releasedMaintenance
+                    - maintenanceCost * count
+                >= 0;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/ManufacturingSystem.cs
+++ b/Assets/Scripts/Systems/ManufacturingSystem.cs
@@ -142,7 +142,7 @@ namespace Rebellion.Systems
             if (!CanStartManufacturing(producer, template, destination, count, ownerInstanceId))
                 return false;
 
-            ReplaceDifferentProject(producer, template);
+            CancelConflictingProject(producer, template);
 
             bool started = false;
             Fleet capitalShipDestination = null;
@@ -312,7 +312,7 @@ namespace Rebellion.Systems
         /// <summary>
         /// Cancels the active project in a production lane when a different unit type is ordered.
         /// </summary>
-        private void ReplaceDifferentProject(Planet producer, IManufacturable template)
+        private void CancelConflictingProject(Planet producer, IManufacturable template)
         {
             ManufacturingType type = template.GetManufacturingType();
             if (

--- a/Assets/Scripts/Systems/ManufacturingSystem.cs
+++ b/Assets/Scripts/Systems/ManufacturingSystem.cs
@@ -280,17 +280,14 @@ namespace Rebellion.Systems
                 faction,
                 template,
                 count,
-                GetReleasedMaintenanceForReplacement(producer, template)
+                GetMaintenanceRefund(producer, template)
             );
         }
 
         /// <summary>
         /// Returns maintenance reserved by the active lane when the requested template would replace it.
         /// </summary>
-        private static int GetReleasedMaintenanceForReplacement(
-            Planet producer,
-            IManufacturable template
-        )
+        private static int GetMaintenanceRefund(Planet producer, IManufacturable template)
         {
             if (
                 producer

--- a/Assets/Scripts/Systems/ManufacturingSystem.cs
+++ b/Assets/Scripts/Systems/ManufacturingSystem.cs
@@ -20,6 +20,8 @@ namespace Rebellion.Systems
             IGameResultHandler<BombardmentResult>,
             IGameResultHandler<PlanetaryAssaultResult>
     {
+        private const int _productionRateScale = 100;
+
         private readonly GameRoot _game;
         private readonly MovementSystem _movementSystem;
         private readonly FleetSystem _fleetSystem;
@@ -1163,10 +1165,15 @@ namespace Rebellion.Systems
         /// <returns>The progress available after uprising and blockade effects.</returns>
         private double GetProductionCycleIncrement(Planet planet)
         {
-            if (planet.IsInUprising || planet.IsBlockaded())
+            if (planet.IsInUprising)
                 return 0;
 
-            return 1;
+            GameConfig.BlockadeConfig config = _game.Config.Blockade;
+            int modifier = planet.GetBlockadeProductionModifier(
+                config.CapitalShipProductionPenaltyPercent,
+                config.FighterProductionPenaltyPercent
+            );
+            return (double)modifier / _productionRateScale;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/ManufacturingSystem.cs
+++ b/Assets/Scripts/Systems/ManufacturingSystem.cs
@@ -20,8 +20,6 @@ namespace Rebellion.Systems
             IGameResultHandler<BombardmentResult>,
             IGameResultHandler<PlanetaryAssaultResult>
     {
-        private const int _productionRateScale = 100;
-
         private readonly GameRoot _game;
         private readonly MovementSystem _movementSystem;
         private readonly FleetSystem _fleetSystem;
@@ -1104,15 +1102,10 @@ namespace Rebellion.Systems
         /// <returns>The progress available after uprising and blockade effects.</returns>
         private double GetProductionCycleIncrement(Planet planet)
         {
-            if (planet.IsInUprising)
+            if (planet.IsInUprising || planet.IsBlockaded())
                 return 0;
 
-            GameConfig.BlockadeConfig config = _game.Config.Blockade;
-            int modifier = planet.GetBlockadeModifier(
-                config.CapitalShipProductionPenaltyPercent,
-                config.FighterProductionPenaltyPercent
-            );
-            return (double)modifier / _productionRateScale;
+            return 1;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -61,7 +61,7 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Applies the original timed blockade and Imperial-garrison support rules.
+        /// Applies the original timed blockade support rule.
         /// </summary>
         private void ApplySupportShifts()
         {
@@ -69,7 +69,6 @@ namespace Rebellion.Systems
             foreach (Planet planet in _game.GetSceneNodesByType<Planet>())
             {
                 ApplyBlockadeSupportShift(planet, config);
-                ApplyGarrisonSupportShift(planet, config);
             }
         }
 
@@ -85,13 +84,12 @@ namespace Rebellion.Systems
             }
 
             Faction blockadingFaction = GetBlockadingFaction(planet);
-            if (
-                blockadingFaction == null
-                || !TryGetSupportLeader(planet, out Faction supportLeader)
-            )
+            if (blockadingFaction == null)
                 return;
 
-            bool blockadeSupportsFavoredFaction = blockadingFaction == supportLeader;
+            bool blockadeSupportsFavoredFaction =
+                TryGetSupportLeader(planet, out Faction supportLeader)
+                && blockadingFaction == supportLeader;
             int interval = GetBlockadeSupportShiftInterval(config, blockadeSupportsFavoredFaction);
             if (interval <= 0)
                 return;
@@ -111,6 +109,12 @@ namespace Rebellion.Systems
             int shift = blockadeSupportsFavoredFaction
                 ? config.BlockadeMatchShift
                 : config.BlockadeOpposeShift;
+            shift = ApplyCoreWeakSupportPenalty(
+                planet,
+                blockadingFaction,
+                shift,
+                config.WeakSupportPenaltyDivisor
+            );
             ShiftPopularSupport(planet, blockadingFaction, shift);
             ScheduleNextBlockadeSupportShift(planet, interval);
         }
@@ -183,74 +187,6 @@ namespace Rebellion.Systems
         {
             planet.NextBlockadeSupportShiftTick = _game.CurrentTick + interval;
             planet.BlockadeSupportShiftIntervalTicks = interval;
-        }
-
-        /// <summary>
-        /// Applies the configured troop-presence drift on controlled, peaceful planets.
-        /// </summary>
-        private void ApplyGarrisonSupportShift(Planet planet, GameConfig.SupportShiftConfig config)
-        {
-            Faction garrisonFaction = GetFactionWithGarrisonSupportShift();
-            if (!CanApplyGarrisonSupportShift(planet, garrisonFaction))
-            {
-                planet.NextGarrisonSupportShiftTick = 0;
-                return;
-            }
-
-            int interval = config.GarrisonSupportShiftIntervalTicks;
-            if (interval <= 0)
-                return;
-
-            if (planet.NextGarrisonSupportShiftTick <= 0)
-            {
-                ScheduleNextGarrisonSupportShift(planet, interval);
-                return;
-            }
-
-            if (_game.CurrentTick < planet.NextGarrisonSupportShiftTick)
-                return;
-
-            ShiftPopularSupport(
-                planet,
-                garrisonFaction,
-                garrisonFaction.Settings.GarrisonSupportShift
-            );
-            ScheduleNextGarrisonSupportShift(planet, interval);
-        }
-
-        /// <summary>
-        /// Returns the faction configured to alter support through troop garrisons.
-        /// </summary>
-        private Faction GetFactionWithGarrisonSupportShift()
-        {
-            return _game
-                .GetFactions()
-                .FirstOrDefault(faction => faction.Settings?.GarrisonSupportShift != 0);
-        }
-
-        /// <summary>
-        /// Returns whether a planet has the controlled, stationary garrison required for a shift.
-        /// </summary>
-        private static bool CanApplyGarrisonSupportShift(Planet planet, Faction faction)
-        {
-            return faction != null
-                && planet.OwnerInstanceID == faction.InstanceID
-                && !planet.IsInUprising
-                && planet
-                    .GetAllRegiments()
-                    .Any(regiment =>
-                        regiment.OwnerInstanceID == faction.InstanceID
-                        && regiment.ManufacturingStatus == ManufacturingStatus.Complete
-                        && regiment.Movement == null
-                    );
-        }
-
-        /// <summary>
-        /// Schedules the planet's next garrison support shift.
-        /// </summary>
-        private void ScheduleNextGarrisonSupportShift(Planet planet, int interval)
-        {
-            planet.NextGarrisonSupportShiftTick = _game.CurrentTick + interval;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -80,48 +80,19 @@ namespace Rebellion.Systems
         {
             if (!planet.IsBlockaded())
             {
-                planet.NextBlockadeSupportShiftTick = 0;
-                planet.BlockadeSupportShiftIntervalTicks = 0;
+                ResetBlockadeSupportShiftSchedule(planet);
                 return;
             }
 
-            Fleet blockadingFleet = planet
-                .GetChildren<Fleet>()
-                .FirstOrDefault(fleet =>
-                    fleet.Movement == null
-                    && fleet.HasOperationalCapitalShips()
-                    && fleet.OwnerInstanceID != planet.OwnerInstanceID
-                );
-            Faction fleetFaction = _game.GetFactionByOwnerInstanceID(
-                blockadingFleet?.OwnerInstanceID
-            );
-            if (fleetFaction == null)
-                return;
-
-            Faction favoredFaction = _game
-                .GetFactions()
-                .OrderByDescending(faction => planet.GetPopularSupport(faction.InstanceID))
-                .FirstOrDefault();
-            if (favoredFaction == null)
-                return;
-
-            int favoredSupport = planet.GetPopularSupport(favoredFaction.InstanceID);
+            Faction blockadingFaction = GetBlockadingFaction(planet);
             if (
-                _game
-                    .GetFactions()
-                    .Any(faction =>
-                        faction.InstanceID != favoredFaction.InstanceID
-                        && planet.GetPopularSupport(faction.InstanceID) == favoredSupport
-                    )
+                blockadingFaction == null
+                || !TryGetSupportLeader(planet, out Faction supportLeader)
             )
-            {
                 return;
-            }
 
-            bool fleetMatchesSupport = fleetFaction.InstanceID == favoredFaction.InstanceID;
-            int interval = fleetMatchesSupport
-                ? config.BlockadeMatchShiftIntervalTicks
-                : config.BlockadeOpposeShiftIntervalTicks;
+            bool blockadeSupportsFavoredFaction = blockadingFaction == supportLeader;
+            int interval = GetBlockadeSupportShiftInterval(config, blockadeSupportsFavoredFaction);
             if (interval <= 0)
                 return;
 
@@ -130,19 +101,88 @@ namespace Rebellion.Systems
                 || planet.BlockadeSupportShiftIntervalTicks != interval
             )
             {
-                planet.NextBlockadeSupportShiftTick = _game.CurrentTick + interval;
-                planet.BlockadeSupportShiftIntervalTicks = interval;
+                ScheduleNextBlockadeSupportShift(planet, interval);
                 return;
             }
 
             if (_game.CurrentTick < planet.NextBlockadeSupportShiftTick)
                 return;
 
-            int shift = fleetMatchesSupport
+            int shift = blockadeSupportsFavoredFaction
                 ? config.BlockadeMatchShift
                 : config.BlockadeOpposeShift;
-            ShiftPopularSupport(planet, fleetFaction, shift);
+            ShiftPopularSupport(planet, blockadingFaction, shift);
+            ScheduleNextBlockadeSupportShift(planet, interval);
+        }
+
+        /// <summary>
+        /// Returns the faction operating the fleet that currently blockades a planet.
+        /// </summary>
+        private Faction GetBlockadingFaction(Planet planet)
+        {
+            Fleet blockadingFleet = planet
+                .GetChildren<Fleet>()
+                .FirstOrDefault(fleet =>
+                    fleet.Movement == null
+                    && fleet.HasOperationalCapitalShips()
+                    && fleet.OwnerInstanceID != planet.OwnerInstanceID
+                );
+            return _game.GetFactionByOwnerInstanceID(blockadingFleet?.OwnerInstanceID);
+        }
+
+        /// <summary>
+        /// Finds the faction with strictly more popular support than every other faction.
+        /// </summary>
+        private bool TryGetSupportLeader(Planet planet, out Faction supportLeader)
+        {
+            List<Faction> factions = _game.GetFactions();
+            Faction candidate = factions
+                .OrderByDescending(faction => planet.GetPopularSupport(faction.InstanceID))
+                .FirstOrDefault();
+            if (candidate == null)
+            {
+                supportLeader = null;
+                return false;
+            }
+
+            int leadingSupport = planet.GetPopularSupport(candidate.InstanceID);
+            bool supportIsTied = factions.Any(faction =>
+                faction != candidate
+                && planet.GetPopularSupport(faction.InstanceID) == leadingSupport
+            );
+            supportLeader = supportIsTied ? null : candidate;
+            return supportLeader != null;
+        }
+
+        /// <summary>
+        /// Returns the blockade shift interval for the planet's current support alignment.
+        /// </summary>
+        private static int GetBlockadeSupportShiftInterval(
+            GameConfig.SupportShiftConfig config,
+            bool blockadeSupportsFavoredFaction
+        )
+        {
+            return blockadeSupportsFavoredFaction
+                ? config.BlockadeMatchShiftIntervalTicks
+                : config.BlockadeOpposeShiftIntervalTicks;
+        }
+
+        /// <summary>
+        /// Clears a planet's blockade support-shift schedule.
+        /// </summary>
+        private static void ResetBlockadeSupportShiftSchedule(Planet planet)
+        {
+            planet.NextBlockadeSupportShiftTick = 0;
+            planet.BlockadeSupportShiftIntervalTicks = 0;
+        }
+
+        /// <summary>
+        /// Schedules the planet's next blockade support shift.
+        /// </summary>
+        private void ScheduleNextBlockadeSupportShift(Planet planet, int interval)
+        {
             planet.NextBlockadeSupportShiftTick = _game.CurrentTick + interval;
+            planet.BlockadeSupportShiftIntervalTicks = interval;
         }
 
         /// <summary>
@@ -150,21 +190,8 @@ namespace Rebellion.Systems
         /// </summary>
         private void ApplyGarrisonSupportShift(Planet planet, GameConfig.SupportShiftConfig config)
         {
-            Faction garrisonFaction = _game
-                .GetFactions()
-                .FirstOrDefault(faction => faction.Settings?.GarrisonSupportShift != 0);
-            if (
-                garrisonFaction == null
-                || planet.OwnerInstanceID != garrisonFaction.InstanceID
-                || planet.IsInUprising
-                || !planet
-                    .GetAllRegiments()
-                    .Any(regiment =>
-                        regiment.OwnerInstanceID == garrisonFaction.InstanceID
-                        && regiment.ManufacturingStatus == ManufacturingStatus.Complete
-                        && regiment.Movement == null
-                    )
-            )
+            Faction garrisonFaction = GetFactionWithGarrisonSupportShift();
+            if (!CanApplyGarrisonSupportShift(planet, garrisonFaction))
             {
                 planet.NextGarrisonSupportShiftTick = 0;
                 return;
@@ -176,7 +203,7 @@ namespace Rebellion.Systems
 
             if (planet.NextGarrisonSupportShiftTick <= 0)
             {
-                planet.NextGarrisonSupportShiftTick = _game.CurrentTick + interval;
+                ScheduleNextGarrisonSupportShift(planet, interval);
                 return;
             }
 
@@ -188,6 +215,41 @@ namespace Rebellion.Systems
                 garrisonFaction,
                 garrisonFaction.Settings.GarrisonSupportShift
             );
+            ScheduleNextGarrisonSupportShift(planet, interval);
+        }
+
+        /// <summary>
+        /// Returns the faction configured to alter support through troop garrisons.
+        /// </summary>
+        private Faction GetFactionWithGarrisonSupportShift()
+        {
+            return _game
+                .GetFactions()
+                .FirstOrDefault(faction => faction.Settings?.GarrisonSupportShift != 0);
+        }
+
+        /// <summary>
+        /// Returns whether a planet has the controlled, stationary garrison required for a shift.
+        /// </summary>
+        private static bool CanApplyGarrisonSupportShift(Planet planet, Faction faction)
+        {
+            return faction != null
+                && planet.OwnerInstanceID == faction.InstanceID
+                && !planet.IsInUprising
+                && planet
+                    .GetAllRegiments()
+                    .Any(regiment =>
+                        regiment.OwnerInstanceID == faction.InstanceID
+                        && regiment.ManufacturingStatus == ManufacturingStatus.Complete
+                        && regiment.Movement == null
+                    );
+        }
+
+        /// <summary>
+        /// Schedules the planet's next garrison support shift.
+        /// </summary>
+        private void ScheduleNextGarrisonSupportShift(Planet planet, int interval)
+        {
             planet.NextGarrisonSupportShiftTick = _game.CurrentTick + interval;
         }
 

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -53,10 +53,145 @@ namespace Rebellion.Systems
         public List<GameResult> ProcessTick()
         {
             List<GameResult> results = new List<GameResult>();
+            ApplyPeriodicSupportShifts();
             UpdateUncolonizedPlanets(results);
             CheckOwnershipTransfers(results);
 
             return results;
+        }
+
+        /// <summary>
+        /// Applies the original timed blockade and Imperial-garrison support rules.
+        /// </summary>
+        private void ApplyPeriodicSupportShifts()
+        {
+            GameConfig.SupportShiftConfig config = _game.Config.SupportShift;
+            foreach (Planet planet in _game.GetSceneNodesByType<Planet>())
+            {
+                ApplyBlockadeSupportShift(planet, config);
+                ApplyImperialGarrisonSupportShift(planet, config);
+            }
+        }
+
+        /// <summary>
+        /// Moves support toward the side already favored while a fleet blockades the planet.
+        /// </summary>
+        private void ApplyBlockadeSupportShift(Planet planet, GameConfig.SupportShiftConfig config)
+        {
+            if (!planet.IsBlockaded())
+            {
+                planet.NextBlockadeSupportShiftTick = 0;
+                planet.BlockadeSupportShiftIntervalTicks = 0;
+                return;
+            }
+
+            Fleet blockadingFleet = planet
+                .GetChildren<Fleet>()
+                .FirstOrDefault(fleet =>
+                    fleet.Movement == null
+                    && fleet.HasOperationalCapitalShips()
+                    && fleet.OwnerInstanceID != planet.OwnerInstanceID
+                );
+            Faction fleetFaction = _game.GetFactionByOwnerInstanceID(
+                blockadingFleet?.OwnerInstanceID
+            );
+            if (fleetFaction == null)
+                return;
+
+            Faction favoredFaction = _game
+                .GetFactions()
+                .OrderByDescending(faction => planet.GetPopularSupport(faction.InstanceID))
+                .FirstOrDefault();
+            if (favoredFaction == null)
+                return;
+
+            int favoredSupport = planet.GetPopularSupport(favoredFaction.InstanceID);
+            if (
+                _game
+                    .GetFactions()
+                    .Any(faction =>
+                        faction.InstanceID != favoredFaction.InstanceID
+                        && planet.GetPopularSupport(faction.InstanceID) == favoredSupport
+                    )
+            )
+            {
+                return;
+            }
+
+            bool fleetMatchesSupport = fleetFaction.InstanceID == favoredFaction.InstanceID;
+            int interval = fleetMatchesSupport
+                ? config.BlockadeMatchShiftIntervalTicks
+                : config.BlockadeOpposeShiftIntervalTicks;
+            if (interval <= 0)
+                return;
+
+            if (
+                planet.NextBlockadeSupportShiftTick <= 0
+                || planet.BlockadeSupportShiftIntervalTicks != interval
+            )
+            {
+                planet.NextBlockadeSupportShiftTick = _game.CurrentTick + interval;
+                planet.BlockadeSupportShiftIntervalTicks = interval;
+                return;
+            }
+
+            if (_game.CurrentTick < planet.NextBlockadeSupportShiftTick)
+                return;
+
+            int shift = fleetMatchesSupport
+                ? config.BlockadeMatchShift
+                : config.BlockadeOpposeShift;
+            ShiftPopularSupport(planet, fleetFaction, shift);
+            planet.NextBlockadeSupportShiftTick = _game.CurrentTick + interval;
+        }
+
+        /// <summary>
+        /// Applies the configured Imperial troop-presence drift on controlled, peaceful planets.
+        /// </summary>
+        private void ApplyImperialGarrisonSupportShift(
+            Planet planet,
+            GameConfig.SupportShiftConfig config
+        )
+        {
+            Faction garrisonFaction = _game
+                .GetFactions()
+                .FirstOrDefault(faction => faction.Settings?.GarrisonSupportShift != 0);
+            if (
+                garrisonFaction == null
+                || planet.OwnerInstanceID != garrisonFaction.InstanceID
+                || planet.IsInUprising
+                || !planet
+                    .GetAllRegiments()
+                    .Any(regiment =>
+                        regiment.OwnerInstanceID == garrisonFaction.InstanceID
+                        && regiment.ManufacturingStatus == ManufacturingStatus.Complete
+                        && regiment.Movement == null
+                    )
+            )
+            {
+                planet.NextGarrisonSupportShiftTick = 0;
+                return;
+            }
+
+            int interval = config.ImperialGarrisonSupportShiftIntervalTicks;
+            if (interval <= 0)
+                return;
+
+            if (planet.NextGarrisonSupportShiftTick <= 0)
+            {
+                planet.NextGarrisonSupportShiftTick = _game.CurrentTick + interval;
+                return;
+            }
+
+            if (_game.CurrentTick < planet.NextGarrisonSupportShiftTick)
+                return;
+
+            ShiftPopularSupport(
+                planet,
+                garrisonFaction,
+                garrisonFaction.Settings.GarrisonSupportShift
+            );
+            planet.NextGarrisonSupportShiftTick = _game.CurrentTick + interval;
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -53,7 +53,7 @@ namespace Rebellion.Systems
         public List<GameResult> ProcessTick()
         {
             List<GameResult> results = new List<GameResult>();
-            ApplySupportShifts();
+            UpdateBlockadeSupport();
             UpdateUncolonizedPlanets(results);
             CheckOwnershipTransfers(results);
 
@@ -63,34 +63,34 @@ namespace Rebellion.Systems
         /// <summary>
         /// Applies the original timed blockade support rule.
         /// </summary>
-        private void ApplySupportShifts()
+        private void UpdateBlockadeSupport()
         {
             GameConfig.SupportShiftConfig config = _game.Config.SupportShift;
             foreach (Planet planet in _game.GetSceneNodesByType<Planet>())
             {
-                ApplyBlockadeSupportShift(planet, config);
+                UpdateBlockadeSupport(planet, config);
             }
         }
 
         /// <summary>
         /// Moves support toward the side already favored while a fleet blockades the planet.
         /// </summary>
-        private void ApplyBlockadeSupportShift(Planet planet, GameConfig.SupportShiftConfig config)
+        private void UpdateBlockadeSupport(Planet planet, GameConfig.SupportShiftConfig config)
         {
             if (!planet.IsBlockaded())
             {
-                ResetBlockadeSupportShiftSchedule(planet);
+                ResetBlockadeSupportTimer(planet);
                 return;
             }
 
-            Faction blockadingFaction = GetBlockadingFaction(planet);
+            Faction blockadingFaction = FindBlockadingFaction(planet);
             if (blockadingFaction == null)
                 return;
 
             bool blockadeSupportsFavoredFaction =
-                TryGetSupportLeader(planet, out Faction supportLeader)
+                TryGetFavoredFaction(planet, out Faction supportLeader)
                 && blockadingFaction == supportLeader;
-            int interval = GetBlockadeSupportShiftInterval(config, blockadeSupportsFavoredFaction);
+            int interval = GetBlockadeSupportInterval(config, blockadeSupportsFavoredFaction);
             if (interval <= 0)
                 return;
 
@@ -99,7 +99,7 @@ namespace Rebellion.Systems
                 || planet.BlockadeSupportShiftIntervalTicks != interval
             )
             {
-                ScheduleNextBlockadeSupportShift(planet, interval);
+                ScheduleBlockadeSupport(planet, interval);
                 return;
             }
 
@@ -109,20 +109,20 @@ namespace Rebellion.Systems
             int shift = blockadeSupportsFavoredFaction
                 ? config.BlockadeMatchShift
                 : config.BlockadeOpposeShift;
-            shift = ApplyCoreWeakSupportPenalty(
+            shift = ApplyCoreSupportResistance(
                 planet,
                 blockadingFaction,
                 shift,
                 config.WeakSupportPenaltyDivisor
             );
             ShiftPopularSupport(planet, blockadingFaction, shift);
-            ScheduleNextBlockadeSupportShift(planet, interval);
+            ScheduleBlockadeSupport(planet, interval);
         }
 
         /// <summary>
         /// Returns the faction operating the fleet that currently blockades a planet.
         /// </summary>
-        private Faction GetBlockadingFaction(Planet planet)
+        private Faction FindBlockadingFaction(Planet planet)
         {
             Fleet blockadingFleet = planet
                 .GetChildren<Fleet>()
@@ -137,7 +137,7 @@ namespace Rebellion.Systems
         /// <summary>
         /// Finds the faction with strictly more popular support than every other faction.
         /// </summary>
-        private bool TryGetSupportLeader(Planet planet, out Faction supportLeader)
+        private bool TryGetFavoredFaction(Planet planet, out Faction supportLeader)
         {
             List<Faction> factions = _game.GetFactions();
             Faction candidate = factions
@@ -161,7 +161,7 @@ namespace Rebellion.Systems
         /// <summary>
         /// Returns the blockade shift interval for the planet's current support alignment.
         /// </summary>
-        private static int GetBlockadeSupportShiftInterval(
+        private static int GetBlockadeSupportInterval(
             GameConfig.SupportShiftConfig config,
             bool blockadeSupportsFavoredFaction
         )
@@ -174,7 +174,7 @@ namespace Rebellion.Systems
         /// <summary>
         /// Clears a planet's blockade support-shift schedule.
         /// </summary>
-        private static void ResetBlockadeSupportShiftSchedule(Planet planet)
+        private static void ResetBlockadeSupportTimer(Planet planet)
         {
             planet.NextBlockadeSupportShiftTick = 0;
             planet.BlockadeSupportShiftIntervalTicks = 0;
@@ -183,7 +183,7 @@ namespace Rebellion.Systems
         /// <summary>
         /// Schedules the planet's next blockade support shift.
         /// </summary>
-        private void ScheduleNextBlockadeSupportShift(Planet planet, int interval)
+        private void ScheduleBlockadeSupport(Planet planet, int interval)
         {
             planet.NextBlockadeSupportShiftTick = _game.CurrentTick + interval;
             planet.BlockadeSupportShiftIntervalTicks = interval;
@@ -484,7 +484,7 @@ namespace Rebellion.Systems
         /// <param name="shift">The unadjusted signed support shift.</param>
         /// <param name="divisor">The configured weak-support divisor.</param>
         /// <returns>The support shift after any core-sector reduction.</returns>
-        internal static int ApplyCoreWeakSupportPenalty(
+        internal static int ApplyCoreSupportResistance(
             Planet planet,
             Faction faction,
             int shift,

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -61,7 +61,7 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Applies the original timed blockade support rule.
+        /// Updates timed popular-support changes caused by blockades.
         /// </summary>
         private void UpdateBlockadeSupport()
         {

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -83,7 +83,7 @@ namespace Rebellion.Systems
                 return;
             }
 
-            Faction blockadingFaction = FindBlockadingFaction(planet);
+            Faction blockadingFaction = GetBlockadingFaction(planet);
             if (blockadingFaction == null)
                 return;
 
@@ -122,7 +122,7 @@ namespace Rebellion.Systems
         /// <summary>
         /// Returns the faction operating the fleet that currently blockades a planet.
         /// </summary>
-        private Faction FindBlockadingFaction(Planet planet)
+        private Faction GetBlockadingFaction(Planet planet)
         {
             Fleet blockadingFleet = planet
                 .GetChildren<Fleet>()

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -53,7 +53,7 @@ namespace Rebellion.Systems
         public List<GameResult> ProcessTick()
         {
             List<GameResult> results = new List<GameResult>();
-            ApplyPeriodicSupportShifts();
+            ApplySupportShifts();
             UpdateUncolonizedPlanets(results);
             CheckOwnershipTransfers(results);
 
@@ -63,7 +63,7 @@ namespace Rebellion.Systems
         /// <summary>
         /// Applies the original timed blockade and Imperial-garrison support rules.
         /// </summary>
-        private void ApplyPeriodicSupportShifts()
+        private void ApplySupportShifts()
         {
             GameConfig.SupportShiftConfig config = _game.Config.SupportShift;
             foreach (Planet planet in _game.GetSceneNodesByType<Planet>())

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -69,7 +69,7 @@ namespace Rebellion.Systems
             foreach (Planet planet in _game.GetSceneNodesByType<Planet>())
             {
                 ApplyBlockadeSupportShift(planet, config);
-                ApplyImperialGarrisonSupportShift(planet, config);
+                ApplyPeacefulGarrisonSupportShift(planet, config);
             }
         }
 
@@ -146,16 +146,16 @@ namespace Rebellion.Systems
         }
 
         /// <summary>
-        /// Applies the configured Imperial troop-presence drift on controlled, peaceful planets.
+        /// Applies the configured troop-presence drift on controlled, peaceful planets.
         /// </summary>
-        private void ApplyImperialGarrisonSupportShift(
+        private void ApplyPeacefulGarrisonSupportShift(
             Planet planet,
             GameConfig.SupportShiftConfig config
         )
         {
             Faction garrisonFaction = _game
                 .GetFactions()
-                .FirstOrDefault(faction => faction.Settings?.GarrisonSupportShift != 0);
+                .FirstOrDefault(faction => faction.Settings?.PeacefulGarrisonSupportShift != 0);
             if (
                 garrisonFaction == null
                 || planet.OwnerInstanceID != garrisonFaction.InstanceID
@@ -173,7 +173,7 @@ namespace Rebellion.Systems
                 return;
             }
 
-            int interval = config.ImperialGarrisonSupportShiftIntervalTicks;
+            int interval = config.PeacefulGarrisonSupportShiftIntervalTicks;
             if (interval <= 0)
                 return;
 
@@ -189,7 +189,7 @@ namespace Rebellion.Systems
             ShiftPopularSupport(
                 planet,
                 garrisonFaction,
-                garrisonFaction.Settings.GarrisonSupportShift
+                garrisonFaction.Settings.PeacefulGarrisonSupportShift
             );
             planet.NextGarrisonSupportShiftTick = _game.CurrentTick + interval;
         }

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -69,7 +69,7 @@ namespace Rebellion.Systems
             foreach (Planet planet in _game.GetSceneNodesByType<Planet>())
             {
                 ApplyBlockadeSupportShift(planet, config);
-                ApplyPeacefulGarrisonSupportShift(planet, config);
+                ApplyGarrisonSupportShift(planet, config);
             }
         }
 
@@ -148,14 +148,14 @@ namespace Rebellion.Systems
         /// <summary>
         /// Applies the configured troop-presence drift on controlled, peaceful planets.
         /// </summary>
-        private void ApplyPeacefulGarrisonSupportShift(
+        private void ApplyGarrisonSupportShift(
             Planet planet,
             GameConfig.SupportShiftConfig config
         )
         {
             Faction garrisonFaction = _game
                 .GetFactions()
-                .FirstOrDefault(faction => faction.Settings?.PeacefulGarrisonSupportShift != 0);
+                .FirstOrDefault(faction => faction.Settings?.GarrisonSupportShift != 0);
             if (
                 garrisonFaction == null
                 || planet.OwnerInstanceID != garrisonFaction.InstanceID
@@ -173,7 +173,7 @@ namespace Rebellion.Systems
                 return;
             }
 
-            int interval = config.PeacefulGarrisonSupportShiftIntervalTicks;
+            int interval = config.GarrisonSupportShiftIntervalTicks;
             if (interval <= 0)
                 return;
 
@@ -189,7 +189,7 @@ namespace Rebellion.Systems
             ShiftPopularSupport(
                 planet,
                 garrisonFaction,
-                garrisonFaction.Settings.PeacefulGarrisonSupportShift
+                garrisonFaction.Settings.GarrisonSupportShift
             );
             planet.NextGarrisonSupportShiftTick = _game.CurrentTick + interval;
         }

--- a/Assets/Scripts/Systems/PlanetaryControlSystem.cs
+++ b/Assets/Scripts/Systems/PlanetaryControlSystem.cs
@@ -148,10 +148,7 @@ namespace Rebellion.Systems
         /// <summary>
         /// Applies the configured troop-presence drift on controlled, peaceful planets.
         /// </summary>
-        private void ApplyGarrisonSupportShift(
-            Planet planet,
-            GameConfig.SupportShiftConfig config
-        )
+        private void ApplyGarrisonSupportShift(Planet planet, GameConfig.SupportShiftConfig config)
         {
             Faction garrisonFaction = _game
                 .GetFactions()

--- a/Assets/Scripts/Systems/RecoverySystem.cs
+++ b/Assets/Scripts/Systems/RecoverySystem.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using Rebellion.Game;
 using Rebellion.Game.Galaxy;
 using Rebellion.Game.Results;
 using Rebellion.Game.Units;
 using Rebellion.SceneGraph;
+using Rebellion.Util.Extensions;
 
 namespace Rebellion.Systems
 {
@@ -73,7 +75,7 @@ namespace Rebellion.Systems
 
         /// <summary>
         /// Repairs hull damage on each damaged capital ship.
-        /// Ships at friendly planets repair faster.
+        /// Ships at friendly orbital shipyards repair faster.
         /// Emits a result only when the ship is fully repaired.
         /// </summary>
         /// <param name="results">Collection to append repair results to.</param>
@@ -81,11 +83,15 @@ namespace Rebellion.Systems
         {
             foreach (CapitalShip ship in _game.GetSceneNodesByType<CapitalShip>())
             {
-                if (!ship.IsDamaged() || ship.ManufacturingStatus != ManufacturingStatus.Complete)
+                if (
+                    !ship.IsDamaged()
+                    || ship.ManufacturingStatus != ManufacturingStatus.Complete
+                    || ship.GetTransitMovement() != null
+                )
                     continue;
 
                 int before = ship.CurrentHullStrength;
-                int amount = IsAtFriendlyPlanet(ship)
+                int amount = IsAtFriendlyShipyard(ship)
                     ? _config.FastRepairAmount
                     : _config.NormalRepairAmount;
                 ship.RepairHull(amount);
@@ -151,6 +157,26 @@ namespace Rebellion.Systems
         {
             Planet planet = unit.GetParentOfType<Planet>();
             return planet != null && planet.OwnerInstanceID == unit.OwnerInstanceID;
+        }
+
+        /// <summary>
+        /// Returns true if the ship is at a friendly planet with an operational orbital shipyard.
+        /// </summary>
+        /// <param name="ship">The capital ship to check.</param>
+        /// <returns>True when a friendly operational shipyard can accelerate repairs.</returns>
+        private static bool IsAtFriendlyShipyard(CapitalShip ship)
+        {
+            Planet planet = ship.GetParentOfType<Planet>();
+            return planet != null
+                && planet.OwnerInstanceID == ship.OwnerInstanceID
+                && planet
+                    .GetChildren<Building>()
+                    .Any(building =>
+                        building.OwnerInstanceID == ship.OwnerInstanceID
+                        && building.BuildingType == BuildingType.Shipyard
+                        && building.ManufacturingStatus == ManufacturingStatus.Complete
+                        && building.Movement == null
+                    );
         }
     }
 }

--- a/Assets/Scripts/Systems/UprisingSystem.cs
+++ b/Assets/Scripts/Systems/UprisingSystem.cs
@@ -1148,7 +1148,7 @@ namespace Rebellion.Systems
             if (shift == 0)
                 return;
 
-            shift = PlanetaryControlSystem.ApplyCoreWeakSupportPenalty(
+            shift = PlanetaryControlSystem.ApplyCoreSupportResistance(
                 planet,
                 faction,
                 shift,

--- a/Assets/Tests/EditMode/UnitTests/Game/Galaxy/PlanetTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/Galaxy/PlanetTests.cs
@@ -942,6 +942,79 @@ namespace Rebellion.Tests.Game.Galaxy
         }
 
         [Test]
+        public void GetBlockadeProductionModifier_ActiveShipsAndFighters_ReducesProduction()
+        {
+            Fleet enemyFleet = CreateOperationalFleet("ENEMY");
+            CapitalShip activeShip = enemyFleet.GetChildren<CapitalShip>().Single();
+            activeShip.AddTestChild(
+                new Starfighter
+                {
+                    OwnerInstanceID = "ENEMY",
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                }
+            );
+            activeShip.AddTestChild(
+                new Starfighter
+                {
+                    OwnerInstanceID = "ENEMY",
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                }
+            );
+            activeShip.AddTestChild(
+                new Starfighter
+                {
+                    OwnerInstanceID = "ENEMY",
+                    ManufacturingStatus = ManufacturingStatus.Building,
+                }
+            );
+            enemyFleet.AddChild(
+                new CapitalShip
+                {
+                    OwnerInstanceID = "ENEMY",
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                    Movement = new MovementState { TransitTicks = 10 },
+                }
+            );
+            _planet.AddChild(enemyFleet);
+            _planet.AddChild(
+                new Starfighter
+                {
+                    OwnerInstanceID = "FNALL1",
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                }
+            );
+
+            int modifier = _planet.GetBlockadeProductionModifier(5, 2);
+
+            Assert.AreEqual(89, modifier);
+        }
+
+        [Test]
+        public void GetBlockadeProductionModifier_OperationalKdy_ReturnsFullProduction()
+        {
+            _planet.AddChild(CreateOperationalFleet("ENEMY"));
+            _planet.AddChild(
+                new Building
+                {
+                    OwnerInstanceID = "FNALL1",
+                    BuildingType = BuildingType.Weapon,
+                    DefenseWeaponEffect = DefenseWeaponEffect.ShieldDamage,
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                }
+            );
+
+            Assert.AreEqual(100, _planet.GetBlockadeProductionModifier(5, 2));
+        }
+
+        [Test]
+        public void GetBlockadeProductionModifier_HeavyBlockade_DoesNotReturnNegativeProduction()
+        {
+            _planet.AddChild(CreateOperationalFleet("ENEMY"));
+
+            Assert.AreEqual(0, _planet.GetBlockadeProductionModifier(100, 2));
+        }
+
+        [Test]
         public void IsBlockaded_EnemyFleetInTransit_ReturnsFalse()
         {
             Fleet enemyFleet = CreateOperationalFleet("ENEMY");

--- a/Assets/Tests/EditMode/UnitTests/Game/Galaxy/PlanetTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/Galaxy/PlanetTests.cs
@@ -905,6 +905,33 @@ namespace Rebellion.Tests.Game.Galaxy
         }
 
         [Test]
+        public void IsBlockaded_NeutralPlanetWithOperationalFleet_ReturnsTrue()
+        {
+            _planet.OwnerInstanceID = null;
+            _planet.AddChild(CreateOperationalFleet("FNALL1"));
+
+            Assert.IsTrue(_planet.IsBlockaded());
+        }
+
+        [Test]
+        public void IsBlockadedFor_NeutralPlanetBlockadingFaction_ReturnsFalse()
+        {
+            _planet.OwnerInstanceID = null;
+            _planet.AddChild(CreateOperationalFleet("FNALL1"));
+
+            Assert.IsFalse(_planet.IsBlockadedFor("FNALL1"));
+        }
+
+        [Test]
+        public void IsBlockadedFor_NeutralPlanetOpposingFaction_ReturnsTrue()
+        {
+            _planet.OwnerInstanceID = null;
+            _planet.AddChild(CreateOperationalFleet("FNALL1"));
+
+            Assert.IsTrue(_planet.IsBlockadedFor("ENEMY"));
+        }
+
+        [Test]
         public void IsBlockaded_InactiveEnemyFleet_ReturnsFalse()
         {
             Fleet enemyFleet = CreateOperationalFleet("ENEMY");
@@ -989,83 +1016,6 @@ namespace Rebellion.Tests.Game.Galaxy
             bool isBlockaded = _planet.IsBlockadedFor("ENEMY");
 
             Assert.IsFalse(isBlockaded);
-        }
-
-        [Test]
-        public void GetBlockadeModifier_ActiveShipsAndFighters_ReducesProduction()
-        {
-            Fleet enemyFleet = CreateOperationalFleet("ENEMY");
-            CapitalShip activeShip = enemyFleet.GetChildren<CapitalShip>().Single();
-            activeShip.AddTestChild(
-                new Starfighter
-                {
-                    OwnerInstanceID = "ENEMY",
-                    ManufacturingStatus = ManufacturingStatus.Complete,
-                }
-            );
-            activeShip.AddTestChild(
-                new Starfighter
-                {
-                    OwnerInstanceID = "ENEMY",
-                    ManufacturingStatus = ManufacturingStatus.Complete,
-                }
-            );
-            activeShip.AddTestChild(
-                new Starfighter
-                {
-                    OwnerInstanceID = "ENEMY",
-                    ManufacturingStatus = ManufacturingStatus.Building,
-                }
-            );
-            enemyFleet.AddChild(
-                new CapitalShip
-                {
-                    OwnerInstanceID = "ENEMY",
-                    ManufacturingStatus = ManufacturingStatus.Complete,
-                    Movement = new MovementState { TransitTicks = 10 },
-                }
-            );
-            _planet.AddChild(enemyFleet);
-            _planet.AddChild(
-                new Starfighter
-                {
-                    OwnerInstanceID = "FNALL1",
-                    ManufacturingStatus = ManufacturingStatus.Complete,
-                }
-            );
-
-            int modifier = _planet.GetBlockadeModifier(5, 2);
-
-            Assert.AreEqual(91, modifier);
-        }
-
-        [Test]
-        public void GetBlockadeModifier_ActiveKdyDefense_ReturnsFullProduction()
-        {
-            _planet.AddChild(CreateOperationalFleet("ENEMY"));
-            _planet.AddChild(
-                new Building
-                {
-                    OwnerInstanceID = "FNALL1",
-                    BuildingType = BuildingType.Weapon,
-                    DefenseWeaponEffect = DefenseWeaponEffect.ShieldDamage,
-                    ManufacturingStatus = ManufacturingStatus.Complete,
-                }
-            );
-
-            int modifier = _planet.GetBlockadeModifier(5, 2);
-
-            Assert.AreEqual(100, modifier);
-        }
-
-        [Test]
-        public void GetBlockadeModifier_HeavyBlockade_DoesNotReturnNegativeProduction()
-        {
-            _planet.AddChild(CreateOperationalFleet("ENEMY"));
-
-            int modifier = _planet.GetBlockadeModifier(100, 2);
-
-            Assert.AreEqual(0, modifier);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/Managers/GameManagerTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Managers/GameManagerTests.cs
@@ -1442,6 +1442,7 @@ namespace Rebellion.Tests.Managers
                 DisplayName = "Planet",
                 OwnerInstanceID = faction.InstanceID,
                 IsColonized = true,
+                EnergyCapacity = 1,
             };
             game.AttachNode(sector, game.GetGalaxyMap());
             game.AttachNode(planet, sector);
@@ -1471,6 +1472,16 @@ namespace Rebellion.Tests.Managers
                 CurrentSquadronSize = 11,
             };
             game.AttachNode(officer, planet);
+            game.AttachNode(
+                new Building
+                {
+                    InstanceID = "SHIPYARD",
+                    OwnerInstanceID = faction.InstanceID,
+                    BuildingType = BuildingType.Shipyard,
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                },
+                planet
+            );
             game.AttachNode(fleet, planet);
             game.AttachNode(ship, fleet);
             game.AttachNode(fighter, ship);

--- a/Assets/Tests/EditMode/UnitTests/Systems/BlockadeSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/BlockadeSystemTests.cs
@@ -247,6 +247,36 @@ namespace Rebellion.Tests.Sectors
             Assert.AreEqual(regiment, game.GetSceneNodeByInstanceID<Regiment>(regiment.InstanceID));
         }
 
+        [Test]
+        public void ApplyEvacuationLosses_OperationalIonCannon_PreventsLoss()
+        {
+            (GameRoot game, Planet planet, _) = BuildScene();
+            planet.IsColonized = true;
+            planet.EnergyCapacity = 1;
+            Regiment regiment = new Regiment
+            {
+                InstanceID = "r1",
+                OwnerInstanceID = "empire",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            Building ionCannon = new Building
+            {
+                InstanceID = "ion-cannon",
+                BuildingType = BuildingType.Weapon,
+                DefenseWeaponEffect = DefenseWeaponEffect.ShieldDamage,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                OwnerInstanceID = "empire",
+            };
+            game.AttachNode(ionCannon, planet);
+            game.AttachNode(regiment, planet);
+            BlockadeSystem system = new BlockadeSystem(game, new FixedRNG());
+
+            EvacuationLossesResult result = system.ApplyEvacuationLosses(regiment, planet);
+
+            Assert.IsNull(result);
+            Assert.AreSame(regiment, game.GetSceneNodeByInstanceID<Regiment>(regiment.InstanceID));
+        }
+
         private (GameRoot game, Planet planet, Fleet hostileFleet) BuildScene()
         {
             GameRoot game = new GameRoot(TestConfig.Create());

--- a/Assets/Tests/EditMode/UnitTests/Systems/BlockadeSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/BlockadeSystemTests.cs
@@ -35,6 +35,23 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
+        public void ProcessTick_NewNeutralPlanetBlockade_EmitsBlockadeStarted()
+        {
+            (GameRoot game, Planet planet, Fleet blockadingFleet) = BuildScene();
+            planet.OwnerInstanceID = null;
+            BlockadeSystem manager = new BlockadeSystem(game, new StubRNG());
+
+            BlockadeChangedResult result = manager
+                .ProcessTick()
+                .OfType<BlockadeChangedResult>()
+                .Single();
+
+            Assert.IsTrue(result.Blockaded);
+            Assert.AreEqual(planet, result.Planet);
+            Assert.AreEqual(blockadingFleet, result.BlockadingFleet);
+        }
+
+        [Test]
         public void ProcessTick_HostileFleetInTransit_EmitsBlockadeOnlyAfterArrival()
         {
             (GameRoot game, _, Fleet hostileFleet) = BuildScene();
@@ -208,6 +225,26 @@ namespace Rebellion.Tests.Sectors
             BlockadeSystem system = new BlockadeSystem(game, new MaximumRNG());
 
             Assert.IsTrue(system.RollEvacuationLoss());
+        }
+
+        [Test]
+        public void ApplyEvacuationLosses_NeutralPlanetBlockadingFaction_ReturnsNoLoss()
+        {
+            (GameRoot game, Planet planet, _) = BuildScene();
+            planet.OwnerInstanceID = null;
+            Regiment regiment = new Regiment
+            {
+                InstanceID = "r1",
+                OwnerInstanceID = "alliance",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(regiment, planet);
+            BlockadeSystem system = new BlockadeSystem(game, new FixedRNG());
+
+            EvacuationLossesResult result = system.ApplyEvacuationLosses(regiment, planet);
+
+            Assert.IsNull(result);
+            Assert.AreEqual(regiment, game.GetSceneNodeByInstanceID<Regiment>(regiment.InstanceID));
         }
 
         private (GameRoot game, Planet planet, Fleet hostileFleet) BuildScene()

--- a/Assets/Tests/EditMode/UnitTests/Systems/FactionAutomationSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/FactionAutomationSystemTests.cs
@@ -122,14 +122,14 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_ManageProduction_FillsCapacityWithMatchedPair()
+        public void ProcessTick_ManageProduction_FillsLaneWithOneProject()
         {
             _faction.ManageGarrisons = false;
 
             _automation.ProcessTick();
 
-            Assert.AreEqual(11, CountResourceFacilities(BuildingType.Mine));
-            Assert.AreEqual(11, CountResourceFacilities(BuildingType.Refinery));
+            Assert.AreEqual(12, CountResourceFacilities(BuildingType.Mine));
+            Assert.AreEqual(10, CountResourceFacilities(BuildingType.Refinery));
         }
 
         [Test]
@@ -143,7 +143,7 @@ namespace Rebellion.Tests.Systems
 
             _automation.ProcessTick();
 
-            Assert.AreEqual(1, _destination.GetTotalBuildingTypeCount(BuildingType.Mine));
+            Assert.AreEqual(2, _destination.GetTotalBuildingTypeCount(BuildingType.Mine));
             Assert.AreEqual(0, distant.GetTotalBuildingTypeCount(BuildingType.Mine));
         }
 
@@ -170,7 +170,7 @@ namespace Rebellion.Tests.Systems
 
             _automation.ProcessTick();
 
-            Assert.AreEqual(1, _destination.GetTotalBuildingTypeCount(BuildingType.Mine));
+            Assert.AreEqual(2, _destination.GetTotalBuildingTypeCount(BuildingType.Mine));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/Systems/ManufacturingSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/ManufacturingSystemTests.cs
@@ -4500,6 +4500,49 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void StartManufacturing_SameProject_AppendsRequestedCopies()
+        {
+            GameRoot game = CreateOrderTestGame();
+            Planet planet = CreateOrderTestConstructionPlanet(game, "p1", "empire");
+            ManufacturingSystem manager = new ManufacturingSystem(game, new FleetSystem(game));
+            Building template = CreateOrderTestBuildingTemplate("mine");
+            Assert.IsTrue(manager.StartManufacturing(planet, template, planet, 2, "empire"));
+
+            bool started = manager.StartManufacturing(planet, template, planet, 1, "empire");
+
+            Assert.IsTrue(started);
+            List<IManufacturable> queue = planet.GetManufacturingQueue()[
+                ManufacturingType.Building
+            ];
+            Assert.AreEqual(3, queue.Count);
+            Assert.IsTrue(queue.All(item => item.GetTypeID() == "mine"));
+        }
+
+        [Test]
+        public void StartManufacturing_DifferentProject_ReplacesEntireProductionLane()
+        {
+            GameRoot game = CreateOrderTestGame();
+            Planet planet = CreateOrderTestConstructionPlanet(game, "p1", "empire");
+            ManufacturingSystem manager = new ManufacturingSystem(game, new FleetSystem(game));
+            Building mines = CreateOrderTestBuildingTemplate("mine");
+            Building refineries = CreateOrderTestBuildingTemplate("refinery");
+            Assert.IsTrue(manager.StartManufacturing(planet, mines, planet, 3, "empire"));
+            List<IManufacturable> replacedItems = planet
+                .GetManufacturingQueue()[ManufacturingType.Building]
+                .ToList();
+
+            bool started = manager.StartManufacturing(planet, refineries, planet, 2, "empire");
+
+            Assert.IsTrue(started);
+            List<IManufacturable> queue = planet.GetManufacturingQueue()[
+                ManufacturingType.Building
+            ];
+            Assert.AreEqual(2, queue.Count);
+            Assert.IsTrue(queue.All(item => item.GetTypeID() == "refinery"));
+            Assert.IsTrue(replacedItems.All(item => item.GetParent() == null));
+        }
+
+        [Test]
         public void RetargetManufacturingDestination_QueuedLaneMovesEveryItem()
         {
             GameRoot game = CreateOrderTestGame();

--- a/Assets/Tests/EditMode/UnitTests/Systems/ManufacturingSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/ManufacturingSystemTests.cs
@@ -1680,7 +1680,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_Blockade_HaltsProductionEvenWithIonCannon()
+        public void ProcessTick_Blockade_AppliesGraduatedRateAndKdyRestoresFullRate()
         {
             GameConfig config = TestConfig.Create();
             GameRoot game = new GameRoot(config);
@@ -1737,9 +1737,19 @@ namespace Rebellion.Tests.Systems
 
             manufacturing.ProcessTick();
 
-            Assert.AreEqual(0, constructionYard.ProductionCycleProgress);
-            Assert.AreEqual(1, empire.RefinedMaterialStockpile);
-            Assert.IsFalse(constructionYard.ProductionInputReserved);
+            double expectedBlockadeProgress =
+                1.0
+                - (
+                    config.Blockade.CapitalShipProductionPenaltyPercent
+                    + config.Blockade.FighterProductionPenaltyPercent
+                ) / 100.0;
+            Assert.AreEqual(
+                expectedBlockadeProgress,
+                constructionYard.ProductionCycleProgress,
+                0.0001
+            );
+            Assert.AreEqual(0, empire.RefinedMaterialStockpile);
+            Assert.IsTrue(constructionYard.ProductionInputReserved);
 
             game.AttachNode(
                 new Building
@@ -1754,15 +1764,18 @@ namespace Rebellion.Tests.Systems
             );
             manufacturing.ProcessTick();
 
-            Assert.AreEqual(0, constructionYard.ProductionCycleProgress);
-            Assert.AreEqual(1, empire.RefinedMaterialStockpile);
-            Assert.IsFalse(constructionYard.ProductionInputReserved);
+            Assert.AreEqual(
+                expectedBlockadeProgress + 1,
+                constructionYard.ProductionCycleProgress,
+                0.0001
+            );
         }
 
         [Test]
-        public void ProcessTick_Blockade_HaltsProductionWithoutReservingInput()
+        public void ProcessTick_FullBlockade_HaltsProductionWithoutReservingInput()
         {
             GameConfig config = TestConfig.Create();
+            config.Blockade.CapitalShipProductionPenaltyPercent = 100;
             GameRoot game = new GameRoot(config);
             Faction empire = new Faction { InstanceID = "empire" };
             Faction rebels = new Faction { InstanceID = "rebels" };

--- a/Assets/Tests/EditMode/UnitTests/Systems/ManufacturingSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/ManufacturingSystemTests.cs
@@ -1680,7 +1680,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_Blockade_AppliesGraduatedRateAndKdyRestoresFullRate()
+        public void ProcessTick_Blockade_HaltsProductionEvenWithIonCannon()
         {
             GameConfig config = TestConfig.Create();
             GameRoot game = new GameRoot(config);
@@ -1737,19 +1737,9 @@ namespace Rebellion.Tests.Systems
 
             manufacturing.ProcessTick();
 
-            double expectedBlockadeProgress =
-                1.0
-                - (
-                    config.Blockade.CapitalShipProductionPenaltyPercent
-                    + config.Blockade.FighterProductionPenaltyPercent
-                ) / 100.0;
-            Assert.AreEqual(
-                expectedBlockadeProgress,
-                constructionYard.ProductionCycleProgress,
-                0.0001
-            );
-            Assert.AreEqual(0, empire.RefinedMaterialStockpile);
-            Assert.IsTrue(constructionYard.ProductionInputReserved);
+            Assert.AreEqual(0, constructionYard.ProductionCycleProgress);
+            Assert.AreEqual(1, empire.RefinedMaterialStockpile);
+            Assert.IsFalse(constructionYard.ProductionInputReserved);
 
             game.AttachNode(
                 new Building
@@ -1764,18 +1754,15 @@ namespace Rebellion.Tests.Systems
             );
             manufacturing.ProcessTick();
 
-            Assert.AreEqual(
-                expectedBlockadeProgress + 1,
-                constructionYard.ProductionCycleProgress,
-                0.0001
-            );
+            Assert.AreEqual(0, constructionYard.ProductionCycleProgress);
+            Assert.AreEqual(1, empire.RefinedMaterialStockpile);
+            Assert.IsFalse(constructionYard.ProductionInputReserved);
         }
 
         [Test]
-        public void ProcessTick_FullBlockade_HaltsProductionWithoutReservingInput()
+        public void ProcessTick_Blockade_HaltsProductionWithoutReservingInput()
         {
             GameConfig config = TestConfig.Create();
-            config.Blockade.CapitalShipProductionPenaltyPercent = 100;
             GameRoot game = new GameRoot(config);
             Faction empire = new Faction { InstanceID = "empire" };
             Faction rebels = new Faction { InstanceID = "rebels" };

--- a/Assets/Tests/EditMode/UnitTests/Systems/PlanetaryControlSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/PlanetaryControlSystemTests.cs
@@ -946,6 +946,66 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_BlockadeFleetOpposesFavoredSide_ShiftsTowardFavoredSide()
+        {
+            _game.Config.SupportShift.BlockadeOpposeShiftIntervalTicks = 30;
+            _game.Config.SupportShift.BlockadeOpposeShift = -1;
+            _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
+            _targetPlanet.SetPopularSupport(_empire.InstanceID, 60);
+            _targetPlanet.SetPopularSupport(_rebels.InstanceID, 40);
+            Fleet fleet = EntityFactory.CreateFleet("rebel-fleet", _rebels.InstanceID);
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "rebel-ship",
+                OwnerInstanceID = _rebels.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                CurrentHullStrength = 1,
+                MaxHullStrength = 1,
+            };
+            _game.AttachNode(fleet, _targetPlanet);
+            _game.AttachNode(ship, fleet);
+            _game.CurrentTick = 30;
+
+            _ownershipSystem.ProcessTick();
+            _game.CurrentTick = 60;
+
+            _ownershipSystem.ProcessTick();
+
+            Assert.AreEqual(61, _targetPlanet.GetPopularSupport(_empire.InstanceID));
+            Assert.AreEqual(39, _targetPlanet.GetPopularSupport(_rebels.InstanceID));
+        }
+
+        [Test]
+        public void ProcessTick_BlockadeFleetMatchesFavoredSide_IncreasesFleetSupport()
+        {
+            _game.Config.SupportShift.BlockadeMatchShiftIntervalTicks = 30;
+            _game.Config.SupportShift.BlockadeMatchShift = 1;
+            _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
+            _targetPlanet.SetPopularSupport(_empire.InstanceID, 40);
+            _targetPlanet.SetPopularSupport(_rebels.InstanceID, 60);
+            Fleet fleet = EntityFactory.CreateFleet("rebel-fleet", _rebels.InstanceID);
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "rebel-ship",
+                OwnerInstanceID = _rebels.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                CurrentHullStrength = 1,
+                MaxHullStrength = 1,
+            };
+            _game.AttachNode(fleet, _targetPlanet);
+            _game.AttachNode(ship, fleet);
+            _game.CurrentTick = 30;
+
+            _ownershipSystem.ProcessTick();
+            _game.CurrentTick = 60;
+
+            _ownershipSystem.ProcessTick();
+
+            Assert.AreEqual(61, _targetPlanet.GetPopularSupport(_rebels.InstanceID));
+            Assert.AreEqual(39, _targetPlanet.GetPopularSupport(_empire.InstanceID));
+        }
+
+        [Test]
         public void ProcessTick_NeutralPlanetBelowThreshold_DoesNotTransferOwnership()
         {
             (Planet planet, PlanetaryControlSystem system) = BuildSupportScene(

--- a/Assets/Tests/EditMode/UnitTests/Systems/PlanetaryControlSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/PlanetaryControlSystemTests.cs
@@ -948,6 +948,7 @@ namespace Rebellion.Tests.Systems
         [Test]
         public void ProcessTick_BlockadeFleetOpposesFavoredSide_ShiftsTowardFavoredSide()
         {
+            _targetPlanet.GetParentOfType<PlanetSector>().SectorType = PlanetSectorType.OuterRim;
             _game.Config.SupportShift.BlockadeOpposeShiftIntervalTicks = 30;
             _game.Config.SupportShift.BlockadeOpposeShift = -1;
             _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
@@ -978,6 +979,7 @@ namespace Rebellion.Tests.Systems
         [Test]
         public void ProcessTick_BlockadeFleetMatchesFavoredSide_IncreasesFleetSupport()
         {
+            _targetPlanet.GetParentOfType<PlanetSector>().SectorType = PlanetSectorType.OuterRim;
             _game.Config.SupportShift.BlockadeMatchShiftIntervalTicks = 30;
             _game.Config.SupportShift.BlockadeMatchShift = 1;
             _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
@@ -1003,6 +1005,68 @@ namespace Rebellion.Tests.Systems
 
             Assert.AreEqual(61, _targetPlanet.GetPopularSupport(_rebels.InstanceID));
             Assert.AreEqual(39, _targetPlanet.GetPopularSupport(_empire.InstanceID));
+        }
+
+        [Test]
+        public void ProcessTick_BlockadeAtTiedSupport_AppliesOpposingShift()
+        {
+            _targetPlanet.GetParentOfType<PlanetSector>().SectorType = PlanetSectorType.OuterRim;
+            _game.Config.SupportShift.BlockadeOpposeShiftIntervalTicks = 30;
+            _game.Config.SupportShift.BlockadeOpposeShift = -1;
+            _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
+            _targetPlanet.SetPopularSupport(_empire.InstanceID, 50);
+            _targetPlanet.SetPopularSupport(_rebels.InstanceID, 50);
+            Fleet fleet = EntityFactory.CreateFleet("rebel-fleet", _rebels.InstanceID);
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "rebel-ship",
+                OwnerInstanceID = _rebels.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                CurrentHullStrength = 1,
+                MaxHullStrength = 1,
+            };
+            _game.AttachNode(fleet, _targetPlanet);
+            _game.AttachNode(ship, fleet);
+            _game.CurrentTick = 30;
+
+            _ownershipSystem.ProcessTick();
+            _game.CurrentTick = 60;
+            _ownershipSystem.ProcessTick();
+
+            Assert.AreEqual(49, _targetPlanet.GetPopularSupport(_rebels.InstanceID));
+            Assert.AreEqual(51, _targetPlanet.GetPopularSupport(_empire.InstanceID));
+        }
+
+        [Test]
+        public void ProcessTick_BlockadeReinforcesWeakCoreAllianceSupport_DoesNotShift()
+        {
+            _game.Config.SupportShift.BlockadeMatchShiftIntervalTicks = 30;
+            _game.Config.SupportShift.BlockadeMatchShift = 1;
+            _game.Config.SupportShift.WeakSupportPenaltyDivisor = 2;
+            _rebels.Settings.SupportResistance = SupportChange.Increase;
+            _targetPlanet.GetParentOfType<PlanetSector>().SectorType = PlanetSectorType.Core;
+            _game.ChangeOwnership(_targetPlanet, _empire.InstanceID);
+            _targetPlanet.SetPopularSupport(_empire.InstanceID, 40);
+            _targetPlanet.SetPopularSupport(_rebels.InstanceID, 60);
+            Fleet fleet = EntityFactory.CreateFleet("rebel-fleet", _rebels.InstanceID);
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "rebel-ship",
+                OwnerInstanceID = _rebels.InstanceID,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                CurrentHullStrength = 1,
+                MaxHullStrength = 1,
+            };
+            _game.AttachNode(fleet, _targetPlanet);
+            _game.AttachNode(ship, fleet);
+            _game.CurrentTick = 30;
+
+            _ownershipSystem.ProcessTick();
+            _game.CurrentTick = 60;
+            _ownershipSystem.ProcessTick();
+
+            Assert.AreEqual(60, _targetPlanet.GetPopularSupport(_rebels.InstanceID));
+            Assert.AreEqual(40, _targetPlanet.GetPopularSupport(_empire.InstanceID));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/Systems/RecoverySystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/RecoverySystemTests.cs
@@ -148,6 +148,29 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
+        public void ProcessTick_OfficerAboardFleetInTransit_DoesNotHeal()
+        {
+            (GameRoot game, Planet planet) = BuildScene();
+            Fleet fleet = EntityFactory.CreateFleet("fleet", "empire");
+            fleet.Movement = new MovementState { TransitTicks = 10 };
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "ship",
+                OwnerInstanceID = "empire",
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            Officer officer = EntityFactory.CreateOfficer("o1", "empire");
+            officer.InjuryPoints = 10;
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+            game.AttachNode(officer, ship);
+
+            new RecoverySystem(game).ProcessTick();
+
+            Assert.AreEqual(10, officer.InjuryPoints);
+        }
+
+        [Test]
         public void ProcessTick_OfficerOnMission_DoesNotHeal()
         {
             (GameRoot game, Planet planet) = BuildScene();
@@ -221,7 +244,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_DamagedShipAtFriendlyPlanet_RepairsFast()
+        public void ProcessTick_DamagedShipAtFriendlyShipyard_RepairsFast()
         {
             (GameRoot game, Planet planet) = BuildScene();
 
@@ -236,6 +259,16 @@ namespace Rebellion.Tests.Systems
             };
             game.AttachNode(fleet, planet);
             game.AttachNode(ship, fleet);
+            game.AttachNode(
+                new Building
+                {
+                    InstanceID = "shipyard",
+                    OwnerInstanceID = "empire",
+                    BuildingType = BuildingType.Shipyard,
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                },
+                planet
+            );
 
             RecoverySystem system = new RecoverySystem(game);
 
@@ -244,8 +277,104 @@ namespace Rebellion.Tests.Systems
             Assert.AreEqual(
                 85,
                 ship.CurrentHullStrength,
-                "Ship at friendly planet should repair 5 per tick"
+                "Ship at a friendly orbital shipyard should repair 5 per tick"
             );
+        }
+
+        [Test]
+        public void ProcessTick_DamagedShipAtFriendlyPlanetWithoutShipyard_RepairsSlowly()
+        {
+            (GameRoot game, Planet planet) = BuildScene();
+            Fleet fleet = EntityFactory.CreateFleet("f1", "empire");
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "s1",
+                OwnerInstanceID = "empire",
+                MaxHullStrength = 100,
+                CurrentHullStrength = 80,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+
+            new RecoverySystem(game).ProcessTick();
+
+            Assert.AreEqual(81, ship.CurrentHullStrength);
+        }
+
+        [Test]
+        public void ProcessTick_DamagedShipAtIncompleteFriendlyShipyard_RepairsSlowly()
+        {
+            (GameRoot game, Planet planet) = BuildScene();
+            Fleet fleet = EntityFactory.CreateFleet("f1", "empire");
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "s1",
+                OwnerInstanceID = "empire",
+                MaxHullStrength = 100,
+                CurrentHullStrength = 80,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+            game.AttachNode(
+                new Building
+                {
+                    InstanceID = "shipyard",
+                    OwnerInstanceID = "empire",
+                    BuildingType = BuildingType.Shipyard,
+                    ManufacturingStatus = ManufacturingStatus.Building,
+                },
+                planet
+            );
+
+            new RecoverySystem(game).ProcessTick();
+
+            Assert.AreEqual(81, ship.CurrentHullStrength);
+        }
+
+        [Test]
+        public void ProcessTick_DamagedShipInTransit_DoesNotRepair()
+        {
+            (GameRoot game, Planet planet) = BuildScene();
+            Fleet fleet = EntityFactory.CreateFleet("f1", "empire");
+            fleet.Movement = new MovementState { TransitTicks = 10 };
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "s1",
+                OwnerInstanceID = "empire",
+                MaxHullStrength = 100,
+                CurrentHullStrength = 80,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+
+            new RecoverySystem(game).ProcessTick();
+
+            Assert.AreEqual(80, ship.CurrentHullStrength);
+        }
+
+        [Test]
+        public void ProcessTick_DamagedShipWithDirectTransit_DoesNotRepair()
+        {
+            (GameRoot game, Planet planet) = BuildScene();
+            Fleet fleet = EntityFactory.CreateFleet("f1", "empire");
+            CapitalShip ship = new CapitalShip
+            {
+                InstanceID = "s1",
+                OwnerInstanceID = "empire",
+                MaxHullStrength = 100,
+                CurrentHullStrength = 80,
+                ManufacturingStatus = ManufacturingStatus.Complete,
+                Movement = new MovementState { TransitTicks = 10 },
+            };
+            game.AttachNode(fleet, planet);
+            game.AttachNode(ship, fleet);
+
+            new RecoverySystem(game).ProcessTick();
+
+            Assert.AreEqual(80, ship.CurrentHullStrength);
         }
 
         [Test]
@@ -317,6 +446,16 @@ namespace Rebellion.Tests.Systems
             };
             game.AttachNode(fleet, planet);
             game.AttachNode(ship, fleet);
+            game.AttachNode(
+                new Building
+                {
+                    InstanceID = "shipyard",
+                    OwnerInstanceID = "empire",
+                    BuildingType = BuildingType.Shipyard,
+                    ManufacturingStatus = ManufacturingStatus.Complete,
+                },
+                planet
+            );
 
             RecoverySystem system = new RecoverySystem(game);
 
@@ -626,6 +765,7 @@ namespace Rebellion.Tests.Systems
                 InstanceID = "p1",
                 OwnerInstanceID = "empire",
                 IsColonized = true,
+                EnergyCapacity = 1,
                 PositionX = 0,
                 PositionY = 0,
             };


### PR DESCRIPTION
## Summary

- Applying a graduated blockade production modifier based on capital ships and fighter squadrons
- Preserving full production when an operational KDY-150 ion cannon is present
- Applying timed blockade support adjustments, including tied-support and core-sector resistance behavior
- Allowing operational fleets to blockade neutral planets without treating their own units as blockade runners
- Protecting regiments covered by an operational KDY-150 from blockade-running losses
- Preventing capital ships and embarked officers from recovering in hyperspace
- Requiring a friendly operational orbital shipyard for accelerated capital-ship repairs
- Removing unused generalized garrison-support configuration
- Pairing with adasgames/rebellion2-media#96

## Validation

- Running `bash build.sh all`
- Passing all Unity EditMode tests
- Passing formatting, compilation, analyzer, and member-order checks
- Meeting line coverage at 81.2%
- Meeting method coverage at 91.1%
- Passing `git diff --check`

## Checklist

- [x] Passing relevant automated tests
- [x] Reviewing AI-assisted changes
- [x] Confirming UI builder changes are not applicable
- [x] Including matching content and schema changes in adasgames/rebellion2-media#96
- [x] Excluding generated UI prefabs, generated scenes, and copyrighted game assets



## Push validation

Before every further push, run `dotnet csharpier check Assets/` and `./build.sh lint`; push only after both succeed.
