### PR TITLE
Allowing Waypoint Movement Cancellation

### DIFF
--- a/Assets/Scripts/Game/Movement/MovementState.cs
+++ b/Assets/Scripts/Game/Movement/MovementState.cs
@@ -35,6 +35,16 @@ namespace Rebellion.Game.Movement
         public string SourceEventInstanceID { get; set; }
 
         /// <summary>
+        /// Identifies the planet from which the current transit leg departed.
+        /// </summary>
+        public string OriginPlanetInstanceID { get; set; }
+
+        /// <summary>
+        /// Indicates that the current transit leg was started by a waypoint route.
+        /// </summary>
+        public bool IsWaypointLeg { get; set; }
+
+        /// <summary>
         /// Position at the start of transit (origin planet coordinates).
         /// Used for interpolating position during transit.
         /// </summary>
@@ -85,6 +95,8 @@ namespace Rebellion.Game.Movement
                 TicksElapsed = TicksElapsed,
                 MovementGroupID = MovementGroupID,
                 SourceEventInstanceID = SourceEventInstanceID,
+                OriginPlanetInstanceID = OriginPlanetInstanceID,
+                IsWaypointLeg = IsWaypointLeg,
                 OriginPositionX = OriginPositionX,
                 OriginPositionY = OriginPositionY,
                 CurrentPositionX = CurrentPositionX,

--- a/Assets/Scripts/Systems/MovementSystem.cs
+++ b/Assets/Scripts/Systems/MovementSystem.cs
@@ -383,6 +383,7 @@ namespace Rebellion.Systems
                 TransitTicks = transitTicks,
                 TicksElapsed = 0,
                 MovementGroupID = Guid.NewGuid().ToString("N"),
+                OriginPlanetInstanceID = origin.InstanceID,
                 OriginPosition = origin.GetPosition(),
                 CurrentPosition = origin.GetPosition(),
             };
@@ -835,32 +836,117 @@ namespace Rebellion.Systems
                 return false;
             }
 
+            foreach (Fleet fleet in fleets)
+                fleet.Movement.IsWaypointLeg = true;
+
             ResultsProduced?.Invoke(results);
             return true;
         }
 
         /// <summary>
-        /// Clears queued waypoint continuation without changing an active movement leg.
+        /// Cancels waypoint routes, returning fleets in transit to their departure planets.
         /// </summary>
         /// <param name="items">The selected fleets or their visible snapshots.</param>
         /// <param name="ownerInstanceId">The faction authorized to command the fleets.</param>
-        /// <returns>True when at least one waypoint was removed.</returns>
-        public bool ClearFleetWaypoints(IReadOnlyList<ISceneNode> items, string ownerInstanceId)
+        /// <returns>True when at least one waypoint route was canceled.</returns>
+        public bool CancelFleetWaypointMoves(
+            IReadOnlyList<ISceneNode> items,
+            string ownerInstanceId
+        )
         {
             if (!TryResolveControlledFleets(items, ownerInstanceId, out List<Fleet> fleets))
                 return false;
 
-            bool cleared = false;
-            foreach (Fleet fleet in fleets)
-            {
-                if (!fleet.HasWaypoints())
-                    continue;
+            List<Fleet> routedFleets = fleets.Where(fleet => fleet.HasWaypoints()).ToList();
+            if (routedFleets.Count == 0)
+                return false;
 
-                fleet.Waypoints.Clear();
-                cleared = true;
+            Dictionary<Fleet, Planet> returnDestinations = new Dictionary<Fleet, Planet>();
+            foreach (
+                Fleet fleet in routedFleets.Where(fleet => fleet.Movement?.IsWaypointLeg == true)
+            )
+            {
+                Planet origin = ResolveWaypointOrigin(fleet.Movement);
+                if (origin?.IsDestroyed != false)
+                    return false;
+
+                returnDestinations.Add(fleet, origin);
             }
 
-            return cleared;
+            foreach (Fleet fleet in routedFleets)
+            {
+                fleet.Waypoints.Clear();
+                if (returnDestinations.TryGetValue(fleet, out Planet origin))
+                    ReturnFleetToWaypointOrigin(fleet, origin);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Resolves the departure planet recorded for a waypoint leg, including movement loaded
+        /// from saves created before departure identifiers were persisted.
+        /// </summary>
+        /// <param name="movement">The active waypoint movement.</param>
+        /// <returns>The unique live departure planet, or null when it cannot be resolved.</returns>
+        private Planet ResolveWaypointOrigin(MovementState movement)
+        {
+            if (movement == null)
+                return null;
+
+            Planet recordedOrigin = _game.GetSceneNodeByInstanceID<Planet>(
+                movement.OriginPlanetInstanceID
+            );
+            if (recordedOrigin != null)
+                return recordedOrigin;
+
+            List<Planet> matchingPlanets = _game
+                .GetSceneNodesByType<Planet>()
+                .Where(planet => planet.GetPosition() == movement.OriginPosition)
+                .Take(2)
+                .ToList();
+            return matchingPlanets.Count == 1 ? matchingPlanets[0] : null;
+        }
+
+        /// <summary>
+        /// Reverses an active waypoint leg from its current position to its departure planet.
+        /// </summary>
+        /// <param name="fleet">The fleet whose active waypoint leg is being canceled.</param>
+        /// <param name="origin">The planet from which that leg departed.</param>
+        private void ReturnFleetToWaypointOrigin(Fleet fleet, Planet origin)
+        {
+            MovementState canceledMovement = fleet.Movement;
+            Point currentPosition = canceledMovement.CurrentPosition;
+            Planet canceledDestination = fleet.GetParentOfType<Planet>();
+
+            _game.MoveNode(fleet, origin);
+            fleet.SetPosition(currentPosition);
+
+            if (currentPosition == origin.GetPosition())
+            {
+                fleet.Movement = null;
+            }
+            else
+            {
+                fleet.Movement = new MovementState
+                {
+                    TransitTicks = CalculateTransitTicks(
+                        fleet,
+                        currentPosition,
+                        origin,
+                        sameSector: IsSameSector(canceledDestination, origin)
+                    ),
+                    TicksElapsed = 0,
+                    MovementGroupID = canceledMovement.MovementGroupID,
+                    SourceEventInstanceID = canceledMovement.SourceEventInstanceID,
+                    OriginPlanetInstanceID = canceledDestination?.InstanceID,
+                    IsWaypointLeg = false,
+                    OriginPosition = currentPosition,
+                    CurrentPosition = currentPosition,
+                };
+            }
+
+            RetargetInTransitFleetJoiners(fleet, origin);
         }
 
         /// <summary>
@@ -2109,6 +2195,8 @@ namespace Rebellion.Systems
                 );
                 if (!accepted)
                     fleet.Waypoints.Clear();
+                else
+                    fleet.Movement.IsWaypointLeg = true;
                 return;
             }
         }
@@ -2796,6 +2884,7 @@ namespace Rebellion.Systems
                 TicksElapsed = 0,
                 MovementGroupID = movementGroupID,
                 SourceEventInstanceID = sourceEventInstanceID,
+                OriginPlanetInstanceID = originPlanet.InstanceID,
                 OriginPosition = originPosition,
                 CurrentPosition = originPosition,
             };
@@ -2859,6 +2948,7 @@ namespace Rebellion.Systems
                 TicksElapsed = 0,
                 MovementGroupID = movementGroupID,
                 SourceEventInstanceID = sourceEventInstanceID,
+                OriginPlanetInstanceID = movable.GetParentOfType<Planet>()?.InstanceID,
                 OriginPosition = currentPosition,
                 CurrentPosition = currentPosition,
             };

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowContextMenuBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowContextMenuBuilder.cs
@@ -97,7 +97,7 @@ internal static class FleetWindowContextMenuBuilder
         commands.Add(
             new StrategyMenuCommand(
                 StrategyMenuAction.WaypointMove,
-                hasWaypoints ? "Clear Waypoints" : "Waypoint Move",
+                hasWaypoints ? "Cancel Waypoint Move" : "Waypoint Move",
                 playerControlsItems && (canMove || allFleetsAreMoving || hasWaypoints)
             )
         );

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Fleet/FleetWindowController.cs
@@ -569,7 +569,7 @@ public sealed class FleetWindowController
             case StrategyMenuAction.WaypointMove
                 when source.Items?.OfType<Fleet>().Any(fleet => fleet.HasWaypoints()) == true:
                 targetingController.Cancel();
-                commandActions.ClearFleetWaypoints(source.Items);
+                commandActions.CancelFleetWaypointMoves(source.Items);
                 break;
             case StrategyMenuAction.CreateMission:
             case StrategyMenuAction.Move:

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowContextMenuBuilder.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowContextMenuBuilder.cs
@@ -120,7 +120,7 @@ internal static class PlanetSectorWindowContextMenuBuilder
             ),
             new StrategyMenuCommand(
                 StrategyMenuAction.WaypointMove,
-                hasWaypoints ? "Clear Waypoints" : "Waypoint Move",
+                hasWaypoints ? "Cancel Waypoint Move" : "Waypoint Move",
                 playerControlsFleets && (canCommandFleets || allFleetsAreMoving || hasWaypoints)
             ),
             StrategyBombardmentMenuBuilder.Build(

--- a/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowController.cs
@@ -678,7 +678,7 @@ public sealed class PlanetSectorWindowController
             case StrategyMenuAction.WaypointMove
                 when source.Items?.OfType<Fleet>().Any(fleet => fleet.HasWaypoints()) == true:
                 targetingController.Cancel();
-                commandActions.ClearFleetWaypoints(source.Items);
+                commandActions.CancelFleetWaypointMoves(source.Items);
                 break;
             case StrategyMenuAction.CreateMission:
             case StrategyMenuAction.Move:

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyWindowCommandActions.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Shared/StrategyWindowCommandActions.cs
@@ -68,11 +68,11 @@ public interface IStrategyWindowCommandActions
     bool TryUndoFleetWaypointPlan(StrategyWindowTargetingSource source);
 
     /// <summary>
-    /// Clears queued waypoint continuation for selected fleets without stopping active transit.
+    /// Cancels selected fleet waypoint routes and reverses any active waypoint legs.
     /// </summary>
     /// <param name="items">The selected fleets or their visible snapshots.</param>
-    /// <returns>True when at least one waypoint was cleared.</returns>
-    bool ClearFleetWaypoints(IReadOnlyList<ISceneNode> items);
+    /// <returns>True when at least one waypoint route was canceled.</returns>
+    bool CancelFleetWaypointMoves(IReadOnlyList<ISceneNode> items);
 }
 
 /// <summary>

--- a/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandController.cs
+++ b/Assets/Scripts/UI/SceneUI/StrategyView/Windows/StrategyWindowCommandController.cs
@@ -267,13 +267,13 @@ public sealed class StrategyWindowCommandController
     }
 
     /// <summary>
-    /// Clears selected fleet waypoint routes while preserving any active movement leg.
+    /// Cancels selected fleet waypoint routes and reverses any active waypoint legs.
     /// </summary>
     /// <param name="items">The selected fleets or their visible snapshots.</param>
-    /// <returns>True when at least one waypoint was cleared.</returns>
-    public bool ClearFleetWaypoints(IReadOnlyList<ISceneNode> items)
+    /// <returns>True when at least one waypoint route was canceled.</returns>
+    public bool CancelFleetWaypointMoves(IReadOnlyList<ISceneNode> items)
     {
-        if (getMovementSystem()?.ClearFleetWaypoints(items, GetPlayerFactionID()) != true)
+        if (getMovementSystem()?.CancelFleetWaypointMoves(items, GetPlayerFactionID()) != true)
             return false;
 
         RefreshAfterWaypointMutation();

--- a/Assets/Tests/EditMode/UnitTests/Game/Movement/MovementStateTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/Movement/MovementStateTests.cs
@@ -16,6 +16,8 @@ namespace Rebellion.Tests.Game.Movement
                 TicksElapsed = 4,
                 MovementGroupID = "group-1",
                 SourceEventInstanceID = "SEND_OFFICER",
+                OriginPlanetInstanceID = "origin-planet",
+                IsWaypointLeg = true,
                 OriginPosition = new Point(12, 34),
                 CurrentPosition = new Point(56, 78),
             };
@@ -27,6 +29,8 @@ namespace Rebellion.Tests.Game.Movement
             Assert.AreEqual(4, restored.TicksElapsed);
             Assert.AreEqual("group-1", restored.MovementGroupID);
             Assert.AreEqual("SEND_OFFICER", restored.SourceEventInstanceID);
+            Assert.AreEqual("origin-planet", restored.OriginPlanetInstanceID);
+            Assert.IsTrue(restored.IsWaypointLeg);
             Assert.AreEqual(new Point(12, 34), restored.OriginPosition);
             Assert.AreEqual(new Point(56, 78), restored.CurrentPosition);
         }

--- a/Assets/Tests/EditMode/UnitTests/Systems/MovementSystemTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Systems/MovementSystemTests.cs
@@ -3801,11 +3801,11 @@ namespace Rebellion.Tests.Sectors
         }
 
         [Test]
-        public void ClearFleetWaypoints_ActiveRoute_PreservesCurrentMovementAndStopsContinuation()
+        public void CancelFleetWaypointMoves_ActiveRoute_ReturnsFleetToDeparturePlanet()
         {
             (
                 _,
-                _,
+                Planet origin,
                 Planet firstDestination,
                 Planet secondDestination,
                 Fleet fleet,
@@ -3816,21 +3816,94 @@ namespace Rebellion.Tests.Sectors
                 new[] { firstDestination.InstanceID, secondDestination.InstanceID },
                 "empire"
             );
-            MovementState activeMovement = fleet.Movement;
+            fleet.Movement.TransitTicks = 10;
+            fleet.Movement.TicksElapsed = 1;
+            movement.ProcessTick();
+            Point cancellationPosition = fleet.Movement.CurrentPosition;
 
-            bool cleared = movement.ClearFleetWaypoints(new ISceneNode[] { fleet }, "empire");
+            bool canceled = movement.CancelFleetWaypointMoves(new ISceneNode[] { fleet }, "empire");
 
-            Assert.IsTrue(cleared);
-            Assert.AreSame(activeMovement, fleet.Movement);
-            Assert.AreSame(firstDestination, fleet.GetParent());
+            Assert.IsTrue(canceled);
+            Assert.AreSame(origin, fleet.GetParent());
             Assert.IsEmpty(fleet.Waypoints);
+            Assert.IsNotNull(fleet.Movement);
+            Assert.IsFalse(fleet.Movement.IsWaypointLeg);
+            Assert.AreEqual(cancellationPosition, fleet.Movement.OriginPosition);
+            Assert.AreEqual(cancellationPosition, fleet.Movement.CurrentPosition);
 
             fleet.Movement.TicksElapsed = fleet.Movement.TransitTicks - 1;
             movement.ProcessTick();
             movement.ContinueFleetWaypointRoutes();
 
             Assert.IsNull(fleet.Movement);
+            Assert.AreSame(origin, fleet.GetParent());
+        }
+
+        [Test]
+        public void CancelFleetWaypointMoves_LegLoadedWithoutOriginId_ResolvesOriginPosition()
+        {
+            (
+                _,
+                Planet origin,
+                Planet firstDestination,
+                Planet secondDestination,
+                Fleet fleet,
+                MovementSystem movement
+            ) = BuildWaypointScene();
+            movement.TrySetFleetWaypointRoute(
+                new ISceneNode[] { fleet },
+                new[] { firstDestination.InstanceID, secondDestination.InstanceID },
+                "empire"
+            );
+            fleet.Movement.OriginPlanetInstanceID = null;
+
+            bool canceled = movement.CancelFleetWaypointMoves(new ISceneNode[] { fleet }, "empire");
+
+            Assert.IsTrue(canceled);
+            Assert.AreSame(origin, fleet.GetParent());
+            Assert.IsEmpty(fleet.Waypoints);
+        }
+
+        [Test]
+        public void CancelFleetWaypointMoves_StationaryRoute_ClearsRemainingWaypoints()
+        {
+            (_, Planet origin, _, Planet secondDestination, Fleet fleet, MovementSystem movement) =
+                BuildWaypointScene();
+            fleet.Waypoints.Add(secondDestination.InstanceID);
+
+            bool canceled = movement.CancelFleetWaypointMoves(new ISceneNode[] { fleet }, "empire");
+
+            Assert.IsTrue(canceled);
+            Assert.AreSame(origin, fleet.GetParent());
+            Assert.IsNull(fleet.Movement);
+            Assert.IsEmpty(fleet.Waypoints);
+        }
+
+        [Test]
+        public void CancelFleetWaypointMoves_RouteQueuedDuringNormalTransit_PreservesActiveLeg()
+        {
+            (
+                _,
+                _,
+                Planet firstDestination,
+                Planet secondDestination,
+                Fleet fleet,
+                MovementSystem movement
+            ) = BuildWaypointScene();
+            movement.RequestMove(fleet, firstDestination);
+            MovementState activeMovement = fleet.Movement;
+            movement.TrySetFleetWaypointRoute(
+                new ISceneNode[] { fleet },
+                new[] { secondDestination.InstanceID },
+                "empire"
+            );
+
+            bool canceled = movement.CancelFleetWaypointMoves(new ISceneNode[] { fleet }, "empire");
+
+            Assert.IsTrue(canceled);
+            Assert.AreSame(activeMovement, fleet.Movement);
             Assert.AreSame(firstDestination, fleet.GetParent());
+            Assert.IsEmpty(fleet.Waypoints);
         }
 
         [Test]

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Defense/DefenseWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Defense/DefenseWindowControllerTests.cs
@@ -539,7 +539,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Defense
 
             public bool TryUndoFleetWaypointPlan(StrategyWindowTargetingSource source) => false;
 
-            public bool ClearFleetWaypoints(IReadOnlyList<ISceneNode> items) => false;
+            public bool CancelFleetWaypointMoves(IReadOnlyList<ISceneNode> items) => false;
         }
     }
 }

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Fleet/FleetWindowContextMenuBuilderTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Fleet/FleetWindowContextMenuBuilderTests.cs
@@ -166,7 +166,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
             StrategyMenuCommand command = commands.Single(candidate =>
                 candidate.Action == StrategyMenuAction.WaypointMove
             );
-            Assert.AreEqual("Clear Waypoints", command.Text);
+            Assert.AreEqual("Cancel Waypoint Move", command.Text);
             Assert.IsTrue(command.Enabled);
         }
 

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Fleet/FleetWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Fleet/FleetWindowControllerTests.cs
@@ -731,7 +731,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Fleet
 
             public bool TryUndoFleetWaypointPlan(StrategyWindowTargetingSource source) => false;
 
-            public bool ClearFleetWaypoints(IReadOnlyList<ISceneNode> items) => false;
+            public bool CancelFleetWaypointMoves(IReadOnlyList<ISceneNode> items) => false;
         }
     }
 }

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowContextMenuBuilderTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowContextMenuBuilderTests.cs
@@ -246,7 +246,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
                 _playerFactionId
             );
 
-            Assert.AreEqual("Clear Waypoints", commands[2].Text);
+            Assert.AreEqual("Cancel Waypoint Move", commands[2].Text);
             Assert.IsTrue(commands[2].Enabled);
         }
 

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowControllerTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/PlanetSector/PlanetSectorWindowControllerTests.cs
@@ -859,7 +859,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.PlanetSector
 
             public bool TryUndoFleetWaypointPlan(StrategyWindowTargetingSource source) => false;
 
-            public bool ClearFleetWaypoints(IReadOnlyList<ISceneNode> items) => false;
+            public bool CancelFleetWaypointMoves(IReadOnlyList<ISceneNode> items) => false;
         }
     }
 }

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Screen/StrategyScreenInputControllerTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Screen/StrategyScreenInputControllerTests.cs
@@ -686,7 +686,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Screen
 
             public bool TryUndoFleetWaypointPlan(StrategyWindowTargetingSource source) => false;
 
-            public bool ClearFleetWaypoints(IReadOnlyList<ISceneNode> items) => false;
+            public bool CancelFleetWaypointMoves(IReadOnlyList<ISceneNode> items) => false;
         }
 
         private sealed class StatusDoubleClickTarget

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Targeting/StrategyWindowItemDragControllerTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Targeting/StrategyWindowItemDragControllerTests.cs
@@ -556,7 +556,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Targeting
 
             public bool TryUndoFleetWaypointPlan(StrategyWindowTargetingSource source) => false;
 
-            public bool ClearFleetWaypoints(IReadOnlyList<ISceneNode> items) => false;
+            public bool CancelFleetWaypointMoves(IReadOnlyList<ISceneNode> items) => false;
         }
     }
 }

--- a/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Windows/StrategyDragControllerTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/UI/SceneUI/StrategyView/Windows/StrategyDragControllerTests.cs
@@ -487,7 +487,7 @@ namespace Rebellion.Tests.UI.SceneUI.StrategyView.Windows
 
             public bool TryUndoFleetWaypointPlan(StrategyWindowTargetingSource source) => false;
 
-            public bool ClearFleetWaypoints(IReadOnlyList<ISceneNode> items) => false;
+            public bool CancelFleetWaypointMoves(IReadOnlyList<ISceneNode> items) => false;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Allowing in-progress waypoint fleets to cancel and return from their current position to their departure planet.
- Preserving ordinary transit when only a queued waypoint continuation is canceled.
- Persisting waypoint-leg and departure-planet state while supporting movement loaded from earlier saves.
- Renaming the context-menu command to `Cancel Waypoint Move` in fleet and planet-sector windows.

## Validation

- Running `bash build.sh all` successfully with 4,862 Unity EditMode tests passing.
- Meeting coverage thresholds at 81.4% line coverage and 91.1% method coverage.
- Running `bash build.sh build` successfully and producing `build/rebellion2.app`.
- Rebuilding generated UI through the Unity test command without committing generated prefabs or scenes.

## Checklist

- [x] Relevant automated tests pass, or the reason they were not run is stated above.
- [x] I reviewed and understand all AI-assisted code; confirm this submission was NOT vibe coded.
- [x] UI builder changes were verified by rebuilding the affected UI.
- [ ] Content path or structure changes were also made in `rebellion2-media`.
- [x] Generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Documentation was updated when behavior or setup changed.