### PR TITLE
Cleaning up low-value tests

### DIFF
--- a/Assets/Tests/EditMode/UnitTests/Game/Factions/FactionTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/Factions/FactionTests.cs
@@ -577,21 +577,25 @@ namespace Rebellion.Tests.Game.Factions
         }
 
         [Test]
-        public void RemoveMessage_MissingMessageBucket_DoesNotThrow()
+        public void RemoveMessage_MissingMessageBucket_RemainsAbsent()
         {
             _faction.Messages.Remove(MessageType.Manufacturing);
             Message message = new StatusMessage(MessageType.Manufacturing, "Manufacturing idle");
 
-            Assert.DoesNotThrow(() => _faction.RemoveMessage(message));
+            _faction.RemoveMessage(message);
+
+            Assert.IsFalse(_faction.Messages.ContainsKey(MessageType.Manufacturing));
         }
 
         [Test]
-        public void RemoveMessage_NullMessageDictionary_DoesNotThrow()
+        public void RemoveMessage_NullMessageDictionary_RemainsNull()
         {
             _faction.Messages = null;
             Message message = new StatusMessage(MessageType.Manufacturing, "Manufacturing idle");
 
-            Assert.DoesNotThrow(() => _faction.RemoveMessage(message));
+            _faction.RemoveMessage(message);
+
+            Assert.IsNull(_faction.Messages);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/Game/Galaxy/GalaxyMapTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/Galaxy/GalaxyMapTests.cs
@@ -47,9 +47,11 @@ namespace Rebellion.Tests.Game.Galaxy
         }
 
         [Test]
-        public void AddChild_WithNullPlanetSector_DoesNotThrowException()
+        public void AddChild_WithNullPlanetSector_LeavesChildrenEmpty()
         {
-            Assert.DoesNotThrow(() => _galaxyMap.AddChild(null));
+            _galaxyMap.AddChild(null);
+
+            Assert.IsEmpty(_galaxyMap.GetChildren<PlanetSector>());
         }
 
         [Test]
@@ -107,9 +109,16 @@ namespace Rebellion.Tests.Game.Galaxy
         }
 
         [Test]
-        public void RemoveChild_WithNullPlanetSector_DoesNotThrowException()
+        public void RemoveChild_WithNullPlanetSector_LeavesChildrenUnchanged()
         {
-            Assert.DoesNotThrow(() => _galaxyMap.RemoveChild(null));
+            _galaxyMap.AddChild(_planetSector1);
+
+            _galaxyMap.RemoveChild(null);
+
+            CollectionAssert.AreEqual(
+                new[] { _planetSector1 },
+                _galaxyMap.GetChildren<PlanetSector>()
+            );
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/Game/GameRootTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/GameRootTests.cs
@@ -709,7 +709,7 @@ namespace Rebellion.Tests.Game
         }
 
         [Test]
-        public void RemoveUnrecruitedOfficer_OfficerNotInList_DoesNotThrow()
+        public void RemoveUnrecruitedOfficer_OfficerNotInList_LeavesListUnchanged()
         {
             // Create officer that is not in the list.
             Officer officer = new Officer
@@ -718,8 +718,11 @@ namespace Rebellion.Tests.Game
                 RecruitingFactionInstanceIDs = new List<string> { "FACTION1" },
             };
 
-            // Remove non-existent officer (should not throw exception).
-            Assert.DoesNotThrow(() => _game.RemoveUnrecruitedOfficer(officer));
+            int countBefore = _game.GetUnrecruitedOfficers().Count;
+
+            _game.RemoveUnrecruitedOfficer(officer);
+
+            Assert.AreEqual(countBefore, _game.GetUnrecruitedOfficers().Count);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/Game/GameSummaryTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/GameSummaryTests.cs
@@ -39,19 +39,6 @@ namespace Rebellion.Tests.Game
         }
 
         [Test]
-        public void Constructor_DefaultConstruction_SeedDiffersAcrossInstances()
-        {
-            GameSummary firstSummary = new GameSummary();
-            GameSummary secondSummary = new GameSummary();
-
-            Assert.AreNotEqual(
-                firstSummary.Seed,
-                secondSummary.Seed,
-                "Each new GameSummary should roll a fresh default seed."
-            );
-        }
-
-        [Test]
         public void SerializeAndDeserialize_ExplicitSeed_RoundTripsExactly()
         {
             GameSummary summary = new GameSummary { Seed = 12345 };

--- a/Assets/Tests/EditMode/UnitTests/Game/Missions/EspionageMissionTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/Missions/EspionageMissionTests.cs
@@ -359,7 +359,7 @@ namespace Rebellion.Tests.Game.Missions
         }
 
         [Test]
-        public void ResolveObjective_WithoutFogSystem_DoesNotThrow()
+        public void ResolveObjective_WithoutFogSystem_CompletesMission()
         {
             (
                 GameRoot game,
@@ -381,7 +381,9 @@ namespace Rebellion.Tests.Game.Missions
             game.AttachNode(mission, enemyPlanet);
             mission.Initiate(0);
 
-            Assert.DoesNotThrow(() => MissionSceneBuilder.RunToSuccess(mission, game));
+            MissionSceneBuilder.RunToSuccess(mission, game);
+
+            Assert.IsTrue(mission.IsComplete());
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/Game/Units/CapitalShipTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/Units/CapitalShipTests.cs
@@ -587,80 +587,20 @@ namespace Rebellion.Tests.Game.Units
         }
 
         [Test]
-        public void WeaponRecharge_DefaultCapitalShip_ReturnsExpectedValue()
+        public void ConfiguredCapitalShip_PreservesCombatAndMovementStatistics()
         {
             Assert.AreEqual(12, _capitalShip.WeaponRecharge);
-        }
-
-        [Test]
-        public void Bombardment_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(20, _capitalShip.Bombardment);
-        }
-
-        [Test]
-        public void HullStrength_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(100, _capitalShip.CurrentHullStrength);
-        }
-
-        [Test]
-        public void DamageControl_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(10, _capitalShip.DamageControl);
-        }
-
-        [Test]
-        public void MaxShieldStrength_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(50, _capitalShip.MaxShieldStrength);
-        }
-
-        [Test]
-        public void ShieldRechargeRate_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(5, _capitalShip.ShieldRechargeRate);
-        }
-
-        [Test]
-        public void Hyperdrive_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(2, _capitalShip.Hyperdrive);
-        }
-
-        [Test]
-        public void SublightSpeed_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(15, _capitalShip.SublightSpeed);
-        }
-
-        [Test]
-        public void Maneuverability_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(8, _capitalShip.Maneuverability);
-        }
-
-        [Test]
-        public void TractorBeamPower_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(7, _capitalShip.TractorBeamPower);
-        }
-
-        [Test]
-        public void TractorBeamRange_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(3, _capitalShip.TractorBeamnRange);
-        }
-
-        [Test]
-        public void HasGravityWell_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.IsFalse(_capitalShip.HasGravityWell);
-        }
-
-        [Test]
-        public void DetectionRating_DefaultCapitalShip_ReturnsExpectedValue()
-        {
             Assert.AreEqual(25, _capitalShip.DetectionRating);
         }
 

--- a/Assets/Tests/EditMode/UnitTests/QuietGameLoggerSetup.cs
+++ b/Assets/Tests/EditMode/UnitTests/QuietGameLoggerSetup.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+using Rebellion.Util.Common;
+
+[SetUpFixture]
+public sealed class QuietGameLoggerSetup
+{
+    private GameLogger.LogLevel _originalMinimumLevel;
+
+    [OneTimeSetUp]
+    public void SuppressRoutineGameLogging()
+    {
+        _originalMinimumLevel = GameLogger.MinimumLevel;
+        GameLogger.SetMinimumLevel(GameLogger.LogLevel.Error);
+    }
+
+    [OneTimeTearDown]
+    public void RestoreGameLogging()
+    {
+        GameLogger.SetMinimumLevel(_originalMinimumLevel);
+    }
+}

--- a/Assets/Tests/EditMode/UnitTests/QuietGameLoggerSetup.cs.meta
+++ b/Assets/Tests/EditMode/UnitTests/QuietGameLoggerSetup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4219b451a73c44a1a8f13fa15ca5b4ea

--- a/Assets/Tests/EditMode/UnitTests/Systems/FogOfWarSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/FogOfWarSystemTests.cs
@@ -1836,12 +1836,9 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void CaptureSnapshot_EmptyPlanet_DoesNotCrash()
+        public void CaptureSnapshot_EmptyPlanet_CreatesPlanetSnapshot()
         {
-            Assert.DoesNotThrow(() =>
-            {
-                _fogSystem.CaptureSnapshot(_alliance, _tatooine, _outerRim, 10);
-            });
+            _fogSystem.CaptureSnapshot(_alliance, _tatooine, _outerRim, 10);
 
             PlanetSectorSnapshot sectorSnapshot = _alliance.Fog.Snapshots["OUTERRIM"];
             PlanetSnapshot snapshot = sectorSnapshot.Planets["TATOOINE"];

--- a/Assets/Tests/EditMode/UnitTests/Systems/ManufacturingSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/ManufacturingSystemTests.cs
@@ -122,7 +122,7 @@ namespace Rebellion.Tests.Systems
         }
 
         [Test]
-        public void ProcessTick_EmptyGame_DoesNotCrash()
+        public void ProcessTick_EmptyGame_ReturnsNoResults()
         {
             GameConfig config = TestContent.Data.GameConfig;
             GameRoot emptyGame = new GameRoot(config);
@@ -136,9 +136,9 @@ namespace Rebellion.Tests.Systems
                 )
             );
 
-            emptyManager.ProcessTick();
+            List<GameResult> results = emptyManager.ProcessTick();
 
-            Assert.Pass();
+            Assert.IsEmpty(results);
         }
 
         [Test]
@@ -3701,16 +3701,7 @@ namespace Rebellion.Tests.Systems
                 _coruscant.GetManufacturingQueue();
 
             Assert.IsNotNull(queue);
-            // Empty queue may not have the key yet - check both cases
-            if (queue.ContainsKey(ManufacturingType.Building))
-            {
-                Assert.AreEqual(0, queue[ManufacturingType.Building].Count);
-            }
-            else
-            {
-                // Key doesn't exist yet, which is fine for an empty queue
-                Assert.Pass();
-            }
+            Assert.IsEmpty(queue);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/Systems/MissionSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/MissionSystemTests.cs
@@ -141,7 +141,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void UpdateMission_CompletedParticipantParentedToMission_DoesNotThrow()
+        public void UpdateMission_CompletedParticipantParentedToMission_ReturnsParticipantToPlanet()
         {
             // Regression: officer parented to the mission (as happens after Initiate moves them
             // there) caused IsMovable() to return false and RequestMove to throw on teardown.
@@ -158,7 +158,10 @@ namespace Rebellion.Tests.Sectors
             while (!mission.IsComplete())
                 mission.IncrementProgress();
 
-            Assert.DoesNotThrow(() => system.UpdateMission(mission));
+            system.UpdateMission(mission);
+
+            Assert.AreSame(planet, officer.GetParent());
+            Assert.IsFalse(game.GetSceneNodesByType<StubMission>().Contains(mission));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/Systems/MovementSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/MovementSystemTests.cs
@@ -528,7 +528,7 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void RequestMove_WhenDestinationRejectsUnit_DoesNotThrow()
+        public void RequestMove_WhenDestinationRejectsUnit_LeavesUnitAtOriginWithoutMovement()
         {
             // Destination ownership changes after scene setup (e.g. enemy captures the planet).
             // RequestMove must not propagate the SceneAccessException — the unit stays at origin.
@@ -546,57 +546,11 @@ namespace Rebellion.Tests.Sectors
                 () => movement.RequestMove(officer, destination),
                 "RequestMove must not throw when the destination rejects the unit"
             );
-        }
-
-        [Test]
-        public void RequestMove_WhenDestinationRejectsUnit_UnitStaysAtOrigin()
-        {
-            (
-                GameRoot game,
-                Planet origin,
-                Planet destination,
-                Officer officer,
-                MovementSystem movement
-            ) = BuildScene();
-
-            destination.OwnerInstanceID = "rebels";
-
-            try
-            {
-                movement.RequestMove(officer, destination);
-            }
-            catch
-            { /* ignored for this assertion */
-            }
-
             Assert.AreEqual(
                 origin,
                 officer.GetParent(),
                 "Unit must remain at origin when destination rejects it"
             );
-        }
-
-        [Test]
-        public void RequestMove_WhenDestinationRejectsUnit_MovementStateNotSet()
-        {
-            (
-                GameRoot game,
-                Planet origin,
-                Planet destination,
-                Officer officer,
-                MovementSystem movement
-            ) = BuildScene();
-
-            destination.OwnerInstanceID = "rebels";
-
-            try
-            {
-                movement.RequestMove(officer, destination);
-            }
-            catch
-            { /* ignored for this assertion */
-            }
-
             Assert.IsNull(
                 officer.Movement,
                 "Movement state must not be set when the destination rejected the unit"

--- a/Assets/Tests/EditMode/UnitTests/Systems/SpaceCombatSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/SpaceCombatSystemTests.cs
@@ -1010,9 +1010,11 @@ namespace Rebellion.Tests.Systems
             game.AttachNode(allianceFleet, planet);
             SpaceCombatSystem manager = MakeSpaceCombat(game);
 
-            RunCombat(manager);
+            bool detected = RunCombat(manager);
 
-            Assert.Pass("Empty fleets should not cause combat");
+            Assert.IsFalse(detected);
+            Assert.IsFalse(empireFleet.IsInCombat);
+            Assert.IsFalse(allianceFleet.IsInCombat);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/UI/Components/ContextMenu/ContextMenuViewTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/Components/ContextMenu/ContextMenuViewTests.cs
@@ -73,24 +73,6 @@ namespace Rebellion.Tests.UI.Components.ContextMenu
         }
 
         [Test]
-        public void Visuals_Constructor_StoresCommandColors()
-        {
-            Color32 enabled = new Color32(1, 2, 3, 4);
-            Color32 active = new Color32(5, 6, 7, 8);
-            Color32 disabled = new Color32(9, 10, 11, 12);
-
-            ContextMenuView.ContextMenuVisuals visuals = new ContextMenuView.ContextMenuVisuals(
-                enabled,
-                active,
-                disabled
-            );
-
-            Assert.AreEqual(enabled, visuals.EnabledColor);
-            Assert.AreEqual(active, visuals.ActiveColor);
-            Assert.AreEqual(disabled, visuals.DisabledColor);
-        }
-
-        [Test]
         public void Metrics_Dimensions_CalculatePanelWidthAndHeight()
         {
             ContextMenuMetrics metrics = new ContextMenuMetrics(20, 30, 2);

--- a/Assets/Tests/EditMode/UnitTests/UI/Components/DragControllerTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/Components/DragControllerTests.cs
@@ -34,28 +34,6 @@ namespace Rebellion.Tests.UI.Components
         }
 
         [Test]
-        public void DragRequest_Source_StoresSource()
-        {
-            object source = new object();
-
-            DragRequest request = new DragRequest(source);
-
-            Assert.AreSame(source, request.Source);
-        }
-
-        [Test]
-        public void DragPreview_Constructor_StoresPresentationValues()
-        {
-            DragPreview preview = new DragPreview(_texture, 10, 20, 3, 4);
-
-            Assert.AreSame(_texture, preview.Texture);
-            Assert.AreEqual(10, preview.Width);
-            Assert.AreEqual(20, preview.Height);
-            Assert.AreEqual(3, preview.OffsetX);
-            Assert.AreEqual(4, preview.OffsetY);
-        }
-
-        [Test]
         public void DragPreview_MultipleImages_PreservesImageBoundsAndHotspot()
         {
             Rect uvRect = new Rect(0.25f, 0f, 0.5f, 1f);

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/OptionsMenu/OptionsMenuViewTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/OptionsMenu/OptionsMenuViewTests.cs
@@ -623,9 +623,12 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 .GetComponentsInChildren<TextMeshProUGUI>(true)
                 .Single(text => text.name == "SlotName0");
 
-            typeof(OptionsSaveListView)
-                .GetMethod("BeginRename", BindingFlags.Instance | BindingFlags.NonPublic)
-                .Invoke(_saveListView, new object[] { 0 });
+            Button rowButton = _root
+                .GetComponentsInChildren<Image>(true)
+                .Single(image => image.name == "SlotRow0")
+                .GetComponent<Button>();
+            rowButton.onClick.Invoke();
+            rowButton.onClick.Invoke();
             _view.Render(data);
 
             Assert.IsFalse(renderedName.gameObject.activeSelf);
@@ -734,9 +737,7 @@ namespace Rebellion.Tests.UI.SceneUI.OptionsMenu
                 false
             );
 
-            typeof(OptionsMenuView)
-                .GetMethod("RenderFooter", BindingFlags.Instance | BindingFlags.NonPublic)
-                .Invoke(_view, new object[] { data });
+            _view.Render(data);
 
             Button backToGame = GetField<Button>("_backToGameButton");
             Button mainMenu = GetField<Button>("_mainMenuButton");

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Bookmarks/BookmarkEntryTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Bookmarks/BookmarkEntryTests.cs
@@ -7,19 +7,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Bookmarks
     public class BookmarkEntryTests
     {
         [Test]
-        public void Constructor_CompleteValues_StoresBookmarkIdentityAndPlacement()
-        {
-            GalaxyMapPlanet planet = CreatePlanet("planet-1", "Coruscant");
-
-            BookmarkEntry entry = new BookmarkEntry(PlanetIcon.Fleet, 120, 240, planet);
-
-            Assert.AreEqual(PlanetIcon.Fleet, entry.Icon);
-            Assert.AreEqual(120, entry.X);
-            Assert.AreEqual(240, entry.Y);
-            Assert.AreSame(planet, entry.Planet);
-        }
-
-        [Test]
         public void ReconcilePlanet_FreshProjection_ReplacesPlanetOnly()
         {
             GalaxyMapPlanet original = CreatePlanet("planet-1", "Coruscant");

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/ContextMenus/StrategyContextMenuProviderTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/ContextMenus/StrategyContextMenuProviderTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.EventSystems;
 
 namespace Rebellion.Tests.UI.SceneUI.StrategyView.ContextMenus
 {
@@ -18,51 +17,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.ContextMenus
         }
 
         [Test]
-        public void ProviderContext_CompleteInvocation_StoresAllValues()
-        {
-            UIWindow window = CreateWindow();
-            StrategyContextMenuLayout layout = new StrategyContextMenuLayout(1, 2, 3, 4, 5, 6, 7);
-            PointerEventData eventData = new PointerEventData(null);
-
-            StrategyContextMenuProviderContext context = new StrategyContextMenuProviderContext(
-                window,
-                layout,
-                eventData,
-                8,
-                9
-            );
-
-            Assert.AreSame(window, context.Window);
-            Assert.AreEqual(1, context.Layout.FacilityMenuWidth);
-            Assert.AreSame(eventData, context.EventData);
-            Assert.AreEqual(8, context.X);
-            Assert.AreEqual(9, context.Y);
-        }
-
-        [Test]
-        public void Layout_CompleteGeometry_StoresEveryWidth()
-        {
-            StrategyContextMenuLayout layout = new StrategyContextMenuLayout(
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17
-            );
-
-            Assert.AreEqual(11, layout.FacilityMenuWidth);
-            Assert.AreEqual(12, layout.FleetMenuWidth);
-            Assert.AreEqual(13, layout.FleetBombardmentMenuWidth);
-            Assert.AreEqual(14, layout.PlanetSectorMenuWidth);
-            Assert.AreEqual(15, layout.DefenseMenuWidth);
-            Assert.AreEqual(16, layout.MissionsMenuWidth);
-            Assert.AreEqual(17, layout.FallbackMenuWidth);
-        }
-
-        [Test]
-        public void MenuData_CommandSource_CopiesCommandsAndStoresPlacement()
+        public void MenuData_CommandSourceChange_PreservesSnapshot()
         {
             UIWindow window = CreateWindow();
             StrategyMenuCommand command = new StrategyMenuCommand(
@@ -81,10 +36,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.ContextMenus
             );
             commands.Clear();
 
-            Assert.AreSame(window, data.Window);
-            Assert.AreEqual(20, data.X);
-            Assert.AreEqual(30, data.Y);
-            Assert.AreEqual(140, data.Width);
             Assert.AreEqual(1, data.Commands.Count);
             Assert.AreSame(command, data.Commands[0]);
         }

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Finder/FinderWindowRenderDataTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Finder/FinderWindowRenderDataTests.cs
@@ -37,36 +37,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Finder
         }
 
         [Test]
-        public void DialogButtonRenderData_Values_PreservesPresentation()
-        {
-            RectInt sourceRect = new RectInt(1, 2, 3, 4);
-
-            FinderWindowDialogButtonRenderData data = new FinderWindowDialogButtonRenderData(
-                FinderWindowCommand.Target,
-                _firstTexture,
-                _secondTexture,
-                sourceRect
-            );
-
-            Assert.AreEqual(FinderWindowCommand.Target, data.Command);
-            Assert.AreSame(_firstTexture, data.Texture);
-            Assert.AreSame(_secondTexture, data.PressedTexture);
-            Assert.AreEqual(sourceRect, data.SourceRect);
-        }
-
-        [Test]
-        public void TabRenderData_Textures_PreservesPresentation()
-        {
-            FinderWindowTabRenderData data = new FinderWindowTabRenderData(
-                _firstTexture,
-                _secondTexture
-            );
-
-            Assert.AreSame(_firstTexture, data.Texture);
-            Assert.AreSame(_secondTexture, data.PressedTexture);
-        }
-
-        [Test]
         public void RowRenderData_SourceChanges_PreservesNormalizedSnapshot()
         {
             string[] counts = { "1", "2" };

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Fleet/FleetWindowRenderDataTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Fleet/FleetWindowRenderDataTests.cs
@@ -46,7 +46,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
         }
 
         [Test]
-        public void FleetListRowRenderData_Values_PreservesNormalizedPresentation()
+        public void FleetListRowRenderData_NullName_NormalizesToEmptyString()
         {
             FleetListRowRenderData data = new FleetListRowRenderData(
                 null,
@@ -60,27 +60,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             );
 
             Assert.AreEqual(string.Empty, data.Name);
-            Assert.AreSame(_firstTexture, data.IconTexture);
-            Assert.AreSame(_secondTexture, data.EnrouteOverlayTexture);
-            Assert.AreSame(_firstTexture, data.DamagedOverlayTexture);
-            Assert.AreSame(_secondTexture, data.StarfighterBadgeTexture);
-            Assert.AreSame(_firstTexture, data.TroopBadgeTexture);
-            Assert.AreSame(_secondTexture, data.PersonnelBadgeTexture);
-            Assert.AreSame(_firstTexture, data.SelectionTexture);
-        }
-
-        [Test]
-        public void FleetWindowTabRenderData_Values_PreservesPresentation()
-        {
-            FleetWindowTabRenderData data = new FleetWindowTabRenderData(
-                FleetWindowTab.Regiments,
-                _firstTexture,
-                _secondTexture
-            );
-
-            Assert.AreEqual(FleetWindowTab.Regiments, data.Tab);
-            Assert.AreSame(_firstTexture, data.Texture);
-            Assert.AreSame(_secondTexture, data.PressedTexture);
         }
 
         [TestCase(0)]

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayRenderDataTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationDisplayRenderDataTests.cs
@@ -26,24 +26,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
-        public void State_Values_PreservesInteractionState()
-        {
-            GalacticInformationDisplayState state = new GalacticInformationDisplayState(
-                true,
-                2,
-                3,
-                true,
-                GalacticInformationFilterMode.FleetWaypoints
-            );
-
-            Assert.IsTrue(state.Visible);
-            Assert.AreEqual(2, state.ActiveCategoryIndex);
-            Assert.AreEqual(3, state.HoveredFilterIndex);
-            Assert.IsTrue(state.DisplayOffHovered);
-            Assert.AreEqual(GalacticInformationFilterMode.FleetWaypoints, state.SelectedFilterMode);
-        }
-
-        [Test]
         public void Display_SourceChanges_PreservesReadOnlyCategorySnapshot()
         {
             GalacticInformationCategoryRenderData category = CreateCategory();
@@ -87,47 +69,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
-        public void Category_Values_PreservesCompletePresentation()
-        {
-            GalacticInformationSubmenuRenderData submenu = new GalacticInformationSubmenuRenderData(
-                true,
-                new RectInt(1, 2, 3, 4),
-                Color.black,
-                null,
-                null
-            );
-            GalacticInformationImageRenderData icon = new GalacticInformationImageRenderData(
-                _firstTexture,
-                new RectInt(5, 6, 7, 8)
-            );
-            GalacticInformationImageRenderData arrow = new GalacticInformationImageRenderData(
-                _secondTexture,
-                new RectInt(9, 10, 11, 12)
-            );
-            GalacticInformationTextRenderData label = new GalacticInformationTextRenderData(
-                "Category",
-                Color.green,
-                new RectInt(13, 14, 15, 16)
-            );
-
-            GalacticInformationCategoryRenderData data = new GalacticInformationCategoryRenderData(
-                true,
-                new RectInt(17, 18, 19, 20),
-                icon,
-                arrow,
-                label,
-                submenu
-            );
-
-            Assert.IsTrue(data.Visible);
-            Assert.AreEqual(new RectInt(17, 18, 19, 20), data.HitBounds);
-            Assert.AreSame(_firstTexture, data.Icon.Texture);
-            Assert.AreSame(_secondTexture, data.Arrow.Texture);
-            Assert.AreEqual("Category", data.Label.Text);
-            Assert.AreSame(submenu, data.Submenu);
-        }
-
-        [Test]
         public void Submenu_SourceChanges_PreservesReadOnlyFilterSnapshot()
         {
             GalacticInformationFilterRenderData filter = new GalacticInformationFilterRenderData(
@@ -159,7 +100,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
-        public void Filter_Values_PreservesCompletePresentation()
+        public void Filter_NullLabelText_NormalizesToEmptyString()
         {
             GalacticInformationImageRenderData icon = new GalacticInformationImageRenderData(
                 _firstTexture,
@@ -184,37 +125,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
                 label
             );
 
-            Assert.AreEqual(GalacticInformationFilterMode.FleetsEnroute, data.Mode);
-            Assert.IsTrue(data.Visible);
-            Assert.AreEqual(new RectInt(9, 10, 11, 12), data.HitBounds);
-            Assert.AreSame(_secondTexture, data.CheckMark.Texture);
-            Assert.AreEqual(new RectInt(-3, 2, 3, 4), data.CheckMark.Bounds);
-            Assert.AreSame(_firstTexture, data.Icon.Texture);
             Assert.AreEqual(string.Empty, data.Label.Text);
-            Assert.AreEqual(Color.cyan, data.Label.Color);
-            Assert.AreEqual(new RectInt(5, 6, 7, 8), data.Label.Bounds);
-        }
-
-        [Test]
-        public void TextRow_Values_PreservesLabelPresentation()
-        {
-            GalacticInformationTextRenderData label = new GalacticInformationTextRenderData(
-                "Display Off",
-                Color.yellow,
-                new RectInt(1, 2, 3, 4)
-            );
-
-            GalacticInformationTextRowRenderData data = new GalacticInformationTextRowRenderData(
-                true,
-                new RectInt(5, 6, 7, 8),
-                default,
-                label
-            );
-
-            Assert.IsTrue(data.Visible);
-            Assert.AreEqual(new RectInt(5, 6, 7, 8), data.HitBounds);
-            Assert.AreEqual("Display Off", data.Label.Text);
-            Assert.AreEqual(Color.yellow, data.Label.Color);
         }
 
         [Test]
@@ -234,32 +145,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             Assert.AreSame(_firstTexture, data.Textures[0]);
             Assert.AreSame(_secondTexture, data.Textures[1]);
             Assert.Throws<NotSupportedException>(() => ((IList<Texture2D>)data.Textures)[0] = null);
-        }
-
-        [Test]
-        public void Legend_Values_PreservesCompletePresentation()
-        {
-            GalacticInformationFrameRenderData frame = new GalacticInformationFrameRenderData(
-                10,
-                20,
-                null
-            );
-
-            GalacticInformationLegendRenderData data = new GalacticInformationLegendRenderData(
-                new RectInt(1, 2, 3, 4),
-                _firstTexture,
-                frame,
-                new RectInt(5, 6, 7, 8),
-                _secondTexture,
-                _firstTexture
-            );
-
-            Assert.AreEqual(new RectInt(1, 2, 3, 4), data.Bounds);
-            Assert.AreSame(_firstTexture, data.Texture);
-            Assert.AreSame(frame, data.Frame);
-            Assert.AreEqual(new RectInt(5, 6, 7, 8), data.CloseBounds);
-            Assert.AreSame(_secondTexture, data.CloseTexture);
-            Assert.AreSame(_firstTexture, data.ClosePressedTexture);
         }
 
         private GalacticInformationCategoryRenderData CreateCategory()

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationFilterEvaluatorTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/GalaxyMap/GalacticInformationFilterEvaluatorTests.cs
@@ -25,20 +25,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             _game.GetFactions().Add(new Faction { InstanceID = _opponentFactionId });
         }
 
-        [Test]
-        public void Marker_Values_PreservesEvaluationResult()
-        {
-            GalacticInformationMarker marker = new GalacticInformationMarker(
-                2,
-                _playerFactionId,
-                true
-            );
-
-            Assert.AreEqual(2, marker.Index);
-            Assert.AreEqual(_playerFactionId, marker.FactionInstanceId);
-            Assert.IsTrue(marker.Mixed);
-        }
-
         [TestCase(true)]
         [TestCase(false)]
         public void Evaluate_MissingInput_ReturnsLowestUnownedMarker(bool missingPlanet)

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapRenderDataTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/GalaxyMap/GalaxyMapRenderDataTests.cs
@@ -26,7 +26,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
         }
 
         [Test]
-        public void ActiveFilterLabel_NullText_ReturnsInvisibleNormalizedPresentation()
+        public void ActiveFilterLabel_NullText_ReturnsInvisibleEmptyLabel()
         {
             GalaxyMapActiveFilterLabelRenderData data = new GalaxyMapActiveFilterLabelRenderData(
                 null,
@@ -37,13 +37,10 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
 
             Assert.IsFalse(data.Visible);
             Assert.AreEqual(string.Empty, data.Text);
-            Assert.AreEqual(Color.red, data.Color);
-            Assert.AreEqual(new RectInt(1, 2, 3, 4), data.Bounds);
-            Assert.AreEqual(5, data.FontSize);
         }
 
         [Test]
-        public void Star_Values_PreservesNormalizedPresentation()
+        public void Star_NullPlanetIdentifier_NormalizesToEmptyString()
         {
             GalaxyMapStarRenderData data = new GalaxyMapStarRenderData(
                 null,
@@ -54,10 +51,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.GalaxyMap
             );
 
             Assert.AreEqual(string.Empty, data.PlanetInstanceId);
-            Assert.AreEqual(1, data.SourceX);
-            Assert.AreEqual(2, data.SourceY);
-            Assert.AreSame(_firstTexture, data.StarTexture);
-            Assert.AreSame(_secondTexture, data.HeadquartersTexture);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewDataTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Hud/StrategyAdvisorViewDataTests.cs
@@ -9,34 +9,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Hud
     public class StrategyAdvisorViewDataTests
     {
         [Test]
-        public void ViewData_CompletePresentation_StoresAllValues()
-        {
-            Texture2D protocol = new Texture2D(4, 4);
-            Texture2D droid = new Texture2D(4, 4);
-            RectInt protocolBounds = new RectInt(10, 20, 30, 40);
-            RectInt droidBounds = new RectInt(50, 60, 70, 80);
-
-            StrategyAdvisorViewData data = new StrategyAdvisorViewData(
-                true,
-                protocol,
-                droid,
-                protocolBounds,
-                droidBounds,
-                0.25f
-            );
-
-            Assert.IsTrue(data.Visible);
-            Assert.AreSame(protocol, data.ProtocolIdleTexture);
-            Assert.AreSame(droid, data.DroidIdleTexture);
-            Assert.AreEqual(protocolBounds, data.ProtocolBounds);
-            Assert.AreEqual(droidBounds, data.DroidBounds);
-            Assert.AreEqual(0.25f, data.FrameIntervalSeconds);
-
-            UnityEngine.Object.DestroyImmediate(droid);
-            UnityEngine.Object.DestroyImmediate(protocol);
-        }
-
-        [Test]
         public void AnimationData_NullFrames_UsesEmptySnapshot()
         {
             StrategyAdvisorAnimationViewData data = new StrategyAdvisorAnimationViewData(

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Overlay/StrategyOverlayRenderDataTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Overlay/StrategyOverlayRenderDataTests.cs
@@ -28,36 +28,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Overlay
         }
 
         [Test]
-        public void Constructor_CompletePresentation_StoresAllValues()
-        {
-            Texture2D texture = new Texture2D(4, 4);
-            RectInt frameBounds = new RectInt(10, 20, 100, 80);
-            RectInt imageBounds = new RectInt(30, 40, 20, 16);
-
-            StrategyOverlayRenderData data = new StrategyOverlayRenderData(
-                frameBounds,
-                texture,
-                imageBounds
-            );
-
-            Assert.AreEqual(frameBounds, data.DragFrameBounds);
-            Assert.AreSame(texture, data.DragImageTexture);
-            Assert.AreEqual(imageBounds, data.DragImageBounds);
-
-            UnityEngine.Object.DestroyImmediate(texture);
-        }
-
-        [Test]
-        public void Constructor_EmptyPresentation_StoresAbsentValues()
-        {
-            StrategyOverlayRenderData data = new StrategyOverlayRenderData(null, null, null);
-
-            Assert.IsNull(data.DragFrameBounds);
-            Assert.IsNull(data.DragImageTexture);
-            Assert.IsNull(data.DragImageBounds);
-        }
-
-        [Test]
         public void Constructor_MultipleDragImages_StoresPreviewAndPointerPosition()
         {
             Texture2D texture = new Texture2D(4, 4);

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowRenderDataTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowRenderDataTests.cs
@@ -72,33 +72,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
         }
 
         [Test]
-        public void Planet_Values_PreservesCompletePresentation()
-        {
-            PlanetSectorPlanetRenderData data = CreatePlanetData(_bar, _bar, _bar);
-
-            Assert.AreEqual(3, data.PlanetIndex);
-            Assert.AreEqual(new Vector2Int(4, 5), data.GalaxyOffset);
-            Assert.AreSame(_texture, data.PlanetTexture);
-            Assert.AreSame(_texture, data.UprisingTexture);
-            Assert.AreSame(_texture, data.FacilityTexture);
-            Assert.AreSame(_texture, data.FacilityPressedTexture);
-            Assert.AreSame(_texture, data.DefenseTexture);
-            Assert.AreSame(_texture, data.DefensePressedTexture);
-            Assert.AreSame(_texture, data.FleetTexture);
-            Assert.AreSame(_texture, data.FleetPressedTexture);
-            Assert.AreSame(_texture, data.MissionTexture);
-            Assert.AreSame(_texture, data.MissionPressedTexture);
-            Assert.AreSame(_texture, data.HeadquartersTexture);
-            Assert.AreEqual("Planet", data.Name);
-            Assert.AreEqual(new Color32(1, 2, 3, 4), data.NameColor);
-            Assert.AreEqual(PlanetIcon.Fleet, data.SelectedIcon);
-            Assert.AreEqual(PlanetIcon.Mission, data.HoveredIcon);
-            Assert.AreSame(_bar, data.EnergyBar);
-            Assert.AreSame(_bar, data.RawResourceBar);
-            Assert.AreSame(_bar, data.SupportBar);
-        }
-
-        [Test]
         public void Planet_NullName_ReturnsEmptyName()
         {
             PlanetSectorPlanetRenderData data = new PlanetSectorPlanetRenderData(
@@ -125,32 +98,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
             );
 
             Assert.AreEqual(string.Empty, data.Name);
-        }
-
-        [Test]
-        public void Bar_Values_PreservesCompletePresentation()
-        {
-            Assert.IsTrue(_bar.Visible);
-            Assert.AreEqual(4, _bar.CellCount);
-            Assert.AreEqual(2, _bar.LitCells);
-            Assert.AreEqual(0.5f, _bar.FillRatio);
-            Assert.AreEqual(new Color32(1, 2, 3, 4), _bar.FillColor);
-            Assert.AreEqual(new Color32(5, 6, 7, 8), _bar.EmptyColor);
-            Assert.AreEqual(new Color32(9, 10, 11, 12), _bar.BackgroundColor);
-        }
-
-        [Test]
-        public void Element_Values_PreservesSemanticIdentity()
-        {
-            PlanetSectorWindowElement data = new PlanetSectorWindowElement(
-                2,
-                PlanetIcon.Defense,
-                true
-            );
-
-            Assert.AreEqual(2, data.PlanetIndex);
-            Assert.AreEqual(PlanetIcon.Defense, data.Icon);
-            Assert.IsTrue(data.PlanetImage);
         }
 
         private PlanetSectorPlanetRenderData CreatePlanetData(

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Shared/ConfirmDialogWindowRenderDataTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Shared/ConfirmDialogWindowRenderDataTests.cs
@@ -17,7 +17,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
         }
 
         [Test]
-        public void Constructor_CompletePresentation_StoresValuesAndCopiesLines()
+        public void Constructor_SourceLinesChange_PreservesReadOnlySnapshot()
         {
             Texture2D background = new Texture2D(4, 4);
             Texture2D title = new Texture2D(2, 2);
@@ -32,10 +32,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
             );
             sourceLines[0] = "Changed";
 
-            Assert.AreEqual(10, data.X);
-            Assert.AreEqual(20, data.Y);
-            Assert.AreSame(background, data.BackgroundTexture);
-            Assert.AreSame(title, data.TitleTexture);
             CollectionAssert.AreEqual(new[] { "Confirm?", "Coruscant" }, data.Lines);
             Assert.Throws<NotSupportedException>(() =>
                 ((IList<string>)data.Lines).Add("Additional")

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Shared/StrategyUnitCardRenderDataTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Shared/StrategyUnitCardRenderDataTests.cs
@@ -7,7 +7,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
     public sealed class StrategyUnitCardRenderDataTests
     {
         [Test]
-        public void Constructor_NullName_NormalizesAndPreservesFlags()
+        public void Constructor_NullName_NormalizesName()
         {
             StrategyUnitCardRenderData card = new StrategyUnitCardRenderData(
                 null,
@@ -28,11 +28,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Shared
             );
 
             Assert.AreEqual(string.Empty, card.Name);
-            Assert.AreEqual((Color32)Color.green, card.NameColor);
-            Assert.IsTrue(card.ShowName);
-            Assert.IsTrue(card.UseAlternateNameLayout);
-            Assert.AreEqual(4, card.EntityFrameYOffset);
-            Assert.IsTrue(card.CanDrag);
         }
     }
 }

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Status/StatusWindowSessionTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Status/StatusWindowSessionTests.cs
@@ -38,24 +38,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Status
         }
 
         [Test]
-        public void Constructor_CompleteTarget_StoresWindowTargetAndAvailability()
-        {
-            UIWindow window = CreateWindow();
-            Officer officer = new Officer { InstanceID = "officer" };
-            StrategyStatusTarget target = new StrategyStatusTarget(
-                null,
-                officer,
-                ManufacturingType.Troop
-            );
-
-            StatusWindowSession session = new StatusWindowSession(window, target, true, _ => null);
-
-            Assert.AreSame(window, session.Window);
-            Assert.AreSame(target, session.Target);
-            Assert.IsTrue(session.InfoDisabled);
-        }
-
-        [Test]
         public void Reconcile_SnapshotBackedTarget_RebindsPlanetAndItemByIdentity()
         {
             UIWindow window = CreateWindow();

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Targeting/StrategyMissionTargetTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Targeting/StrategyMissionTargetTests.cs
@@ -12,19 +12,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Targeting
     public class StrategyMissionTargetTests
     {
         [Test]
-        public void Constructor_PlanetAndItem_StoresTargetState()
-        {
-            GalaxyMapPlanet planet = CreateMapPlanet("planet", "player");
-            Officer officer = new Officer();
-
-            StrategyMissionTarget target = new StrategyMissionTarget(planet, officer);
-
-            Assert.AreSame(planet, target.Planet);
-            Assert.AreSame(officer, target.Item);
-            Assert.AreSame(target, target.Target);
-        }
-
-        [Test]
         public void GetMoveDestination_MissingPlanet_ReturnsNull()
         {
             StrategyMissionTarget target = new StrategyMissionTarget(null, new Officer());

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Targeting/StrategyWindowTargetingSourceTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Targeting/StrategyWindowTargetingSourceTests.cs
@@ -19,7 +19,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Targeting
         }
 
         [Test]
-        public void Constructor_CompleteState_CopiesItemsAndStoresValues()
+        public void Constructor_SourceItemsChange_PreservesSnapshot()
         {
             UIWindow window = CreateWindow();
             Officer officer = new Officer();
@@ -34,10 +34,6 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Targeting
             );
             items.Clear();
 
-            Assert.AreSame(window, source.Window);
-            Assert.AreEqual(StrategyMenuAction.Move, source.Action);
-            Assert.AreEqual(12, source.SourceX);
-            Assert.AreEqual(34, source.SourceY);
             Assert.AreEqual(1, source.Items.Count);
             Assert.AreSame(officer, source.Items[0]);
         }


### PR DESCRIPTION
## Summary

- Removing flaky, conditional-pass, constructor-echo, and property-echo tests
- Replacing no-throw assertions and private-method calls with observable behavioral assertions
- Consolidating repetitive coverage while retaining validation, normalization, snapshots, mappings, and gameplay outcomes
- Suppressing routine game logging during tests while preserving error-path logging

## Validation

- Passing all 4,740 Unity EditMode tests
- Passing analyzer tests with 6 of 6 successful
- Producing zero lint diagnostics
- Passing formatting, style, member-order, and diff checks