### PR TITLE
Suppressing neutral blockade announcements

### DIFF
--- a/Assets/Scripts/Game/Messages/MessageFactory.cs
+++ b/Assets/Scripts/Game/Messages/MessageFactory.cs
@@ -2090,6 +2090,8 @@ namespace Rebellion.Game.Messages
                     result.BlockadingFleet?.GetOwnerInstanceID()
                 );
                 Faction targetFaction = GetBlockadeFaction(game, result.Planet?.OwnerInstanceID);
+                if (targetFaction == null)
+                    continue;
                 AddBlockadeDelivery(
                     deliveries,
                     blockadingFaction,

--- a/Assets/Tests/EditMode/UnitTests/Game/Messages/MessageFactoryTests.cs
+++ b/Assets/Tests/EditMode/UnitTests/Game/Messages/MessageFactoryTests.cs
@@ -3740,6 +3740,43 @@ namespace Rebellion.Tests.Game.Messages
         }
 
         [Test]
+        public void CreateMessages_NeutralPlanetBlockade_DoesNotCreateMessages()
+        {
+            (GameRoot game, Faction alliance, _, _, Planet target) = BuildTwoFactionMessageScene();
+            target.OwnerInstanceID = null;
+            Fleet fleet = new Fleet { OwnerInstanceID = alliance.InstanceID };
+
+            List<MessageDeliveryRequest> deliveries = CreateMessages(
+                game,
+                new[]
+                {
+                    Definition(
+                        MessageResultType.BlockadeInitiated,
+                        MessageType.Fleet,
+                        "initiated",
+                        "initiated",
+                        imagePaths: FactionImages()
+                    ),
+                    Definition(
+                        MessageResultType.BlockadeDetected,
+                        MessageType.Fleet,
+                        "detected",
+                        "detected",
+                        imagePaths: FactionImages()
+                    ),
+                },
+                new BlockadeChangedResult
+                {
+                    Planet = target,
+                    BlockadingFleet = fleet,
+                    Blockaded = true,
+                }
+            );
+
+            Assert.IsEmpty(deliveries);
+        }
+
+        [Test]
         public void CreateMessages_EvacuationLosses_JoinsLostUnitNames()
         {
             (GameRoot game, Faction alliance, Planet origin, _) = BuildMessageScene();


### PR DESCRIPTION
## Summary

- Suppressing player-facing blockade announcements when a fleet establishes a blockade at a neutral planet.
- Preventing neutral blockades from falling back to the opposing faction's announcement image.
- Adding regression coverage that verifies neutral blockades produce no message deliveries.

## Validation

- Passing `dotnet csharpier check Assets/`.
- Passing `./build.sh lint` with the required Unity assemblies staged locally.
- Passing `CreateMessages_NeutralPlanetBlockade_DoesNotCreateMessages` in Unity EditMode against the matching media revision.

## Checklist

- [x] Confirming relevant automated tests pass.
- [x] Reviewing and understanding all AI-assisted code; confirming this submission was not vibe coded.
- [x] Confirming no UI builder changes require a rebuild.
- [x] Confirming no content path or structure changes require a `rebellion2-media` update.
- [x] Confirming generated UI prefabs, generated scenes, and copyrighted game assets are not committed.
- [x] Confirming no documentation changes are required for this bug fix.